### PR TITLE
fix(dashboard): anchor health tile to prevent default layout overlap (GH#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Dashboard default layout overlap in bottom-right corner (GH#77):** On new installations with all four sensor types present (GPU, thermal, battery, fan), the default layout generator placed the health tile at column 4 — past the grid boundary — causing it to be clamped to column 3 and overlap the fan tile. The health tile is now anchored to a fixed position (row 1, col 3) and sensor tiles fill columns 0–2, wrapping to the next row if all four are present.
 - **Translation files missing from AppImage and .deb packages (GH#75):** All non-English locales were silently broken in distributed packages — the compiled `.qm` files were generated during the build but never included in the install step, so `cmake --install` (used by both the AppImage and .deb workflows) left them behind. Added a CMake install rule that stages all `nexis_*.qm` files into `share/nexis/translations/`. Also fixed the runtime translation load path in `AppManager`: the app was searching `<binaryDir>/translations/` (correct for dev builds only), but installed layouts place the files at `<binaryDir>/../share/nexis/translations/`. The loader now tries the FHS-installed path first, with the beside-binary path as a fallback for development builds.
 
 ## [2.3.9] - 2026-06-01

--- a/shared/nexis/Pages/Dashboard/dashboard_page.cpp
+++ b/shared/nexis/Pages/Dashboard/dashboard_page.cpp
@@ -1197,12 +1197,17 @@ QJsonArray DashboardPage::defaultLayout() const
     addEntry("disk", 0, 2, 1, 1);
     addEntry("network", 0, 3, 1, 1);
 
-    int col = 0;
-    if (im->hasGpu()) addEntry("gpu", 1, col++, 1, 1);
-    if (im->hasThermalSensors()) addEntry("temp", 1, col++, 1, 1);
-    if (im->hasBattery()) addEntry("battery", 1, col++, 1, 1);
-    if (im->hasFanSensors()) addEntry("fan", 1, col++, 1, 1);
-    addEntry("health", 1, col++, 1, 1);
+    addEntry("health", 1, 3, 1, 1);
+
+    int sRow = 1, sCol = 0;
+    auto addSensor = [&](const QString &id) {
+        if (sCol >= 3) { sRow = 2; sCol = 0; }
+        addEntry(id, sRow, sCol++, 1, 1);
+    };
+    if (im->hasGpu())            addSensor("gpu");
+    if (im->hasThermalSensors()) addSensor("temp");
+    if (im->hasBattery())        addSensor("battery");
+    if (im->hasFanSensors())     addSensor("fan");
 
     return arr;
 }


### PR DESCRIPTION
## Summary

- On new installations with all four sensor types (GPU, thermal, battery, fan), the default dashboard layout placed the health tile at column 4 — one past the 4-column grid boundary
- `deserializeLayout()` clamped it back to column 3, causing the health tile to render on top of the fan tile in the bottom-right corner
- Health tile is now anchored to a fixed position `(row 1, col 3)` — it is always present and benefits from a consistent location
- Sensor tiles pack left-to-right into columns 0–2; if all four are present the 4th (fan) wraps to `(row 2, col 0)`
- Only `defaultLayout()` changed — no impact on saved layouts or any other code path

## Test plan

- [ ] Fresh install (no saved `DashboardLayout` setting): verify health tile appears at top-right of row 1 with no overlap
- [ ] System with all 4 sensor types: fan tile at (row 2, col 0), health at (row 1, col 3), no overlap
- [ ] System with 0–3 sensor tiles: health at (row 1, col 3), sensors fill (row 1, cols 0–2)
- [ ] Existing users with a saved layout: layout unchanged on launch
- [ ] 28/29 tests passing (ScreenshotTests pixel-drift is pre-existing)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)