### PR TITLE
fix(aur): disable LTO and LLD to fix CachyOS link failure (GH#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.13] - 2026-06-05
+
+### Fixed
+- **AUR install still failed on CachyOS / Arch with `undefined symbol: main` (GH#82):** The v2.3.12 fix only disabled the test suite, which moved the same link failure from the test binaries onto the `nexis` executable itself. The real cause is GCC LTO objects being linked by LLD: on distros that enable LTO by default (CachyOS), GCC emits slim LTO objects, and LLD cannot resolve symbols defined inside them — the lone real-object reference into LTO code (`Scrt1.o`'s `_start → main`) surfaces as an undefined `main`, which is why *every* executable failed and only on `main`. The build also force-selected LLD via the in-tree `CXXBASICS_USE_FASTER_LINKERS` helper, so the LLD half was self-inflicted. The PKGBUILD now sets `options=('!lto')` (no `-flto` injection) and builds with `-DCXXBASICS_USE_FASTER_LINKERS=OFF` (system default linker), making the packaged build a reproducible default-toolchain build that links cleanly. The underlying GCC 16 + LLD + LTO toolchain incompatibility remains tracked in GH#88.
+
 ## [2.3.12] - 2026-06-04
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
-project(Nexis VERSION 2.3.12)
+project(Nexis VERSION 2.3.13)
 
 # Adding features(build cache + faster linkers) and reasonable defaults(Debug build by default)
 include("${CMAKE_CURRENT_SOURCE_DIR}/shared/cmake/cxxbasics/CXXBasics.cmake")

--- a/linux/aur/PKGBUILD
+++ b/linux/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Luke Simpson <luke@s4solutions.ai>
 pkgname=nexis
-pkgver=2.3.12
+pkgver=2.3.13
 pkgrel=1
 pkgdesc="Linux system optimizer and monitoring tool"
 arch=('x86_64' 'aarch64')
@@ -8,15 +8,27 @@ url="https://github.com/s4solutionsllc/Nexis"
 license=('GPL-3.0-or-later')
 depends=('qt6-base' 'qt6-charts' 'qt6-svg')
 makedepends=('cmake' 'gcc' 'make' 'qt6-tools')
+# GH#82: '!lto' stops makepkg injecting -flto. On distros that enable LTO by
+# default (CachyOS), GCC emits slim LTO objects that LLD cannot resolve, so the
+# link fails with "undefined symbol: main" (Scrt1.o's _start -> main, the one
+# real-object reference into an LTO object). Disabling LTO keeps the packaged
+# build using plain objects that any linker handles.
+options=('!lto')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/s4solutionsllc/Nexis/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('SKIP')
 
 build() {
+    # GH#82: CXXBASICS_USE_FASTER_LINKERS=OFF disables the in-tree auto-selection
+    # of LLD (UseFasterLinkers.cmake). A distro package should link with the
+    # system default linker (BFD), which understands GCC's LTO plugin, rather
+    # than force-selecting LLD. Combined with options=('!lto') this makes the
+    # packaged build a reproducible default-toolchain build.
     cmake -B build -S "Nexis-$pkgver" \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DAPP_VERSION_OVERRIDE="$pkgver" \
         -DBUILD_TESTING=OFF \
+        -DCXXBASICS_USE_FASTER_LINKERS=OFF \
         -Wno-dev
     cmake --build build -j$(nproc)
 }

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,10 @@
+nexis (2.3.13-0) unstable; urgency=medium
+
+  * Fix AUR install failing on CachyOS/Arch with "undefined symbol: main" —
+    disable LTO and LLD force-selection in the packaged build (GH#82)
+
+ -- Luke Simpson <luke@s4solutions.ai>  Fri, 05 Jun 2026 00:00:00 +0000
+
 nexis (2.3.12-0) unstable; urgency=medium
 
   * Fix language change requiring restart now prompts and offers to relaunch


### PR DESCRIPTION
## Problem

`paru -S nexis` / `yay -S nexis` still abort on CachyOS (and Arch GCC 16 + LLD) with:

```
ld.lld: error: undefined symbol: main
>>> referenced by .../Scrt1.o:(_start)
```

The v2.3.12 fix (`-DBUILD_TESTING=OFF`, #89) only disabled the *test* binaries — so the identical failure simply moved onto the `nexis` executable itself. Reported still-failing on the issue: https://github.com/s4solutionsllc/Nexis/issues/82

## Root cause

`undefined symbol: main` requires **both** GCC-LTO objects **and** the LLD linker:

1. CachyOS's `makepkg.conf` enables `lto` in `OPTIONS`, injecting `-flto` → **GCC 16 emits slim LTO objects** (GIMPLE bytecode, no machine code).
2. **LLD does not support the GNU LTO plugin**, so it can't materialize symbols defined inside GCC LTO objects. References *between* LTO objects bind silently against the stub symtab; the one reference from a **real** object — `Scrt1.o`'s `_start → main` — has no real `main` to bind to → `undefined symbol: main`.

That fingerprint (every executable fails, *only* on `main`) is the textbook LTO+LLD signature. The LLD half was self-inflicted: [`UseFasterLinkers.cmake`](shared/cmake/cxxbasics/accelerators/UseFasterLinkers.cmake) defaults `CXXBASICS_USE_FASTER_LINKERS=ON` and force-selects `-fuse-ld=lld`. Stock Arch and the `.deb`/AppImage builds are unaffected because they don't enable LTO; BFD `ld` handles GCC LTO via its plugin.

## Fix

Make the packaged build a reproducible default-toolchain build — fix on both axes (defense-in-depth; either alone resolves it, both cover stock-Arch, CachyOS, and any derivative regardless of default linker):

- `options=('!lto')` — stop makepkg injecting `-flto`
- `-DCXXBASICS_USE_FASTER_LINKERS=OFF` — link with the system default linker (BFD) instead of force-selecting LLD

Bumps version to **2.3.13** (CMake project version, PKGBUILD `pkgver`, CHANGELOG, debian changelog).

## Verification

- ✅ PKGBUILD passes `bash -n`
- ✅ Confirmed `if(CXXBASICS_USE_FASTER_LINKERS)` gates the entire LLD-selection block, so `=OFF` skips it
- ⚠️ Could not reproduce the GCC 16 + LLD + LTO link on the macOS dev box — the fix is reasoned from the build logs + toolchain behavior. **@DoYouKnowMyNamePlz to confirm after a v2.3.13 tag is cut.**

Underlying GCC 16 + LLD + LTO toolchain incompatibility remains tracked in GH#88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)