### PR TITLE
feat(website): deploy SEO copy, /alternatives/stacer, and sitemap (SSO-91)

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,8 +1,9 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
+import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
   site: 'https://s4solutionsllc.github.io',
   base: '/Nexis',
-  integrations: [tailwind()],
+  integrations: [tailwind(), sitemap()],
 });

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nexis-website",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/sitemap": "^3.2.1",
         "@astrojs/tailwind": "^5.1.3",
         "astro": "^4.16.18",
         "tailwindcss": "^3.4.17"
@@ -73,6 +74,17 @@
       },
       "engines": {
         "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.2.1.tgz",
+      "integrity": "sha512-uxMfO8f7pALq0ADL6Lk68UV6dNYjJ2xGUzyjjVj60JLBs5a6smtlkBYv3tQ0DzoqwS7c9n4FUx5lgv0yPo/fgA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^8.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@astrojs/tailwind": {
@@ -1745,6 +1757,24 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -5242,6 +5272,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -5351,6 +5390,31 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.3.tgz",
+      "integrity": "sha512-9Ew1tR2WYw8RGE2XLy7GjkusvYXy8Rg6y8TYuBuQMfIEdGcWoJpY2Wr5DzsEiL/TKCw56+YKTCCUHglorEYK+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^17.0.5",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5387,6 +5451,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -5668,6 +5738,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.2.1",
     "@astrojs/tailwind": "^5.1.3",
     "astro": "^4.16.18",
     "tailwindcss": "^3.4.17"

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -21,13 +21,13 @@ try {
     <img src="/Nexis/images/logo.svg" alt="Nexis logo" class="mx-auto mb-6 h-20 w-20" />
 
     <h1 class="text-4xl font-bold tracking-tight text-white md:text-5xl lg:text-6xl">
-      Linux & macOS<br />
+      Free Linux & macOS<br />
       <span class="text-nexis-orange">System Optimizer</span>
     </h1>
 
     <p class="mx-auto mt-6 max-w-2xl text-lg text-nexis-muted md:text-xl">
       Monitor hardware, clean system junk, manage services — all in one app.
-      Open source, built with Qt 6.
+      The open-source Stacer alternative, built with Qt 6.
     </p>
 
     <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -5,8 +5,8 @@ interface Props {
 }
 
 const {
-  title = 'Nexis — Linux & macOS System Optimizer',
-  description = 'Open-source system optimizer and monitor for Linux and macOS. Real-time dashboard, GPU monitoring, system cleaner, and more. Built with Qt 6 and C++17.',
+  title = 'Nexis — Free Linux System Optimizer & macOS Cleaner',
+  description = 'Free, open-source Linux system optimizer and macOS system cleaner. Real-time monitoring, service management, and junk cleanup. The active Stacer successor.',
 } = Astro.props;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);

--- a/website/src/pages/alternatives/stacer.astro
+++ b/website/src/pages/alternatives/stacer.astro
@@ -1,0 +1,172 @@
+---
+import Base from '../../layouts/Base.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+---
+
+<Base
+  title="Nexis vs Stacer — Free Open-Source Stacer Alternative"
+  description="Stacer is no longer maintained. Nexis is the free, open-source Stacer alternative for Linux and macOS — actively developed, with Qt 6 and GPU monitoring."
+>
+  <Nav />
+  <main class="mx-auto max-w-3xl px-6 py-24 md:py-32">
+
+    <h1 class="text-4xl font-bold tracking-tight text-white md:text-5xl">
+      Nexis: The Free, Maintained<br />
+      <span class="text-nexis-orange">Stacer Alternative</span>
+    </h1>
+
+    <p class="mt-6 text-lg text-nexis-muted leading-relaxed">
+      If you've searched for a Stacer alternative, you've already noticed the problem:
+      Stacer's development stopped in 2022. No updates, no security patches, no Qt 6, and
+      no support for any Linux distribution released in the last two years.
+    </p>
+    <p class="mt-4 text-lg text-nexis-muted leading-relaxed">
+      <strong class="text-white">Nexis is the maintained successor.</strong> It does everything
+      Stacer did, runs on both Linux and macOS, and ships regular releases with active bug fixes
+      and new features.
+    </p>
+
+    <h2 class="mt-16 text-2xl font-bold text-white">What Happened to Stacer?</h2>
+    <p class="mt-4 text-nexis-muted leading-relaxed">
+      Stacer was a popular open-source Linux system optimizer that accumulated over 16,000 GitHub
+      stars. But after 2022, commits slowed and then stopped entirely. Issues pile up unanswered,
+      and the last release doesn't install cleanly on Ubuntu 24.04, Fedora 40, or other current
+      distributions. If you're running a modern system, Stacer simply doesn't work reliably anymore.
+    </p>
+
+    <h2 class="mt-12 text-2xl font-bold text-white">Why Choose Nexis as Your Stacer Alternative?</h2>
+    <p class="mt-4 text-nexis-muted leading-relaxed">
+      Nexis was built to fill exactly the gap Stacer left:
+    </p>
+    <ul class="mt-4 space-y-2 text-nexis-muted">
+      <li><span class="text-nexis-orange font-semibold">Actively maintained</span> — releases every 4–6 weeks, critical bugs fixed within days</li>
+      <li><span class="text-nexis-orange font-semibold">Qt 6 native</span> — not Electron; lower memory, better HiDPI, faster startup</li>
+      <li><span class="text-nexis-orange font-semibold">Linux and macOS</span> — one tool for mixed-platform teams or dual-boot setups</li>
+      <li><span class="text-nexis-orange font-semibold">GPU monitoring</span> — NVIDIA and AMD GPU stats, something Stacer never supported</li>
+      <li><span class="text-nexis-orange font-semibold">GPL-3.0 licensed</span> — free to use, modify, and redistribute, forever</li>
+    </ul>
+
+    <h2 class="mt-12 text-2xl font-bold text-white">Nexis vs Stacer: Feature Comparison</h2>
+    <div class="mt-6 overflow-x-auto">
+      <table class="w-full text-sm border-collapse">
+        <thead>
+          <tr class="border-b border-nexis-border">
+            <th class="py-3 pr-6 text-left text-nexis-muted font-semibold">Feature</th>
+            <th class="py-3 px-4 text-center text-nexis-muted font-semibold">Stacer</th>
+            <th class="py-3 px-4 text-center text-nexis-orange font-semibold">Nexis</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-nexis-border/50">
+          <tr>
+            <td class="py-3 pr-6 text-nexis-muted">Actively maintained</td>
+            <td class="py-3 px-4 text-center text-red-400">✗</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+          </tr>
+          <tr>
+            <td class="py-3 pr-6 text-nexis-muted">Qt 6 (native app)</td>
+            <td class="py-3 px-4 text-center text-red-400">✗</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+          </tr>
+          <tr>
+            <td class="py-3 pr-6 text-nexis-muted">macOS support</td>
+            <td class="py-3 px-4 text-center text-red-400">✗</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+          </tr>
+          <tr>
+            <td class="py-3 pr-6 text-nexis-muted">GPU monitoring</td>
+            <td class="py-3 px-4 text-center text-red-400">✗</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+          </tr>
+          <tr>
+            <td class="py-3 pr-6 text-nexis-muted">System cleaner</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+          </tr>
+          <tr>
+            <td class="py-3 pr-6 text-nexis-muted">Startup manager</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+          </tr>
+          <tr>
+            <td class="py-3 pr-6 text-nexis-muted">Services manager</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+          </tr>
+          <tr>
+            <td class="py-3 pr-6 text-nexis-muted">Process manager</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+          </tr>
+          <tr>
+            <td class="py-3 pr-6 text-nexis-muted">Open source</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+          </tr>
+          <tr>
+            <td class="py-3 pr-6 text-nexis-muted">Free</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+            <td class="py-3 px-4 text-center text-green-400">✓</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2 class="mt-12 text-2xl font-bold text-white">What Does Nexis Include?</h2>
+    <dl class="mt-6 space-y-4">
+      <div>
+        <dt class="font-semibold text-white">Dashboard</dt>
+        <dd class="mt-1 text-nexis-muted">Real-time CPU, memory, swap, disk I/O, GPU, and network charts — everything you need for at-a-glance system health.</dd>
+      </div>
+      <div>
+        <dt class="font-semibold text-white">System Cleaner</dt>
+        <dd class="mt-1 text-nexis-muted">Scan for application caches, package manager leftovers, and log files taking up disk space.</dd>
+      </div>
+      <div>
+        <dt class="font-semibold text-white">Startup Manager</dt>
+        <dd class="mt-1 text-nexis-muted">Enable or disable startup applications without touching a config file.</dd>
+      </div>
+      <div>
+        <dt class="font-semibold text-white">Services Manager</dt>
+        <dd class="mt-1 text-nexis-muted">Start, stop, enable, and disable systemd services from a GUI.</dd>
+      </div>
+      <div>
+        <dt class="font-semibold text-white">Process Manager</dt>
+        <dd class="mt-1 text-nexis-muted">Sort processes by CPU or memory; kill runaway processes in one click.</dd>
+      </div>
+      <div>
+        <dt class="font-semibold text-white">GPU Monitor</dt>
+        <dd class="mt-1 text-nexis-muted">View NVIDIA and AMD GPU load, VRAM usage, and temperature in real time. Stacer never supported this.</dd>
+      </div>
+    </dl>
+
+    <h2 class="mt-12 text-2xl font-bold text-white">Does Nexis Work on macOS?</h2>
+    <p class="mt-4 text-nexis-muted leading-relaxed">
+      Yes. Nexis runs natively on macOS (Apple Silicon and Intel). It provides CPU, memory, disk,
+      and GPU monitoring, plus a system cleaner for application caches. Stacer was Linux-only;
+      Nexis works on both, making it the only free, open-source Stacer-class optimizer that
+      covers mixed-platform teams.
+    </p>
+
+    <h2 class="mt-12 text-2xl font-bold text-white">Is Nexis Free?</h2>
+    <p class="mt-4 text-nexis-muted leading-relaxed">
+      Yes. Nexis is GPL-3.0 licensed and will remain free forever. There is no paid tier,
+      no premium features, and no subscription. It is maintained by open-source contributors —
+      not by selling access.
+    </p>
+
+    <div class="mt-16 rounded-xl border border-nexis-border/50 bg-nexis-dark/50 p-8 text-center">
+      <h2 class="text-2xl font-bold text-white">Replace Stacer Today</h2>
+      <p class="mt-3 text-nexis-muted">Download the latest release and get the maintained Linux system optimizer you've been missing.</p>
+      <a
+        href="https://github.com/s4solutionsllc/Nexis/releases/latest"
+        class="mt-6 inline-flex items-center gap-2 rounded-lg bg-nexis-orange px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-nexis-orange-hover"
+      >
+        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" /></svg>
+        Download Nexis Free
+      </a>
+    </div>
+
+  </main>
+  <Footer />
+</Base>


### PR DESCRIPTION
## Summary

Deploys all SEO work for [SSO-91](/SSO/issues/SSO-91), including copy from [SSO-88](/SSO/issues/SSO-88) (which was on the SSO-93 branch and not yet merged to native):

- **Homepage `<title>`**: `Nexis — Free Linux System Optimizer & macOS Cleaner` (52 chars)
- **Meta description**: 155-char keyword-rich phrase targeting Stacer-successor queries
- **Hero H1**: adds "Free", tagline updated to "open-source Stacer alternative"
- **New page `/alternatives/stacer`**: ~500-word comparison landing with feature table and FAQ H2s structured for Google featured-snippet extraction
- **Sitemap**: added `@astrojs/sitemap@3.2.1`; `sitemap-index.xml` + `sitemap-0.xml` now generate at build time — `robots.txt` was already referencing the correct URL
- **robots.txt**: pre-existing and correct (`User-agent: * / Allow: /` + Sitemap pointer) — no changes needed

## Build verification

```
[@astrojs/sitemap] `sitemap-index.xml` created at `dist`
[build] 22 page(s) built in 1.41s
[build] Complete!
```

Sitemap includes all 22 pages including `/Nexis/alternatives/stacer/`.

## Note on @astrojs/sitemap version

`@astrojs/sitemap@3.7.2` (latest) has a bug with Astro 4.16.x — `routes` is renamed to `_routes` internally but not destructured from the `astro:build:done` hook, causing `Cannot read properties of undefined (reading 'reduce')`. Pinned to `3.2.1` which correctly receives `routes` from the hook.

## Test plan

- [ ] Build passes with no errors
- [ ] `/alternatives/stacer` renders correctly
- [ ] `sitemap-index.xml` is present at site root after deploy
- [ ] Homepage title and meta description reflect the new SEO copy