### PR TITLE
chore(claude): decommission Plane, Paperclip is system of record

### DIFF
--- a/.claude/commands/session-start.md
+++ b/.claude/commands/session-start.md
@@ -8,33 +8,18 @@ Initialize a new work session by gathering project status and presenting a summa
    - Run `git status` to see if there are staged/unstaged changes or untracked files from a previous session
    - If uncommitted work exists, summarize it and ask if it should be committed or stashed
 
-2. **Validate Plane project management:**
-   - Read `CLAUDE.md` and confirm the Plane project identifier is `NEX` (workspace `s4`)
-   - Call `mcp__plane__list_projects` and confirm project `NEX` exists
-   - If the project is not found, warn: *"CLAUDE.md references Plane project `NEX` but it wasn't found in the workspace."*
-   - Check whether `FEATURE_REQUESTS.md` or `BUGS.md` still exist in the project root; if either exists, note it and ask if the user wants to migrate the remaining items to Plane
+2. **Scan on-disk work items (`backlog/`):**
+   - List the `backlog/` directory for `*_research.md` / `*_plan.md` artifacts; each is named by its issue ID (e.g. `NEX-123_plan.md`, `GH64_plan.md`)
+   - Paperclip is the system of record and has no MCP — reference issues by their `NEX-<number>` ID and ask the user for an issue's scope when needed. Do **not** call any `mcp__plane__*` tools; the Plane instance is decommissioned
+   - Check whether `FEATURE_REQUESTS.md` or `BUGS.md` still exist in the project root; if either exists, note it
 
-3. **Read open work items from Plane:**
-   - Call `list_work_items` for the `NEX` project filtered to `state_groups=["unstarted","started","backlog"]`, ordered by `-priority`, limit 50
-
-3. **Sync GitHub issues to Plane:**
+3. **Check GitHub issues:**
    - Run: `gh issue list --repo s4solutionsllc/Nexis --state open --limit 100 --json number,title,body,labels`
-   - For each open issue, search Plane: `search_work_items(project_identifier="NEX", query="<issue title keywords>")`
-   - If no match is found, create a Plane work item:
-     ```
-     create_work_item(
-       project_id=<NEX project UUID>,
-       name="<issue title>",
-       description_html="<p>GitHub: <a href='...'>s4solutionsllc/Nexis#N</a></p><p><issue body></p>",
-       priority="medium",
-       state=<Todo state UUID>
-     )
-     ```
-   - Classify: bugs (labels contain "bug") get priority "medium" or "high"; features get "none" or "low"
-   - Report how many new work items were created, or "GitHub issues up to date"
+   - Classify: bugs (labels contain "bug") vs features
+   - Report open issues grouped by label
 
 4. **Check active work items:**
-   - Identify Plane items with state `In Progress`
+   - Identify `backlog/` items that have a `_plan.md` but no corresponding completed/archived artifact (work that looks in progress)
 
 5. **Check build state:**
    - Run `cmake --build build -j$(sysctl -n hw.ncpu) 2>&1 | tail -5` to verify the project builds cleanly
@@ -45,10 +30,10 @@ Initialize a new work session by gathering project status and presenting a summa
    ```
    ## Session Status
    - **Git:** [clean / N uncommitted changes]
-   - **Work items (source):** [Plane / MD files]
-   - **Open:** X items (list all with NEX-ID, priority, title)
+   - **Work items (source):** backlog/ MD files (Paperclip = system of record, no MCP)
+   - **Open:** X items (list all with NEX-ID, title)
    - **In Progress:** [list with NEX-ID and title, or "none"]
-   - **GitHub sync:** [N new items created / up to date]
+   - **GitHub issues:** [N open, grouped by label]
    - **Build:** [passing / failing]
    - **Tests:** [N/N passing]
    ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,9 +104,11 @@ After changing a QSS dynamic property on a parent, child widgets need explicit `
 
 ## Work Item Tracking
 
-**Plane is frozen (read-only as of 2026-05-24).** All work management has moved to **Paperclip** at `https://paperclip.s4solutions.ai`. The Plane `NEX` project is a historical archive only — do not create or update Plane work items.
+**Paperclip is the system of record** for all issues, features, and tracking. The issue-ID prefix is `NEX` — reference issues as `NEX-<number>` in commit messages and PRs.
 
-Use Paperclip for all new issues, features, and tracking. Reference issues as `GH#<number>` in commit messages.
+There is **no Paperclip MCP server** — it is human-driven. Reference issues by their `NEX-<number>` ID; when you need an issue's scope or details, ask the user rather than looking it up programmatically.
+
+**The old self-hosted Plane instance has been decommissioned.** Do **not** call any `mcp__plane__*` tools — the `plane` MCP server is gone and those calls will fail.
 
 ## GitHub Issues Sync (Run at Every Session Start)
 


### PR DESCRIPTION
Plane (self-hosted issue tracker + its `plane` MCP server) has been decommissioned. Paperclip is now the system of record (human-driven, no MCP).

## Changes
- **CLAUDE.md** — rewrote the Work Item Tracking section: Paperclip is the system of record, issue-ID prefix `NEX` preserved (`NEX-<number>` in commits/PRs), no Paperclip MCP (reference by ID, ask user for scope), old Plane instance decommissioned and `mcp__plane__*` must not be called.
- **.claude/commands/session-start.md** — replaced the Plane project-validation and `list_work_items`/`search_work_items`/`create_work_item` sync steps with on-disk `backlog/` scanning + GitHub-issue reporting; updated the status-summary lines.
- **.claude/settings.local.json** (gitignored, not in this PR) — removed the six `mcp__plane__*` permission allow-list entries locally; JSON validated.

Issue prefix `NEX` preserved throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)