### PR TITLE
fix(ci): repair AUR and PPA distribution for v2.3.4

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -5,6 +5,11 @@ on:
     workflows: ["Release"]
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 2.3.4)'
+        required: true
 
 permissions:
   contents: read
@@ -14,8 +19,9 @@ jobs:
     name: Update AUR package
     runs-on: ubuntu-latest
     if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'v')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
 
     steps:
       - name: Checkout
@@ -24,15 +30,24 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          TAG="${{ github.event.workflow_run.head_branch }}"
-          echo "VERSION=${TAG#v}" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+            echo "VERSION=${TAG#v}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update PKGBUILD version
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" linux/aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" linux/aur/PKGBUILD
 
       - name: Publish to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
         with:
           pkgname: nexis
-          pkgbuild_dir: linux/aur
-          pkgver: ${{ steps.version.outputs.VERSION }}
+          pkgbuild: linux/aur/PKGBUILD
           commit_username: github-actions[bot]
           commit_email: github-actions[bot]@users.noreply.github.com
           ssh_private_key: ${{ secrets.AUR_SSH_KEY }}

--- a/.github/workflows/ppa.yml
+++ b/.github/workflows/ppa.yml
@@ -57,8 +57,9 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
-        series: [noble, jammy, questing]
+        series: [noble, questing, jammy]
 
     steps:
       - name: Checkout

--- a/linux/aur/PKGBUILD
+++ b/linux/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Luke Simpson <luke@s4solutions.ai>
 pkgname=nexis
-pkgver=2.3.3
+pkgver=2.3.4
 pkgrel=1
 pkgdesc="Linux system optimizer and monitoring tool"
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
## Summary

- **AUR**: `KSXGitHub/github-actions-deploy-aur@v4.1.1` changed its input API — `pkgbuild_dir` and `pkgver` were removed. Fixed by adding a `sed` step to patch `pkgver` in the PKGBUILD before the action runs, switching to the new `pkgbuild` input (full file path), and dropping the removed `pkgver` input. Also adds `workflow_dispatch` so AUR publishing can be manually re-triggered.
- **AUR PKGBUILD**: `pkgver` was still at `2.3.3` in the repo; bumped to `2.3.4`.
- **PPA (Jammy)**: Three series ran in parallel. Questing and Jammy both tried to FTP-upload the same `orig.tar.gz` at t+1m27s / t+1m29s. Launchpad rejected the concurrent write with `550 internal server error`. Fixed by adding `max-parallel: 1` to serialize series uploads. Reordered matrix so jammy (oldest, needs the Qt6OpenGL patch) runs last.

## After merging

1. Manually re-trigger AUR for v2.3.4:
   ```
   gh workflow run aur.yml --repo s4solutionsllc/Nexis -r native -f version=2.3.4
   ```
2. Manually re-trigger PPA for v2.3.4:
   ```
   gh workflow run ppa.yml --repo s4solutionsllc/Nexis -r native -f version=2.3.4
   ```

## Homebrew

The Homebrew Cask workflow **succeeded** for v2.3.4. The Cask is correct (`version "2.3.4"`, correct SHA256, proper `#{version}` URL interpolation, and the DMG was properly notarized). If you're still seeing a Homebrew error, please share the specific error message — it may be a runtime/Gatekeeper issue rather than a packaging issue.

## Test plan

- [ ] Merge PR to `native`
- [ ] Re-trigger AUR workflow; confirm it completes successfully
- [ ] Re-trigger PPA workflow; confirm all three series (noble, questing, jammy) pass
- [ ] `yay -Syu nexis` on an Arch system shows v2.3.4
- [ ] `sudo apt update && sudo apt install nexis` on Jammy/Noble shows v2.3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)