### PR TITLE
feat(settings): start minimized in system tray (SSO-354 / GH#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Start minimized in system tray (SSO-354 / GH#54):** New "Start minimized in system tray" toggle under Settings → General. When enabled, Nexis launches with no main window — only the tray icon is visible — regardless of how it was started (autostart entry, launcher click, terminal). The tray icon's activate handler restores the window as usual. Equivalent to passing `--hide` on every launch; useful when Nexis is in your login autostart list and you don't want it to pop on top of other apps. Off by default.
 - **Flatpak packaging (SSO-93):** Flatpak manifest added at `linux/flatpak/io.github.s4solutionsllc.Nexis.yml` for Flathub submission. Uses the KDE Qt6 SDK (`org.kde.Platform//6.7`), `--filesystem=host` for broad system access (required for /proc, /sys, hardware sensors, APT sources, and host tool invocations), and `org.freedesktop.PolicyKit1` D-Bus access for privileged operations. Reviewer justification at `docs/flatpak-reviewer-justification.md`.
 
 ### Fixed

--- a/shared/nexis/Managers/setting_manager.cpp
+++ b/shared/nexis/Managers/setting_manager.cpp
@@ -326,6 +326,16 @@ bool SettingManager::getMinimizeToTray() const
     return mSettings->value(SettingKeys::MinimizeToTray, false).toBool();
 }
 
+void SettingManager::setStartMinimizedToTray(bool value)
+{
+    mSettings->setValue(SettingKeys::StartMinimizedToTray, value);
+}
+
+bool SettingManager::getStartMinimizedToTray() const
+{
+    return mSettings->value(SettingKeys::StartMinimizedToTray, false).toBool();
+}
+
 void SettingManager::setUpdateAlertEnabled(bool value)
 {
     mSettings->setValue(SettingKeys::UpdateAlertEnabled, value);

--- a/shared/nexis/Managers/setting_manager.h
+++ b/shared/nexis/Managers/setting_manager.h
@@ -35,6 +35,7 @@ namespace SettingKeys {
     const QString TrayIconStyle("TrayIconStyle");
     const QString DashboardLayout("DashboardLayout");
     const QString MinimizeToTray("MinimizeToTray");
+    const QString StartMinimizedToTray("StartMinimizedToTray");
     const QString UpdateAlertEnabled("UpdateAlertEnabled");
     const QString UpdateCheckIntervalMinutes("UpdateCheckIntervalMinutes");
     const QString UpdateLastCount("UpdateLastCount");
@@ -173,6 +174,9 @@ public:
 
     void setMinimizeToTray(bool value);
     bool getMinimizeToTray() const;
+
+    void setStartMinimizedToTray(bool value);
+    bool getStartMinimizedToTray() const;
 
     void setUpdateAlertEnabled(bool value);
     bool getUpdateAlertEnabled() const;

--- a/shared/nexis/Pages/Settings/settings_page.cpp
+++ b/shared/nexis/Pages/Settings/settings_page.cpp
@@ -124,6 +124,9 @@ void SettingsPage::init()
     // minimize to tray
     ui->checkMinimizeToTray->setChecked(mSettingManager->getMinimizeToTray());
 
+    // start minimized to tray (SSO-354)
+    ui->checkStartMinimizedToTray->setChecked(mSettingManager->getStartMinimizedToTray());
+
     // dashboard footer visibility
     ui->checkDashboardFooter->setChecked(mSettingManager->getDashboardFooterVisible());
 
@@ -294,6 +297,11 @@ void SettingsPage::on_checkAppQuitDontAsk_clicked(bool checked)
 void SettingsPage::on_checkMinimizeToTray_clicked(bool checked)
 {
     mSettingManager->setMinimizeToTray(checked);
+}
+
+void SettingsPage::on_checkStartMinimizedToTray_clicked(bool checked)
+{
+    mSettingManager->setStartMinimizedToTray(checked);
 }
 
 void SettingsPage::on_checkDashboardFooter_clicked(bool checked)

--- a/shared/nexis/Pages/Settings/settings_page.h
+++ b/shared/nexis/Pages/Settings/settings_page.h
@@ -40,6 +40,7 @@ private slots:
     void on_spinBatteryHealthPercent_valueChanged(int value);
     void on_checkAppQuitDontAsk_clicked(bool checked);
     void on_checkMinimizeToTray_clicked(bool checked);
+    void on_checkStartMinimizedToTray_clicked(bool checked);
     void on_checkDashboardFooter_clicked(bool checked);
     void cmbColorSchemeChanged(int index);
     void cmbFontChanged(int index);

--- a/shared/nexis/Pages/Settings/settings_page.ui
+++ b/shared/nexis/Pages/Settings/settings_page.ui
@@ -123,6 +123,15 @@
           </item>
 
           <item row="6" column="0" colspan="2">
+           <widget class="QCheckBox" name="checkStartMinimizedToTray">
+            <property name="text"><string>Start minimized in system tray</string></property>
+            <property name="toolTip"><string>When enabled, Nexis launches hidden and only shows the tray icon. Useful when Nexis is in your autostart list.</string></property>
+            <property name="cursor"><cursorShape>PointingHandCursor</cursorShape></property>
+            <property name="focusPolicy"><enum>Qt::NoFocus</enum></property>
+           </widget>
+          </item>
+
+          <item row="7" column="0" colspan="2">
            <widget class="QCheckBox" name="checkDashboardFooter">
             <property name="text"><string>Show Dashboard system summary and status bar</string></property>
             <property name="cursor"><cursorShape>PointingHandCursor</cursorShape></property>

--- a/shared/nexis/main.cpp
+++ b/shared/nexis/main.cpp
@@ -370,7 +370,10 @@ int main(int argc, char *argv[])
 
     App w;
 
-    if (argc < 2 || !isHide) {
+    // SSO-354: setting-based equivalent of --hide for any launch path.
+    const bool startMinimizedToTray = SettingManager::ins()->getStartMinimizedToTray();
+
+    if (!isHide && !startMinimizedToTray) {
         w.show();
     }
 


### PR DESCRIPTION
## Summary
- Adds a Settings → General toggle ("Start minimized in system tray") that hides the main window on launch.
- Equivalent to passing `--hide` on every launch, so users in autostart can avoid wiring the flag manually. Tray icon's activate handler still restores the window.
- New `SettingManager::getStartMinimizedToTray()/setStartMinimizedToTray()` pair, persisted under key `StartMinimizedToTray`. Default off.

## Changes
- `shared/nexis/Managers/setting_manager.h/.cpp` — add `StartMinimizedToTray` setting + accessors.
- `shared/nexis/Pages/Settings/settings_page.ui/.h/.cpp` — add `checkStartMinimizedToTray` row right under the existing "Minimize to system tray on close" checkbox; auto-connected slot persists the toggle.
- `shared/nexis/main.cpp` — at startup, skip `w.show()` when the setting is on, mirroring the `--hide` CLI flag.
- `CHANGELOG.md` — Unreleased / Added entry.

## Test plan
- [ ] Build on Linux and macOS (`cmake -B build && cmake --build build`).
- [ ] Toggle "Start minimized in system tray" in Settings → General, quit, relaunch — window should not appear; tray icon should be present.
- [ ] Click the tray icon — window restores correctly (existing `App::createTrayActions` activate handler).
- [ ] Toggle off, relaunch — main window appears as before.
- [ ] Confirm `--hide` CLI still works (regression check on the autostart path).
- [ ] Confirm splash screen still finishes cleanly when started minimized (matches existing `--hide` behaviour; not changed here).

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)