### PR TITLE
chore(release): bump version to 2.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.9] - 2026-06-01
+
+### Fixed
+- **GPU gauge shows N/A on NVIDIA cards (GH#72):** `discoverGpus()` was storing the sysfs PCI bus ID (`"0000:07:00.0"`) in the utilization query field, but the update path called `.toInt()` on it expecting a numeric nvidia-smi device index — always failing, leaving utilization at -1 (N/A) indefinitely. Fixed by querying `nvidia-smi --query-gpu=index,pci.bus_id` once at startup to map each GPU's PCI address to its nvidia-smi index, with normalization to reconcile sysfs (`0000:07:00.0`) and nvidia-smi (`00000000:07:00.0`) formats. GPU name detection was unaffected.
+
 ## [2.3.8] - 2026-05-29
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
-project(Nexis VERSION 2.3.8)
+project(Nexis VERSION 2.3.9)
 
 # Adding features(build cache + faster linkers) and reasonable defaults(Debug build by default)
 include("${CMAKE_CURRENT_SOURCE_DIR}/shared/cmake/cxxbasics/CXXBasics.cmake")

--- a/linux/aur/PKGBUILD
+++ b/linux/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Luke Simpson <luke@s4solutions.ai>
 pkgname=nexis
-pkgver=2.3.7
+pkgver=2.3.9
 pkgrel=1
 pkgdesc="Linux system optimizer and monitoring tool"
 arch=('x86_64' 'aarch64')

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,10 @@
+nexis (2.3.9-0) unstable; urgency=medium
+
+  * Fix GPU utilization gauge showing N/A on NVIDIA cards even when
+    nvidia-smi is available. GPU name detection was unaffected (GH#72).
+
+ -- Luke Simpson <luke@s4solutions.ai>  Sun, 01 Jun 2026 00:00:00 +0000
+
 nexis (2.3.8-0) unstable; urgency=medium
 
   * Multi-battery support: detect and display all batteries on dual-battery


### PR DESCRIPTION
## Release v2.3.9

### Changes in this release
- **GH#72** — Fix GPU utilization gauge showing N/A on NVIDIA cards

### Files updated
| File | Change |
|------|--------|
| `CMakeLists.txt` | `2.3.8` → `2.3.9` |
| `CHANGELOG.md` | `[Unreleased]` → `[2.3.9] - 2026-06-01`, fresh `[Unreleased]` added |
| `linux/aur/PKGBUILD` | `pkgver=2.3.7` → `pkgver=2.3.9` |
| `linux/debian/changelog` | New `2.3.9-0` entry added |

## To complete the release

After merging this PR, apply the annotated tag to trigger `release.yml`:

```bash
git checkout native && git pull
git tag -a v2.3.9 -m "Nexis 2.3.9"
git push origin v2.3.9
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)