### PR TITLE
fix(ci): apply remaining fixes from PR #31

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -5,6 +5,11 @@ on:
     workflows: ["Release"]
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 2.3.4)'
+        required: true
 
 permissions:
   contents: read
@@ -14,8 +19,9 @@ jobs:
     name: Update AUR package
     runs-on: ubuntu-latest
     if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'v')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
 
     steps:
       - name: Checkout
@@ -24,8 +30,18 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          TAG="${{ github.event.workflow_run.head_branch }}"
-          echo "VERSION=${TAG#v}" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+            echo "VERSION=${TAG#v}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update PKGBUILD version
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" linux/aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" linux/aur/PKGBUILD
 
       - name: Publish to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.1

--- a/.github/workflows/ppa.yml
+++ b/.github/workflows/ppa.yml
@@ -57,8 +57,9 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
-        series: [noble, jammy, questing]
+        series: [noble, questing, jammy]
 
     steps:
       - name: Checkout

--- a/linux/aur/PKGBUILD
+++ b/linux/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Luke Simpson <luke@s4solutions.ai>
 pkgname=nexis
-pkgver=2.3.3
+pkgver=2.3.4
 pkgrel=1
 pkgdesc="Linux system optimizer and monitoring tool"
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
## Summary

Picks up three changes that were in the unmerged PR #31 but not yet in `native`:

- **`ppa.yml`**: add `max-parallel: 1` to serialize Launchpad uploads — parallel uploads race on the shared `orig.tar.gz` and produce `550 internal server error`. Reorder matrix to `[noble, questing, jammy]` so jammy (needs Qt6OpenGL patch) runs last.
- **`aur.yml`**: add `workflow_dispatch` trigger with a `version` input for manual re-runs; add `sed` step to patch `pkgver`/`pkgrel` in PKGBUILD at publish time.
- **`linux/aur/PKGBUILD`**: bump `pkgver` from `2.3.3` to `2.3.4`.

## After merging

Re-trigger v2.3.4 for AUR and PPA:
```bash
gh workflow run aur.yml --repo s4solutionsllc/Nexis -r native -f version=2.3.4
gh workflow run ppa.yml --repo s4solutionsllc/Nexis -r native -f version=2.3.4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)