### PR TITLE
fix(gpu): resolve NVIDIA utilization always showing N/A

### DIFF
--- a/linux/nexis-core/Info/gpu_info.cpp
+++ b/linux/nexis-core/Info/gpu_info.cpp
@@ -96,6 +96,37 @@ static QString readFramebufferDeviceName(const QString &pciBusId, int cardIndex)
 }
 
 /**
+ * Query nvidia-smi once at startup to build a map from normalized PCI bus ID
+ * to nvidia-smi device index.  Returns empty map if nvidia-smi is unavailable.
+ */
+static QHash<QString, int> buildNvidiaIndexMap()
+{
+    QHash<QString, int> map;
+    if (!CommandUtil::isExecutable("nvidia-smi"))
+        return map;
+
+    ExecResult result = CommandUtil::execWithStatus(
+        "nvidia-smi",
+        {"--query-gpu=index,pci.bus_id", "--format=csv,noheader,nounits"},
+        5000);
+
+    if (result.exitCode != 0)
+        return map;
+
+    for (const QString &line : result.output.trimmed().split('\n', Qt::SkipEmptyParts)) {
+        QStringList parts = line.split(',');
+        if (parts.size() < 2)
+            continue;
+        bool ok = false;
+        int idx = parts.at(0).trimmed().toInt(&ok);
+        if (!ok)
+            continue;
+        map.insert(GpuInfo::normalizePciBusId(parts.at(1).trimmed()), idx);
+    }
+    return map;
+}
+
+/**
  * Map a PCI vendor ID string to a vendor name.
  */
 static QString vendorFromPciId(const QString &vendorId)
@@ -110,6 +141,8 @@ void GpuInfoLinux::discoverGpus()
 {
     mDevices.clear();
     mDiagEntries.clear();
+
+    const QHash<QString, int> nvidiaIndexMap = buildNvidiaIndexMap();
 
     QDir drmDir(DRM_BASE);
     if (!drmDir.exists())
@@ -157,8 +190,9 @@ void GpuInfoLinux::discoverGpus()
                 if (!QFile::exists(dev.sysfsLoadPath))
                     dev.sysfsLoadPath.clear();
             } else if (vendor == "NVIDIA") {
-                if (!pciBusId.isEmpty() && CommandUtil::isExecutable("nvidia-smi"))
-                    dev.queryCommand = pciBusId;
+                const QString normId = GpuInfo::normalizePciBusId(pciBusId);
+                if (nvidiaIndexMap.contains(normId))
+                    dev.queryCommand = QString::number(nvidiaIndexMap.value(normId));
             } else if (vendor == "Intel") {
                 QString curFreqPath = cardPath + "/gt_cur_freq_mhz";
                 QString maxFreqPath = cardPath + "/gt_max_freq_mhz";

--- a/shared/nexis-core/Info/gpu_info.h
+++ b/shared/nexis-core/Info/gpu_info.h
@@ -14,7 +14,8 @@ struct GpuDevice {
 
     // Platform-specific fields used internally for re-reading utilization
     QString sysfsLoadPath;  // Linux: path to gpu_busy_percent or similar
-    QString queryCommand;   // Linux: nvidia-smi command for this GPU (if NVIDIA)
+    QString queryCommand;   // Linux/NVIDIA: nvidia-smi device index as decimal string ("0","1",…)
+                            // Linux/Intel:  sysfs path to gt_max_freq_mhz
     QString pciBusId;       // PCI bus address (e.g. "0000:03:00.0") for consistent ordering
     int     deviceIndex;    // index within vendor's enumeration
     quint64 registryEntryID = 0; // macOS: IOKit registry entry ID for matching
@@ -45,6 +46,10 @@ public:
     // Extracts the parent PCI bus address from a simple-framebuffer DRM symlink target.
     // e.g. ".../0000:04:00.0/simple-framebuffer.0/drm/card0" → "0000:04:00.0"
     static QString parseFramebufferParentPciBusId(const QString &symlinkTarget);
+
+    // Normalizes a PCI bus ID from any tool format to "bus:device.function" lowercase.
+    // e.g. "0000:07:00.0" and "00000000:07:00.0" both become "07:00.0"
+    static QString normalizePciBusId(const QString &rawBusId);
 
     // Returns a structured diagnostic report for GPU troubleshooting.
     virtual QString getDiagnosticReport() const;

--- a/shared/nexis-core/Info/gpu_info_shared.cpp
+++ b/shared/nexis-core/Info/gpu_info_shared.cpp
@@ -78,6 +78,14 @@ QString GpuInfo::parseFramebufferParentPciBusId(const QString &symlinkTarget)
     return {};
 }
 
+QString GpuInfo::normalizePciBusId(const QString &rawBusId)
+{
+    QStringList segs = rawBusId.split(':');
+    if (segs.size() < 2)
+        return rawBusId.toLower();
+    return (segs.at(segs.size() - 2) + ":" + segs.last()).toLower();
+}
+
 QString GpuInfo::getDiagnosticReport() const
 {
     QString report;

--- a/tests/core/test_gpu_info.cpp
+++ b/tests/core/test_gpu_info.cpp
@@ -42,6 +42,13 @@ private slots:
     void framebuffer_noPciParent();
     void framebuffer_noFramebufferInPath();
     void framebuffer_emptyInput();
+
+    // normalizePciBusId
+    void normPci_sysfsFormat();
+    void normPci_nvidiaSmiFormat();
+    void normPci_uppercase();
+    void normPci_shortForm();
+    void normPci_empty();
 };
 
 // --- parseNvidiaSmiUtilization ---
@@ -201,6 +208,33 @@ void TestGpuInfo::framebuffer_noFramebufferInPath()
 void TestGpuInfo::framebuffer_emptyInput()
 {
     QVERIFY(GpuInfo::parseFramebufferParentPciBusId("").isEmpty());
+}
+
+// --- normalizePciBusId ---
+
+void TestGpuInfo::normPci_sysfsFormat()
+{
+    QCOMPARE(GpuInfo::normalizePciBusId("0000:07:00.0"), "07:00.0");
+}
+
+void TestGpuInfo::normPci_nvidiaSmiFormat()
+{
+    QCOMPARE(GpuInfo::normalizePciBusId("00000000:07:00.0"), "07:00.0");
+}
+
+void TestGpuInfo::normPci_uppercase()
+{
+    QCOMPARE(GpuInfo::normalizePciBusId("00000000:0A:00.0"), "0a:00.0");
+}
+
+void TestGpuInfo::normPci_shortForm()
+{
+    QCOMPARE(GpuInfo::normalizePciBusId("07:00.0"), "07:00.0");
+}
+
+void TestGpuInfo::normPci_empty()
+{
+    QCOMPARE(GpuInfo::normalizePciBusId(""), "");
 }
 
 QTEST_MAIN(TestGpuInfo)


### PR DESCRIPTION
## Summary

- `discoverGpus()` was storing the sysfs PCI bus ID (`"0000:07:00.0"`) in `GpuDevice::queryCommand`
- `updateGpuInfo()` called `.toInt()` on it expecting an nvidia-smi integer index — always returned `ok=false`
- `NvidiaSmiCache::get()` was therefore never called; utilization stayed at -1 (N/A) forever
- GPU name subtitle was correctly populated (lspci path), only utilization was broken

## Fix

At startup in `discoverGpus()`, call `nvidia-smi --query-gpu=index,pci.bus_id` once to build a PCI bus ID → nvidia-smi index map. Normalize both sysfs (`0000:07:00.0`) and nvidia-smi (`00000000:07:00.0`) formats to `bus:device.function` lowercase for comparison, then store the integer index in `queryCommand`. No changes to `updateGpuInfo()` or `NvidiaSmiStreamer`.

## Changes

| File | Change |
|------|--------|
| `shared/nexis-core/Info/gpu_info.h` | Add `normalizePciBusId()` static method; fix `queryCommand` doc comment |
| `shared/nexis-core/Info/gpu_info_shared.cpp` | Implement `normalizePciBusId()` |
| `linux/nexis-core/Info/gpu_info.cpp` | Add `buildNvidiaIndexMap()` helper; fix `discoverGpus()` NVIDIA branch |
| `tests/core/test_gpu_info.cpp` | 5 unit tests for `normalizePciBusId()` |

## Test plan

- [ ] Build passes clean
- [ ] `ctest`: 30/30 passing (verified)
- [ ] GPU gauge shows live utilization % on NVIDIA hardware (manual — run Nexis on the P40 system)
- [ ] AMD and Intel GPU paths unaffected (no changes to those branches)

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)