### PR TITLE
fix(flatpak): bump manifest target to v2.3.7 (SSO-93)

### DIFF
--- a/linux/flatpak/io.github.s4solutionsllc.Nexis.yml
+++ b/linux/flatpak/io.github.s4solutionsllc.Nexis.yml
@@ -68,8 +68,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/s4solutionsllc/Nexis.git
-        tag: v2.3.6
-        commit: 85824742b832a6988af28024eb3ed21109a5da74
+        tag: v2.3.7
+        commit: da814255d56c8db4235fae33a02ee2a465a1772d
         x-checker-data:
           type: json
           url: https://api.github.com/repos/s4solutionsllc/Nexis/releases/latest


### PR DESCRIPTION
## Summary

- Bumps the Flatpak manifest source target from `v2.3.6` → `v2.3.7`
- Required so the build picks up `linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml`, which Flathub mandates and which did not exist in `v2.3.6`

## Why

[SSO-93](/SSO/issues/SSO-93) — preparing the upstream Flathub submission. The AppStream metainfo (PR #46) landed *after* the `v2.3.6` tag, so a Flathub submission pointing at `v2.3.6` would be rejected. `v2.3.7` (commit `da814255`) is the first release tag containing the metainfo file.

## Verification

- `git show v2.3.7:linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml` — file exists at the new tag
- `git ls-tree -r v2.3.6 -- linux/metainfo/` — empty (file did not exist at v2.3.6)
- Commit SHA `da814255d56c8db4235fae33a02ee2a465a1772d` confirmed via `git log -1 v2.3.7 --format=%H`

After this lands, the same manifest will be opened against `flathub/flathub` as the upstream submission PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)