### PR TITLE
fix(i18n): actually compile .qm files so translations ship in packages (GH#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Translations still missing from all packages — the actual root cause (GH#75):** The 2.3.10 fix added a CMake install rule and corrected the runtime load path, but translations remained broken because no `.qm` files were ever compiled in the first place. The `qt_create_translation` call was passing the bare token `NEXIS_TRANSLATIONS` instead of the expanded `${NEXIS_TRANSLATIONS}` list, so none of the arguments ended in `.ts` and lrelease was never invoked — `QM_FILES` came out empty, leaving the install rule with nothing to stage. Switched to `qt_add_translation(QM_FILES ${NEXIS_TRANSLATIONS})`, which compiles the committed `.ts` files into `.qm` via lrelease only. (Using `qt_add_translation` rather than `qt_create_translation` also keeps the build from running lupdate over the sources and rewriting the tracked `.ts` files — source-string extraction is owned by the separate `lupdate.yml` workflow.) All 34 locales now compile and install to `share/nexis/translations/`.
+
 ## [2.3.10] - 2026-06-03
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,10 +477,15 @@ set(NEXIS_TRANSLATIONS
   "${SHARED_DIR}/translations/nexis_zh-cn.ts"
   "${SHARED_DIR}/translations/nexis_zh-tw.ts"
 )
-find_package(Qt6 COMPONENTS LinguistTools)
-qt_create_translation(QM_FILES NEXIS_TRANSLATIONS
-    ${GUI_SHARED_SRCS} ${GUI_PLAT_SRCS}
-    ${CORE_SHARED_SRCS} ${CORE_PLAT_SRCS})
+find_package(Qt6 COMPONENTS LinguistTools REQUIRED)
+# Compile the committed .ts files into .qm. Use qt_add_translation (lrelease
+# only) rather than qt_create_translation: source-string extraction via lupdate
+# is handled by the dedicated lupdate.yml workflow, so the build must not
+# regenerate the tracked .ts files. (Also note: qt_create_translation only
+# emits .qm for arguments ending in .ts — passing the bare variable name
+# NEXIS_TRANSLATIONS instead of ${NEXIS_TRANSLATIONS} silently produced zero
+# .qm files, which is why translations were missing from every package.)
+qt_add_translation(QM_FILES ${NEXIS_TRANSLATIONS})
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${QM_FILES}")
 
 install(


### PR DESCRIPTION
## Summary

The 2.3.10 fix for GH#75 (#78) addressed two real symptoms — a missing CMake `install()` rule for `.qm` files and a wrong runtime load path — but translations remained broken in every distributed package because **no `.qm` files were ever compiled in the first place**, so the install rule had nothing to stage.

## Root cause

In `CMakeLists.txt`, `qt_create_translation` was passed the bare token `NEXIS_TRANSLATIONS` instead of the expanded `${NEXIS_TRANSLATIONS}` list:

```cmake
qt_create_translation(QM_FILES NEXIS_TRANSLATIONS ...)
```

`qt_create_translation` only emits a `.qm` for arguments that **end in `.ts`**. Because the variable was never expanded, none of the 34 `.ts` paths were seen, `lrelease` never ran, and `QM_FILES` came out **empty** — leaving both the install rule and the (correct) runtime loader with nothing to work with.

Confirmed empirically: a clean Release build completed successfully but produced **0 `.qm` files** with no lrelease step in the log; a debug `message()` showed `QM_FILES = []` while `NEXIS_TRANSLATIONS` was fully populated.

## Fix

Switched to `qt_add_translation(QM_FILES ${NEXIS_TRANSLATIONS})`:

- **Expands the variable** so the `.ts` files are actually passed to lrelease.
- **`qt_add_translation` (lrelease only)** instead of `qt_create_translation` (lupdate + lrelease) — source-string extraction is already owned by the dedicated `lupdate.yml` workflow, so the build must not rewrite the tracked `.ts` files. Verified `git status` shows no `.ts` modifications after a build.
- Marked `LinguistTools REQUIRED` so a missing toolchain fails configure loudly instead of silently dropping translations.

## Verification

- 34 `nexis_*.qm` files now compile during the build.
- `DESTDIR=... cmake --install build` stages all 34 into `usr/share/nexis/translations/` — exactly the FHS path the runtime loader (fixed in 2.3.10) searches.
- Full chain now works for both the AppImage and `.deb` flows.
- No tracked `.ts` files modified by the build.

https://claude.ai/code/session_01LDL43NapTQV3ZssJpeykTo

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDL43NapTQV3ZssJpeykTo)_