### PR TITLE
fix(i18n): prompt to restart when interface language changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Changing the interface language had no visible effect:** Selecting a different language in Settings only saved the preference — the translator is installed once at startup and was never swapped, and no page implements live `retranslateUi()`, so the UI stayed in the previous language with no indication why. Nexis now tells the user the change takes effect after a restart and offers to relaunch immediately. (The relaunch uses `$APPIMAGE` when running from an AppImage so it re-launches the bundle rather than the transient mount path.)
+
 ## [2.3.11] - 2026-06-04
 
 ### Fixed

--- a/docs/APPLICATION_OVERVIEW.md
+++ b/docs/APPLICATION_OVERVIEW.md
@@ -685,7 +685,7 @@ tests/
 | Concurrent | `QtConcurrent::run` for async operations |
 | Network | `QNetworkInterface` for network info |
 | Test | Qt Test framework for unit tests (CTest integration) |
-| LinguistTools | `qt_create_translation` for i18n |
+| LinguistTools | `qt_add_translation` (lrelease) for i18n |
 
 ### Build Commands
 
@@ -801,8 +801,8 @@ OS-native scheduling:
 
 Arabic, Afrikaans, Catalan, Chinese (Simplified/Traditional), Czech, Danish, Dutch, English, Finnish, French, Galician, German, Greek, Hebrew, Hindi, Italian, Japanese, Kannada, Korean, Malayalam, Norwegian, Occitan, Polish, Portuguese, Romanian, Russian, Serbian, Spanish, Swedish, Turkish, Ukrainian, Vietnamese
 
-**Build:** `qt_create_translation()` generates binary `.qm` files embedded in the executable.
-**Runtime:** `AppManager` loads the selected language via `QTranslator::load()`.
+**Build:** `qt_add_translation()` compiles the committed `.ts` files into binary `.qm` files via `lrelease` (source-string extraction with `lupdate` is handled separately by the `lupdate.yml` workflow). The `.qm` files are installed to `share/nexis/translations/` so they ship in the AppImage and `.deb` packages.
+**Runtime:** `AppManager` loads the selected language via `QTranslator::load()` once at startup, searching the FHS install path (`../share/nexis/translations`) first, then beside the binary for dev builds. Changing the language in Settings requires a restart — Nexis prompts the user and offers to relaunch (there is no live `retranslateUi()`).
 **Management:** Crowdin integration with automated PR workflows for community translations.
 
 ---

--- a/shared/nexis/Pages/Settings/settings_page.cpp
+++ b/shared/nexis/Pages/Settings/settings_page.cpp
@@ -9,6 +9,8 @@
 #include "utilities.h"
 #include <QApplication>
 #include <QFileDialog>
+#include <QMessageBox>
+#include <QProcess>
 #include <QRegularExpression>
 #include <QLineEdit>
 #include <QGridLayout>
@@ -220,7 +222,31 @@ void SettingsPage::init()
 void SettingsPage::cmbLanguagesChanged(const int &index)
 {
     QString langCode = ui->cmbLanguages->itemData(index).toString();
+
+    // Ignore programmatic re-selection that doesn't actually change the language
+    // (e.g. the combo being repopulated) so we don't prompt spuriously.
+    if (langCode == mSettingManager->getLanguage())
+        return;
+
     mSettingManager->setLanguage(langCode);
+
+    // Translations are installed once at startup (see AppManager), so a new
+    // language only takes effect after a relaunch. Tell the user and offer to
+    // restart now rather than leaving the UI silently unchanged.
+    const auto choice = QMessageBox::question(
+        this, tr("Language Changed"),
+        tr("The language change will take effect after Nexis is restarted.\n\n"
+           "Restart now?"),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+
+    if (choice == QMessageBox::Yes) {
+        // Inside an AppImage the executable lives on a transient mount that
+        // disappears on exit; relaunch the .AppImage itself via $APPIMAGE.
+        const QString target =
+            qEnvironmentVariable("APPIMAGE", qApp->applicationFilePath());
+        QProcess::startDetached(target, qApp->arguments().mid(1));
+        qApp->quit();
+    }
 }
 
 void SettingsPage::cmbDiskChanged(const int &index)


### PR DESCRIPTION
## Summary

Changing the interface language in Settings appeared to do nothing. This fixes that with a restart prompt.

## Root cause

Selecting a language only persisted the preference:
- `SettingsPage::cmbLanguagesChanged()` called `setLanguage()` and nothing else.
- The translator (`AppManager::mTranslator`) is installed **once at startup** and never swapped.
- `App::changeEvent()` doesn't handle `QEvent::LanguageChange`, and no page implements `retranslateUi()` — there is no live-retranslation infrastructure.

So the text only changed on the **next launch**, with no indication to the user that a restart was required. (This is distinct from GH#75, which fixed the `.qm` files being absent from packages — that part now works at startup.)

## Fix

`SettingsPage::cmbLanguagesChanged()` now:
- Guards against programmatic re-selection that doesn't actually change the language (no spurious prompt).
- Informs the user the change takes effect after a restart and offers to relaunch immediately.
- Relaunches via `$APPIMAGE` when set, so an AppImage re-launches the bundle rather than the transient mount path that disappears on exit; falls back to `applicationFilePath()` for `.deb`/dev/macOS.

A full live-retranslation (re-installing the translator + `changeEvent`/`retranslateUi` across every page) was considered but is a large, cross-cutting change and wouldn't cover strings set dynamically in C++; the restart prompt is the reliable, low-risk fix and matches common Qt-app behavior.

## Verification

- Builds cleanly (`cmake --build build --target nexis`).
- No unit tests touch this path; only the screenshot test renders the page, and the prompt only fires on user-initiated change.
- Not verified on a real display (headless container) — the relaunch logic is the standard Qt restart idiom; an on-device check of the AppImage relaunch is worth doing.

## Docs

- `CHANGELOG.md` — entry under `[Unreleased]`.
- `docs/APPLICATION_OVERVIEW.md` — Translation System section corrected (now `qt_add_translation`/lrelease, `.qm` installed to `share/nexis/translations/` rather than "embedded in the executable", and the restart-on-change behavior noted).

https://claude.ai/code/session_01LDL43NapTQV3ZssJpeykTo

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDL43NapTQV3ZssJpeykTo)_