### PR TITLE
fix(flatpak): correct commit SHA and bump SDK to 6.9 (SSO-93)

### DIFF
--- a/linux/flatpak/README.md
+++ b/linux/flatpak/README.md
@@ -2,7 +2,7 @@
 
 App ID: `io.github.s4solutionsllc.Nexis`  
 Manifest: `io.github.s4solutionsllc.Nexis.yml`  
-Runtime: `org.kde.Platform//6.7` (KDE Qt6 SDK)
+Runtime: `org.kde.Platform//6.9` (KDE Qt6 SDK)
 
 ---
 
@@ -17,7 +17,7 @@ sudo dnf install flatpak-builder     # Fedora
 flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
 # Install KDE runtime and SDK (~2-3 GB)
-flatpak install flathub org.kde.Platform//6.7 org.kde.Sdk//6.7
+flatpak install flathub org.kde.Platform//6.9 org.kde.Sdk//6.9
 ```
 
 ---

--- a/linux/flatpak/io.github.s4solutionsllc.Nexis.yml
+++ b/linux/flatpak/io.github.s4solutionsllc.Nexis.yml
@@ -1,6 +1,6 @@
 app-id: io.github.s4solutionsllc.Nexis
 runtime: org.kde.Platform
-runtime-version: '6.7'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 command: nexis
 
@@ -69,7 +69,7 @@ modules:
       - type: git
         url: https://github.com/s4solutionsllc/Nexis.git
         tag: v2.3.6
-        commit: 697f8fa486609b935b43b2f3fe80c4da6995540e
+        commit: 85824742b832a6988af28024eb3ed21109a5da74
         x-checker-data:
           type: json
           url: https://api.github.com/repos/s4solutionsllc/Nexis/releases/latest


### PR DESCRIPTION
## Summary

Two fixes to the Flatpak manifest discovered during local `flatpak-builder` smoke test:

- **Wrong commit SHA**: the `commit:` field had the annotated tag *object* SHA (`697f8fa`) rather than the actual commit SHA (`8582474`). flatpak-builder validates this and would fail on Flathub CI.
- **EOL SDK**: `runtime-version: '6.7'` is end-of-life on Flathub (only 6.9 and 6.10 are offered). Bumped to `6.9`.

## Verification

Both changes verified locally:

```
flatpak-builder --force-clean --sandbox /tmp/nexis-build \
  linux/flatpak/io.github.s4solutionsllc.Nexis.yml
```

Build succeeded with `org.kde.Sdk//6.9`. Desktop file and all 6 icon sizes renamed correctly. No errors.

## Notes

- AppStream metainfo at `v2.3.6` is not yet included (metainfo was added in PR #46, *after* the v2.3.6 tag). The Flathub PR should only be opened after a new release is cut that includes the metainfo file.
- `x-checker-data` in the manifest will keep the commit SHA current automatically once Flathub's external-data-checker bot runs.

Closes [SSO-93](/SSO/issues/SSO-93) (build verification phase).