### PR TITLE
fix(system-cleaner): card overflow, window geometry persistence, Select All (GH#55 / SSO-355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Flatpak packaging (SSO-93):** Flatpak manifest added at `linux/flatpak/io.github.s4solutionsllc.Nexis.yml` for Flathub submission. Uses the KDE Qt6 SDK (`org.kde.Platform//6.7`), `--filesystem=host` for broad system access (required for /proc, /sys, hardware sensors, APT sources, and host tool invocations), and `org.freedesktop.PolicyKit1` D-Bus access for privileged operations. Reviewer justification at `docs/flatpak-reviewer-justification.md`.
+- **Select All / Clear All on System Cleaner (GH#55 / SSO-355):** Restored the bulk-toggle affordance that was dropped in the FR-130 card redesign. New button in the System Cleaner footer flips every category checkbox in one click and switches its label to **Clear All** once everything is selected.
+
+### Fixed
+- **System Cleaner cards overflowed in small windows (GH#55 / SSO-355):** The FR-130 card grid was added to a `QScrollArea` but the layout gave it no stretch and no minimum height, so the page fought for its 1025×736 design size and clipped at smaller resolutions. The scroll area now stretches to fill the available vertical space and compresses to a small minimum, engaging its vertical scrollbar instead of overflowing the page.
+- **Window size & position not remembered (GH#55 / SSO-355):** Nexis re-centered itself at the default 1025×736 on every relaunch because no `saveGeometry()` / `restoreGeometry()` calls existed for the main window. `App::closeEvent` now persists `QMainWindow::saveGeometry()` and `saveState()` to `SettingManager`, and `App::init` restores them on launch (including from the minimize-to-tray "ignored close" path, where Qt does not deliver a second `closeEvent` if the user later quits from the tray).
 
 ## [2.3.6] - 2026-05-11
 

--- a/shared/nexis/Managers/setting_manager.cpp
+++ b/shared/nexis/Managers/setting_manager.cpp
@@ -563,3 +563,23 @@ int SettingManager::getNetCapAlertLastPercent() const
 {
     return mSettings->value(SettingKeys::NetCapAlertLastPercent, 0).toInt();
 }
+
+void SettingManager::setWindowGeometry(const QByteArray &value)
+{
+    mSettings->setValue(SettingKeys::WindowGeometry, value);
+}
+
+QByteArray SettingManager::getWindowGeometry() const
+{
+    return mSettings->value(SettingKeys::WindowGeometry).toByteArray();
+}
+
+void SettingManager::setWindowState(const QByteArray &value)
+{
+    mSettings->setValue(SettingKeys::WindowState, value);
+}
+
+QByteArray SettingManager::getWindowState() const
+{
+    return mSettings->value(SettingKeys::WindowState).toByteArray();
+}

--- a/shared/nexis/Managers/setting_manager.h
+++ b/shared/nexis/Managers/setting_manager.h
@@ -74,6 +74,10 @@ namespace SettingKeys {
     const QString NetCapAlertEnabled("NetCapAlertEnabled");
     const QString NetCapResetDay("NetCapResetDay");
     const QString NetCapAlertLastPercent("NetCapAlertLastPercent");
+
+    // GH#55 / SSO-355
+    const QString WindowGeometry("WindowGeometry");
+    const QString WindowState("WindowState");
 }
 
 class SettingManager
@@ -239,6 +243,12 @@ public:
     int getNetCapResetDay() const;
     void setNetCapAlertLastPercent(int pct);
     int getNetCapAlertLastPercent() const;
+
+    // GH#55 / SSO-355 — persist main window size/position
+    void setWindowGeometry(const QByteArray &value);
+    QByteArray getWindowGeometry() const;
+    void setWindowState(const QByteArray &value);
+    QByteArray getWindowState() const;
 
 private:
     static SettingManager *instance;

--- a/shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp
+++ b/shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp
@@ -221,11 +221,17 @@ void SystemCleanerPage::buildCategoryCards()
     // Pre-size mCards so enum-indexed access is safe
     mCards.resize(SNAP_FLATPAK_REVISIONS + 1);
 
+    // GH#55 / SSO-355: cards must scroll inside their own region so the page
+    // fits in windows smaller than the FR-130 design size (1025×736). Give the
+    // scroll area a small minimum height — the parent layout can then shrink
+    // it and the vertical scrollbar engages instead of the page overflowing.
     QScrollArea *scrollArea = new QScrollArea(ui->cleanerCategories);
     scrollArea->setWidgetResizable(true);
     scrollArea->setFrameShape(QFrame::NoFrame);
     scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     scrollArea->setStyleSheet("QScrollArea{background-color:transparent;}");
+    scrollArea->setMinimumHeight(Dpi::scale(160));
+    scrollArea->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     QWidget *container = new QWidget;
     container->setStyleSheet("background-color:transparent;");
@@ -318,7 +324,9 @@ void SystemCleanerPage::buildCategoryCards()
     mScanProgress->hide();
 
     catLayout->addWidget(mScanProgress);
-    catLayout->addWidget(scrollArea);
+    // Stretch 1 so the scroll area absorbs available vertical space and
+    // compresses (rather than overflowing) when the window is small.
+    catLayout->addWidget(scrollArea, 1);
 }
 
 // ─── Inline results (reparented from stacked widget page 1) ──────────────────
@@ -366,6 +374,17 @@ void SystemCleanerPage::buildCleanerFooter()
     leftCol->addWidget(mLblEstimated);
 
     footerRow->addLayout(leftCol, 1);
+
+    // GH#55 / SSO-355: restore the "Select All" affordance dropped in the
+    // FR-130 redesign. Toggles every category card's checkbox in one click;
+    // label flips to "Clear All" when every card is already checked.
+    mBtnSelectAll = new QPushButton(tr("Select All"), mCleanerFooter);
+    mBtnSelectAll->setObjectName("btnSelectAll");
+    mBtnSelectAll->setCursor(Qt::PointingHandCursor);
+    mBtnSelectAll->setFocusPolicy(Qt::NoFocus);
+    connect(mBtnSelectAll, &QPushButton::clicked,
+            this, &SystemCleanerPage::onSelectAllClicked);
+    footerRow->addWidget(mBtnSelectAll);
 
     mBtnCleanSelected = new QPushButton(tr("Clean selected"), mCleanerFooter);
     mBtnCleanSelected->setObjectName("btnCleanSelected");
@@ -429,11 +448,34 @@ void SystemCleanerPage::updateFooterTotal()
 void SystemCleanerPage::updateCleanerCheckBadge()
 {
     int count = 0;
+    int total = 0;
     for (const CategoryCard &c : mCards) {
-        if (c.check && c.check->isChecked())
-            ++count;
+        if (!c.check) continue;
+        ++total;
+        if (c.check->isChecked()) ++count;
     }
     emit checkedCategoryCountChanged(count);
+
+    // GH#55 / SSO-355: when every card is already checked, the affordance
+    // becomes "Clear All" so the user has a one-click escape hatch.
+    if (mBtnSelectAll)
+        mBtnSelectAll->setText((total > 0 && count == total) ? tr("Clear All") : tr("Select All"));
+}
+
+void SystemCleanerPage::onSelectAllClicked()
+{
+    bool allChecked = true;
+    int total = 0;
+    for (const CategoryCard &c : mCards) {
+        if (!c.check) continue;
+        ++total;
+        if (!c.check->isChecked()) { allChecked = false; break; }
+    }
+    const bool target = !(total > 0 && allChecked); // false ⇒ clear, true ⇒ select
+    for (const CategoryCard &c : mCards) {
+        if (c.check && c.check->isEnabled())
+            c.check->setChecked(target);
+    }
 }
 
 // ─── Scan ─────────────────────────────────────────────────────────────────────
@@ -467,6 +509,7 @@ void SystemCleanerPage::on_btnScan_clicked()
     // Disable UI during scan
     mBtnScanSystem->setEnabled(false);
     mBtnSchedule->setEnabled(false);
+    if (mBtnSelectAll) mBtnSelectAll->setEnabled(false);
     for (const CategoryCard &c : mCards)
         if (c.check) c.check->setEnabled(false);
 
@@ -666,6 +709,7 @@ void SystemCleanerPage::onScanFinished()
         if (c.check) c.check->setEnabled(true);
     mBtnScanSystem->setEnabled(true);
     mBtnSchedule->setEnabled(true);
+    if (mBtnSelectAll) mBtnSelectAll->setEnabled(true);
 
     // Show details only for currently checked categories
     refreshInlineTree();
@@ -791,6 +835,7 @@ void SystemCleanerPage::quickCleanByCategory()
 
     mBtnCleanSelected->setEnabled(false);
     mBtnScanSystem->setEnabled(false);
+    if (mBtnSelectAll) mBtnSelectAll->setEnabled(false);
     for (const CategoryCard &c : mCards)
         if (c.check) c.check->setEnabled(false);
 
@@ -851,6 +896,7 @@ void SystemCleanerPage::onCleanFinished()
             if (c.check) c.check->setEnabled(true);
         mBtnScanSystem->setEnabled(true);
         mBtnSchedule->setEnabled(true);
+        if (mBtnSelectAll) mBtnSelectAll->setEnabled(true);
 
     } else {
         // Clean from tree results page (page 1)

--- a/shared/nexis/Pages/SystemCleaner/system_cleaner_page.h
+++ b/shared/nexis/Pages/SystemCleaner/system_cleaner_page.h
@@ -86,6 +86,7 @@ private slots:
     void onManageExclusions();
     void onTreeContextMenu(const QPoint &pos);
     void onSnapshotTaken(const QString &toolName);
+    void onSelectAllClicked();
 
     void showEvent(QShowEvent *event) override;
 
@@ -118,6 +119,7 @@ private:
     QLabel      *mLblCleanerTitle    = nullptr;
     QPushButton *mBtnScanSystem      = nullptr;
     QPushButton *mBtnSchedule        = nullptr;
+    QPushButton *mBtnSelectAll       = nullptr;
     QPushButton *mBtnCleanSelected   = nullptr;
     QLabel      *mLblEstimated       = nullptr;
     QFrame      *mCleanerFooter      = nullptr;

--- a/shared/nexis/app.cpp
+++ b/shared/nexis/app.cpp
@@ -329,15 +329,26 @@ void App::buildSidebar()
 
 void App::init()
 {
-    QScreen *screen = qApp->primaryScreen();
-    if (screen) {
-        setGeometry(
-            QStyle::alignedRect(Qt::LeftToRight, Qt::AlignCenter,
-                size(), screen->availableGeometry())
-        );
-    }
-
     setMinimumSize(700, 480);
+
+    // GH#55 / SSO-355: restore saved window geometry & state, otherwise center
+    // on the primary screen at the design size.
+    const QByteArray savedGeometry = SettingManager::ins()->getWindowGeometry();
+    const QByteArray savedState    = SettingManager::ins()->getWindowState();
+    bool restored = false;
+    if (!savedGeometry.isEmpty())
+        restored = restoreGeometry(savedGeometry);
+    if (!savedState.isEmpty())
+        restoreState(savedState);
+    if (!restored) {
+        QScreen *screen = qApp->primaryScreen();
+        if (screen) {
+            setGeometry(
+                QStyle::alignedRect(Qt::LeftToRight, Qt::AlignCenter,
+                    size(), screen->availableGeometry())
+            );
+        }
+    }
 
     ui->horizontalLayout->setContentsMargins(0,0,0,0);
     ui->horizontalLayout->setSpacing(0);
@@ -727,6 +738,14 @@ void App::init()
 
 void App::closeEvent(QCloseEvent *event)
 {
+    // GH#55 / SSO-355: persist window size & position on every close path,
+    // including the minimize-to-tray "ignored close" — the user can quit from
+    // the tray later, after which Qt does not deliver another closeEvent.
+    // saveGeometry() captures maximized/fullscreen state alongside the
+    // underlying normal geometry, so always call it.
+    SettingManager::ins()->setWindowGeometry(saveGeometry());
+    SettingManager::ins()->setWindowState(saveState());
+
     if (SettingManager::ins()->getMinimizeToTray()) {
         emit SignalMapper::ins()->sigAppVisibilityChanged(false);
         hide();


### PR DESCRIPTION
## Summary

Fixes the three sub-bugs reported in [#55](https://github.com/s4solutionsllc/Nexis/issues/55):

- **Card overflow** — the FR-130 `QScrollArea` had no stretch and no minimum height, so the page fought for its 1025×736 design size at smaller window sizes. Scroll area now takes `stretch=1` + a Dpi-scaled 160 px min height, so the vertical scrollbar engages cleanly. (`shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp`)
- **Window state not persisted** — `App::closeEvent` now writes `QMainWindow::saveGeometry()` / `saveState()` into `SettingManager` (new `WindowGeometry` / `WindowState` keys); `App::init` restores them. Save also fires on the minimize-to-tray "ignored close" path because Qt does not deliver another `closeEvent` if the user later quits from the tray. (`shared/nexis/app.cpp`, `shared/nexis/Managers/setting_manager.{h,cpp}`)
- **Select All restored** — new footer button toggles every card checkbox; label flips to **Clear All** when all are checked; disabled in lock-step with the existing scan/clean enable/disable cycles. (`shared/nexis/Pages/SystemCleaner/system_cleaner_page.{h,cpp}`)

CHANGELOG updated under **Unreleased / Added** and **Unreleased / Fixed**.

## Test plan

- [ ] Resize the main window down to ~800 × 500 — System Cleaner card grid stays inside the page and its own vertical scrollbar engages
- [ ] Resize / move main window, close, relaunch — window comes back at the saved geometry instead of recentering at the default size
- [ ] Maximize the window, close, relaunch — comes back maximized
- [ ] Close via minimize-to-tray (Settings → minimize to tray on) then quit from the tray — relaunch restores the last visible geometry
- [ ] On the System Cleaner page click **Select All** — all category checkboxes light up, label changes to **Clear All**; click **Clear All** — all clear, label flips back
- [ ] Trigger a scan — Select All button disables alongside category checkboxes; re-enables when the scan finishes

## Notes

- The plan called for a reference screenshot diff under `tests/reference_screenshots/` but the existing directory only contains `.gitkeep` placeholders — no screenshot regressions are wired up for the System Cleaner page yet. Headless screenshot generation requires Qt6 + an offscreen QPA, which this branch did not exercise. Leaving the reference-capture task for a separate pass when the harness has a known-good baseline to diff against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)