### PR TITLE
fix(i18n): wrap missing user-visible strings in tr()

### DIFF
--- a/shared/nexis/Pages/Dashboard/health_score_calculator.cpp
+++ b/shared/nexis/Pages/Dashboard/health_score_calculator.cpp
@@ -1,5 +1,6 @@
 #include "health_score_calculator.h"
 
+#include <QCoreApplication>
 #include <QtGlobal>
 
 HealthScoreCalculator::HealthScoreCalculator()
@@ -84,9 +85,9 @@ int HealthScoreCalculator::compositeScore() const
 QString HealthScoreCalculator::scoreLabel() const
 {
     int score = compositeScore();
-    if (score >= 75) return QStringLiteral("Excellent");
-    if (score >= 40) return QStringLiteral("Good");
-    return QStringLiteral("Poor");
+    if (score >= 75) return QCoreApplication::translate("HealthScoreCalculator", "Excellent");
+    if (score >= 40) return QCoreApplication::translate("HealthScoreCalculator", "Good");
+    return QCoreApplication::translate("HealthScoreCalculator", "Poor");
 }
 
 QList<HealthComponent> HealthScoreCalculator::components() const

--- a/shared/nexis/Pages/Dashboard/health_score_tile.cpp
+++ b/shared/nexis/Pages/Dashboard/health_score_tile.cpp
@@ -17,8 +17,7 @@ static const QMap<QString, QString> kComponentColorTokens = {
 
 HealthScoreTile::HealthScoreTile(const QString &colorToken, QWidget *parent)
     : MetricTileBase("Health Score", colorToken, parent),
-      mCurrentScore(100),
-      mCurrentLabel("Excellent")
+      mCurrentScore(100)
 {
     setObjectName("healthScoreTile");
     buildLayout();

--- a/shared/nexis/Pages/Dashboard/health_score_tile.h
+++ b/shared/nexis/Pages/Dashboard/health_score_tile.h
@@ -40,7 +40,6 @@ private:
     QLabel *mLblScoreLabel;
 
     int mCurrentScore;
-    QString mCurrentLabel;
 };
 
 #endif // HEALTH_SCORE_TILE_H

--- a/shared/nexis/Pages/GnomeSettings/gnome_wm_tab.cpp
+++ b/shared/nexis/Pages/GnomeSettings/gnome_wm_tab.cpp
@@ -194,12 +194,12 @@ void GnomeWmTab::loadSettings()
 {
     mLoading = true;
 
-    auto addTitlebarActions = [](QComboBox *combo) {
-        combo->addItem("Toggle Maximize", "toggle-maximize");
-        combo->addItem("Minimize",        "minimize");
-        combo->addItem("Lower",           "lower");
-        combo->addItem("Menu",            "menu");
-        combo->addItem("None",            "none");
+    auto addTitlebarActions = [this](QComboBox *combo) {
+        combo->addItem(tr("Toggle Maximize"), "toggle-maximize");
+        combo->addItem(tr("Minimize"),        "minimize");
+        combo->addItem(tr("Lower"),           "lower");
+        combo->addItem(tr("Menu"),            "menu");
+        combo->addItem(tr("None"),            "none");
     };
 
     // WM Preferences

--- a/shared/nexis/Pages/Search/search_page.cpp
+++ b/shared/nexis/Pages/Search/search_page.cpp
@@ -160,10 +160,10 @@ void SearchPage::initComboboxValues()
     ui->cmbSizeCriteria->addItem(tr("Equal (=)"), "");
     ui->cmbSizeCriteria->addItem(tr("Greater (>)"), "+");
 
-    ui->cmbSizeUnits->addItem("Bytes", "c");
-    ui->cmbSizeUnits->addItem("Kibibytes", "k");
-    ui->cmbSizeUnits->addItem("Mebibytes", "M");
-    ui->cmbSizeUnits->addItem("Gibibytes", "G");
+    ui->cmbSizeUnits->addItem(tr("Bytes"), "c");
+    ui->cmbSizeUnits->addItem(tr("Kibibytes"), "k");
+    ui->cmbSizeUnits->addItem(tr("Mebibytes"), "M");
+    ui->cmbSizeUnits->addItem(tr("Gibibytes"), "G");
 }
 
 void SearchPage::on_btnBrowseSearchDir_clicked()


### PR DESCRIPTION
## Summary

- `search_page.cpp` — Bytes/Kibibytes/Mebibytes/Gibibytes size unit labels now go through `tr()`
- `gnome_wm_tab.cpp` — titlebar action items (Toggle Maximize/Minimize/Lower/Menu/None) now go through `tr()` (lambda captures `this`)
- `health_score_calculator.cpp` — Excellent/Good/Poor labels now use `QCoreApplication::translate()` (non-QObject class)
- `health_score_tile.h/.cpp` — removed dead `mCurrentLabel` member that was initialized but never read (actual label comes from `scoreLabel()` at runtime)

These strings were translatable in intent but bypassed the translation system entirely. They'll be picked up by lupdate and sent to Crowdin for translation.

## Test plan

- [ ] Build clean — no errors
- [ ] Search page: size units combo shows "Bytes/Kibibytes/Mebibytes/Gibibytes" in English, translated when a completed locale is active
- [ ] GNOME Settings: titlebar action combos translate correctly
- [ ] Dashboard health score: "Excellent/Good/Poor" label translates correctly

🤖 Generated with [Claude Code](https://claude.ai/code)