### PR TITLE
fix(i18n): stage .qm files next to binary for dev/in-tree builds (GH#85)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,6 +601,15 @@ add_executable(nexis
 
 target_link_libraries(nexis nexis-gui)
 
+# Stage .qm files next to the binary for dev/in-tree runs.
+# cmake --install handles packages; this covers build-tree execution where
+# applicationDirPath()/translations would otherwise never exist.
+add_custom_command(TARGET nexis POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${EXECUTABLE_OUTPUT_PATH}translations"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QM_FILES} "${EXECUTABLE_OUTPUT_PATH}translations/"
+    COMMENT "Staging .qm files for in-tree runs"
+)
+
 # ============================================================================
 # Tests (Qt Test + CTest)
 # ============================================================================


### PR DESCRIPTION
## Summary

- Translations never loaded when running `build/output/nexis` directly from the build tree
- `qt_add_translation` puts `.qm` files in `CMAKE_CURRENT_BINARY_DIR` (`build/`), but the binary is in `EXECUTABLE_OUTPUT_PATH` (`build/output/`)
- The runtime search path `applicationDirPath()/translations` → `build/output/translations/` never existed, so `QTranslator::load()` failed silently

## Fix

One `POST_BUILD` command on the `nexis` target copies all `.qm` files into `build/output/translations/` after each build, matching the existing runtime search path used for dev/in-tree execution.

Installed packages are unaffected — `cmake --install` already places `.qm` files correctly via the `install(FILES ...)` rule added in GH#83.

## Test plan

- [ ] Build from tree and verify `build/output/translations/nexis_*.qm` (34 files) exist
- [ ] Run `build/output/nexis`, switch to a non-English language, restart, verify UI text changes
- [ ] Confirm `cmake --install` flow still works (`.qm` files appear in `DESTDIR/usr/share/nexis/translations/`)

Closes #85

🤖 Generated with [Claude Code](https://claude.ai/code)