### PR TITLE
fix(dashboard): make MetricTile background transparent

### DIFF
--- a/shared/nexis/Pages/Dashboard/metric_tile.cpp
+++ b/shared/nexis/Pages/Dashboard/metric_tile.cpp
@@ -10,7 +10,6 @@ MetricTile::MetricTile(const QString &title, const QString &colorToken, QWidget 
     : MetricTileBase(title, colorToken, parent)
 {
     setObjectName("metricTile");
-    setAttribute(Qt::WA_StyledBackground, true);
     buildLayout();
     refreshThemeColors();
 
@@ -81,6 +80,7 @@ void MetricTile::buildLayout()
 
     mChartView = new QChartView(mChart, this);
     mChartView->setFrameShape(QFrame::NoFrame);
+    mChartView->setBackgroundBrush(Qt::NoBrush);
     mChartView->setRenderHint(QPainter::Antialiasing);
     mChartView->setMinimumHeight(40);
     mChartView->setMaximumHeight(60);
@@ -178,7 +178,7 @@ void MetricTile::refreshThemeColors()
     fillColor.setAlphaF(0.1);
     mAreaSeries->setBrush(fillColor);
 
-    mChart->setBackgroundBrush(QColor(sv->value("@cardBg").toString()));
+    mChart->setBackgroundBrush(Qt::transparent);
 
     mProgressBar->setStyleSheet(
         QString("QProgressBar#metricTileProgress::chunk { background-color: %1; border-radius: 2; }").arg(colorHex));


### PR DESCRIPTION
## Summary

- `MetricTile` was the only tile type with `setAttribute(Qt::WA_StyledBackground, true)`, causing the QSS `background-color: @cardBg` rule to paint a solid card background behind the Memory tile
- `RingTile`, `HybridTile`, `GaugeTile`, etc. lack this attribute and correctly appear transparent
- Also cleared the QChart and QChartView backgrounds so the sparkline area is fully transparent

## Test plan

- [ ] Launch Nexis → Dashboard — Memory tile should have no white card background
- [ ] Verify Memory tile appears transparent like CPU and GPU tiles
- [ ] Switch between dark and light themes — transparent in both
- [ ] `ctest --test-dir build --output-on-failure` — all 28 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)