### PR TITLE
feat(cleaner): post-snapshot toast notification (NEX-281)

### DIFF
--- a/shared/nexis/Managers/cleaner_service.cpp
+++ b/shared/nexis/Managers/cleaner_service.cpp
@@ -452,7 +452,8 @@ void CleanerService::maybeTakeSnapshot(const QList<CleanCategory> &categories)
         catNames << categoryName(cat);
 
     const QString reason = QStringLiteral("Nexis pre-clean: %1").arg(catNames.join(", "));
-    svc->takeSnapshot(reason);   // silently logs on failure; we don't block the clean.
+    if (svc->takeSnapshot(reason))
+        emit snapshotTaken(svc->toolDisplayName());
 }
 
 CleanerService::CleanResult CleanerService::cleanSchedule(const QString &scheduleId)

--- a/shared/nexis/Managers/cleaner_service.h
+++ b/shared/nexis/Managers/cleaner_service.h
@@ -77,6 +77,7 @@ public:
 signals:
     void cleaningStarted(QString scheduleName);
     void cleaningFinished(CleanResult result);
+    void snapshotTaken(QString toolName);   // emitted on worker thread after a successful pre-clean snapshot
 
 private:
     CleanerService();

--- a/shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp
+++ b/shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp
@@ -24,6 +24,7 @@
 #include <QMenu>
 #include <QHeaderView>
 #include <QScrollBar>
+#include <QTimer>
 
 SystemCleanerPage::~SystemCleanerPage()
 {
@@ -68,6 +69,9 @@ void SystemCleanerPage::init()
 
     connect(this, &SystemCleanerPage::scanFinishedS, this, &SystemCleanerPage::onScanFinished);
     connect(this, &SystemCleanerPage::cleanFinishedS, this, &SystemCleanerPage::onCleanFinished);
+    connect(mCleanerService, &CleanerService::snapshotTaken,
+            this, &SystemCleanerPage::onSnapshotTaken,
+            Qt::QueuedConnection);
 
     ui->treeWidgetScanResult->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui->treeWidgetScanResult, &QTreeWidget::customContextMenuRequested,
@@ -341,11 +345,15 @@ void SystemCleanerPage::buildCleanerFooter()
     mCleanerFooter = new QFrame(ui->cleanerCategories);
     mCleanerFooter->setObjectName("cleanerFooter");
 
-    QHBoxLayout *footerRow = new QHBoxLayout(mCleanerFooter);
-    footerRow->setContentsMargins(14, 10, 14, 10);
+    QVBoxLayout *outerLayout = new QVBoxLayout(mCleanerFooter);
+    outerLayout->setContentsMargins(14, 10, 14, 10);
+    outerLayout->setSpacing(8);
+
+    // Main row: estimated size + clean button
+    QHBoxLayout *footerRow = new QHBoxLayout;
+    footerRow->setContentsMargins(0, 0, 0, 0);
     footerRow->setSpacing(12);
 
-    // Left: label + size
     QLabel *lblEstimatedLabel = new QLabel(tr("ESTIMATED RECOVERABLE"), mCleanerFooter);
     lblEstimatedLabel->setObjectName("lblEstimatedLabel");
 
@@ -359,7 +367,6 @@ void SystemCleanerPage::buildCleanerFooter()
 
     footerRow->addLayout(leftCol, 1);
 
-    // Right: clean selected button (always visible, enabled only after scan + selection)
     mBtnCleanSelected = new QPushButton(tr("Clean selected"), mCleanerFooter);
     mBtnCleanSelected->setObjectName("btnCleanSelected");
     mBtnCleanSelected->setCursor(Qt::PointingHandCursor);
@@ -369,6 +376,14 @@ void SystemCleanerPage::buildCleanerFooter()
             this, &SystemCleanerPage::quickCleanByCategory);
 
     footerRow->addWidget(mBtnCleanSelected);
+    outerLayout->addLayout(footerRow);
+
+    // Toast: appears briefly after a successful pre-clean snapshot (NEX-281)
+    mLblSnapshotToast = new QLabel(mCleanerFooter);
+    mLblSnapshotToast->setObjectName("lblSnapshotToast");
+    mLblSnapshotToast->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    mLblSnapshotToast->hide();
+    outerLayout->addWidget(mLblSnapshotToast);
 
     catLayout->addWidget(mCleanerFooter);
 }
@@ -868,6 +883,13 @@ void SystemCleanerPage::onCleanFinished()
 
     mCleanInProgress = false;
     mCleaningFromCard = false;
+}
+
+void SystemCleanerPage::onSnapshotTaken(const QString &toolName)
+{
+    mLblSnapshotToast->setText(tr("✓ Restore point created via %1. Disable in Settings.").arg(toolName));
+    mLblSnapshotToast->show();
+    QTimer::singleShot(5000, mLblSnapshotToast, &QLabel::hide);
 }
 
 // ─── Tree widget helpers ──────────────────────────────────────────────────────

--- a/shared/nexis/Pages/SystemCleaner/system_cleaner_page.h
+++ b/shared/nexis/Pages/SystemCleaner/system_cleaner_page.h
@@ -85,6 +85,7 @@ private slots:
     void updateScheduleIndicator();
     void onManageExclusions();
     void onTreeContextMenu(const QPoint &pos);
+    void onSnapshotTaken(const QString &toolName);
 
     void showEvent(QShowEvent *event) override;
 
@@ -183,6 +184,8 @@ private:
 
     // Track background tasks so they can be awaited on shutdown (BUG-05)
     QFuture<void> mWorkerFuture;
+
+    QLabel      *mLblSnapshotToast = nullptr;
 
     // Exclusion rules gear button (in header row)
     QToolButton *mBtnExclusions = nullptr;

--- a/shared/nexis/static/themes/default/style/style.qss
+++ b/shared/nexis/static/themes/default/style/style.qss
@@ -1310,6 +1310,13 @@ QLabel[accessibleName="dialog-title"] {
     color: @color06;
 }
 
+#lblSnapshotToast {
+    color: @successColor;
+    border-left: 3px solid @successColor;
+    padding: 4px 10px;
+    font-size: 9pt;
+}
+
 #lblExclusionNotice {
     color: @color05;
     padding: 6px 0;


### PR DESCRIPTION
## Summary

- Adds a `snapshotTaken(QString toolName)` signal to `CleanerService`, emitted after a successful pre-clean snapshot
- `SystemCleanerPage` connects via `Qt::QueuedConnection` (signal fires on the worker thread) and shows a brief toast label: *"✓ Restore point created via Timeshift. Disable in Settings."*
- Toast auto-hides after 5 seconds via `QTimer::singleShot`
- Styled with Option B (success green): transparent background, `@successColor` left border and text — consistent with the existing `#lblRemovedTotalSize` pattern in the same footer
- No new settings, no new toggle — the existing `PreCleanSnapshotEnabled` checkbox in Settings continues to gate all snapshot behavior

## Background

NEX-281 / GitHub #40: a user reported that Timeshift snapshots were being taken silently and didn't know how to disable the behavior. The toggle already existed in Settings (FR-112), but there was zero in-app feedback when it ran. This PR closes the discoverability gap.

## Files changed

| File | Change |
|------|--------|
| `shared/nexis/Managers/cleaner_service.h` | Add `snapshotTaken` signal |
| `shared/nexis/Managers/cleaner_service.cpp` | Emit signal when `takeSnapshot()` returns `true` |
| `shared/nexis/Pages/SystemCleaner/system_cleaner_page.h` | Add `mLblSnapshotToast` member + `onSnapshotTaken` slot |
| `shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp` | Restructure footer to QVBoxLayout, build toast label, connect signal, implement slot |
| `shared/nexis/static/themes/default/style/style.qss` | Add `#lblSnapshotToast` style |

## Test plan

- [ ] Enable *"Create restore point before cleaning"* in Settings → System Cleaner
- [ ] Run a clean — confirm toast appears in the footer with the correct tool name and hides after ~5 s
- [ ] Disable the setting — confirm no toast appears on next clean
- [ ] Verify on macOS the tool name reads "APFS snapshot" (if tmutil available)
- [ ] Build passes clean; 27/28 tests pass (ScreenshotTests failure is pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)