### PR TITLE
docs(audit): full project audit + Ubuntu 26.04/macOS feature roadmap

### DIFF
--- a/docs/plans/2026-06-10-audit.md
+++ b/docs/plans/2026-06-10-audit.md
@@ -1,0 +1,219 @@
+# Nexis — Full Project Audit
+
+> **Date:** 2026-06-10
+> **Audited version:** v2.3.13 (`project(Nexis VERSION 2.3.13)`)
+> **Method:** 8 specialist reviewers (security, memory/concurrency, Qt/UI, architecture, build/packaging, CI/release, tests, docs/community) read the tree directly; every non-low finding was then put through an independent adversarial verifier that read the cited code and tried to refute it. Only confirmed findings are listed below. Build/CI artifacts, `.claude/`, and vendored copies were out of scope.
+> **Code modified:** none (read-only audit).
+
+---
+
+## TL;DR
+
+Nexis is in genuinely good shape for a one-maintainer fork. The post-Stacer platform split (abstract `Info`/`Tool` bases with `#ifdef` factories, a centralized `DataRefreshService`, a `SignalMapper` bus) is sound; Linux privilege escalation uses safe `pkexec` argv vectors throughout; theming/i18n discipline is largely intact; and the parser tests that exist are high quality. **No critical issues were found.**
+
+The risk is concentrated in a few places:
+
+- **Concurrency lifetimes.** A handful of detached `QtConcurrent` workers and a synchronous-finish `QProcess` path can use-after-free or null-deref and crash the app; one disk-health container is read/written across threads with no mutex.
+- **The throwing `CommandUtil::exec` contract.** It throws a raw `QString` on any error including a 30 s timeout, and at least one user-facing delete/trash path calls it with no `try/catch` on the UI thread — an escaping exception terminates the process.
+- **The destructive code is the least-tested code.** `CleanerService::clean()` / `cleanFiles()` (which ends in a root `rm -rf`) and the uninstaller have effectively zero coverage, and the only visual-regression suite is excluded from CI and has been red for ~4 months on stale baselines.
+- **Packaging premises that are wrong.** The Flatpak manifest cannot work as written (host tools aren't on the sandbox PATH; setuid `pkexec` is inert in the bubble), and the GH#82 linker bug is only worked around per-channel — the root cause is still on by default in-tree.
+- **Compliance edges.** Bundled OFL/UFL fonts ship without their license texts and are misdeclared as GPL-3.0 in `debian/copyright`; the repo states two different GPL versions; there's no `SECURITY.md` despite a 7-day CVE SLA.
+
+### Findings by severity
+
+| Severity | Count | Theme |
+|----------|-------|-------|
+| Critical | 0 | — |
+| High | 11 | Crash-class concurrency/exception bugs, broken Flatpak premise, untested destructive paths, unpinned CI credentials, font licensing |
+| Medium | 29 | Latent injection, theming gaps, architecture debt, release-pipeline gaps, doc drift |
+| Low (confirmed) | 2 | Hardening flags, parked screenshot suite |
+
+A larger tail of low-severity items surfaced (see each section's *Unverified low* notes); they were not run through verification and are listed for completeness, not as committed work.
+
+---
+
+## High-severity findings
+
+### H1 — Use-after-free: Maintenance Wizard workers capture `this` on a `WA_DeleteOnClose` dialog
+**File:** [maintenance_wizard_dialog.cpp:142](shared/nexis/Pages/Dashboard/maintenance_wizard_dialog.cpp) · **Dimension:** memory-safety
+
+`runChecks()` launches four detached `QtConcurrent::run` lambdas (plus a fifth in `onCleanSafeItems()`) that capture raw `this` and finish with `QMetaObject::invokeMethod(this, ...)`. The dialog is created with `setAttribute(Qt::WA_DeleteOnClose)` and `exec()` in `DashboardPage::launchMaintenanceWizard` ([dashboard_page.cpp:1928](shared/nexis/Pages/Dashboard/dashboard_page.cpp)). The checks run filesystem scans and `apt`/`brew` queries that routinely take 10–60 s. If the user closes the dialog (or presses Esc) before the workers finish, the dialog is deleted while workers still hold `this`; the subsequent `invokeMethod` on a dangling pointer is undefined behavior. No `QFuture` is stored, there is no destructor wait, and there is no `QPointer` guard (the header declares no destructor).
+
+**Fix:** Store the `QFuture`s and wait in a destructor, or use a `QFutureWatcher` parented to the dialog and connect with the dialog as context object so delivery is dropped on destruction; or guard the callback with a captured `QPointer<MaintenanceWizardDialog>`.
+
+### H2 — Null-pointer call in `LogProvider::cancel()` when `finished()` fires inside `waitForFinished()`
+**File:** [log_provider.cpp:37](shared/nexis/Pages/SystemLogs/log_provider.cpp) · **Dimension:** memory-safety
+
+`cancel()` does `mProcess->kill(); mProcess->waitForFinished(3000); mProcess->deleteLater();`. `waitForFinished()` emits `finished()` synchronously on the same thread, so `onProcessFinished()` runs *inside* the wait; `kill()` produces `CrashExit`, the slot takes the error path, calls `deleteLater()` itself and sets `mProcess = nullptr`. Control returns to `cancel()`, which then calls `mProcess->deleteLater()` on the now-null member — a member call through a null pointer. `SystemLogsPage::~SystemLogsPage()` unconditionally calls `cancel()`, and the macOS `log show --last 1h` fetch runs for seconds, so quitting shortly after opening System Logs crashes at exit.
+
+**Fix:** Disconnect the finished signal before `kill()` (`mProcess->disconnect(this)`), or copy the pointer locally and null the member first; re-check for null after `waitForFinished()`.
+
+### H3 — Data race on `DiskHealthInfo::mDrives` (worker writes, UI thread reads and writes, no mutex)
+**File:** [data_refresh_service.cpp:367](shared/nexis/Managers/data_refresh_service.cpp) · **Dimension:** memory-safety
+
+`onSlowTick()` runs `discoverDiskHealth()` / `refreshDiskHealth()` on a `QtConcurrent` worker every 30 s. `DiskHealthInfoLinux::discoverDrives()` does `mDrives.clear()` then appends drives one at a time, running `smartctl` per drive in between — so the container is in a mutating state for *seconds*. Meanwhile the UI thread copies the same list via `getDrives()` (from `HardwareInfoPage` and `ResourcesPage::init`) and even writes `mDrives[i]` in `refreshHealthElevated`. There is no `QMutex` anywhere in `DiskHealthInfo`, even though sibling streamers (`nvidia_smi_streamer`, `nettop_streamer`) do mutex their cross-thread state — confirming this is an oversight, not a guarded design. Copying/indexing a `QList` while another thread clears/reallocates it is UB.
+
+**Fix:** Add a `QMutex` guarding `mDrives` across all accessors, or have the worker build into a local `QList` and publish it on the UI thread via the existing `invokeMethod` hop (the pattern already used correctly for `DiskInfo::setDisks`).
+
+### H4 / H5 — Uncaught `QString` exception from `CommandUtil::exec` on the UI-thread delete/trash path
+**Files:** [file_search_service.cpp:69](shared/nexis/Services/file_search_service.cpp), [command_util_shared.cpp:61](shared/nexis-core/Utils/command_util_shared.cpp) · **Dimensions:** memory-safety + architecture (same root cause)
+
+`CommandUtil::exec` throws a raw `QString` on any `QProcess` error, including a 30 s default timeout (the child is `kill()`ed first). `FileSearchService::moveToTrash`/`deleteFile` call `exec("mv"/"rm", ...)` with **no `try/catch`**, and `SearchPage`'s context-menu actions invoke them directly on the UI thread. Deleting/moving a large tree easily exceeds 30 s: the child is killed mid-operation (partial delete) and the `QString` propagates out of the slot through the Qt event loop, terminating the app. The UI is also frozen for the full duration. The same file's `search()` already wraps the identical call in `try/catch` + `QtConcurrent`, so the destructive paths are the unprotected outliers.
+
+**Fix (tactical):** Wrap the two `FileSearchService` calls in `try/catch`, surface failure to the user, and move them off the UI thread like `search()` already does; raise/remove the 30 s timeout for bulk file ops. **Fix (strategic):** see [A1](#a1--three-coexisting-error-handling-models-in-the-exec-layer) — standardize on the non-throwing `execWithStatus`/`execAsync` and retire the throwing variant.
+
+### H6 — Headless `--clean` mode requires a GUI display; cron-scheduled cleans silently fail
+**File:** [main.cpp:179](shared/nexis/main.cpp) · **Dimension:** architecture
+
+The scheduled-clean entry point (`--clean`, `--check-threshold`) runs *after* `QApplication app(argc, argv)`. `QApplication` aborts if no QPA platform loads. The generated cron line and the systemd user unit set no `DISPLAY`/`WAYLAND_DISPLAY` and no `QT_QPA_PLATFORM=offscreen` (those strings appear nowhere in the tree). Under cron the environment is guaranteed display-less, and `Persistent=true` timers fire catch-up runs at boot before graphical login — in both cases the binary dies in `QApplication` construction and the scheduled clean never runs, with no error surfaced.
+
+**Fix:** For headless argv, `qputenv("QT_QPA_PLATFORM", "offscreen")` before constructing `QApplication` (or use `QCoreApplication`). Longer term, extract `CleanerService` into `nexis-core` so a true CLI/daemon target exists.
+
+### H7 — Flatpak manifest's core premise is wrong: host tools can't run in the sandbox
+**File:** [io.github.s4solutionsllc.Nexis.yml:55](linux/flatpak/io.github.s4solutionsllc.Nexis.yml) · **Dimension:** build-packaging
+
+The manifest and `docs/flatpak-reviewer-justification.md` claim `--filesystem=host` puts the host's `/usr/bin` on the sandbox PATH. It does not — the host root mounts at `/run/host`, and the sandbox `/usr` is the `org.kde.Platform` runtime, which contains none of `systemctl`, `apt`, `pkexec`, `smartctl`, `fstrim`, `ethtool`, or `nvidia-smi`. Even if found, `pkexec` is setuid-root and setuid is ignored inside bubblewrap, so *every* privileged operation fails unconditionally. The sandbox also has its own PID namespace, so the Processes page would list only the app's own processes. There is zero `flatpak-spawn`/sandbox-detection code anywhere. Submitted to Flathub as-is, the app would silently break most of its headline features while requesting `--filesystem=host` + `--device=all` (the most invasive permission set possible), which a reviewer will reject on sight.
+
+**Fix:** Before any Flathub submission, run the README's own privileged-operation checklist against a real flatpak build. Either add `--talk-name=org.freedesktop.Flatpak` and route `CommandUtil` through `flatpak-spawn --host` when sandboxed (detect via `/.flatpak-info`), or drop the Flatpak channel and document it as unsupported. Rewrite the reviewer-justification doc.
+
+### H8 — Third-party CI actions pinned by mutable tag while holding publishing credentials
+**File:** [aur.yml:47-55](.github/workflows/aur.yml) · **Dimension:** ci-release
+
+Every action across all 8 workflows is pinned by *tag*, not commit SHA. The dangerous cases hold long-lived publishing secrets: `KSXGitHub/github-actions-deploy-aur@v4.1.3` receives `secrets.AUR_SSH_KEY` — a re-pointed tag could exfiltrate the AUR maintainer key and push a malicious `PKGBUILD` that runs build code on every Arch user's machine. Similarly `crowdin/github-action@v2` (Crowdin token + `contents:write`/`pull-requests:write`), `softprops/action-gh-release@v3` (`contents:write`, controls release assets), `EndBug/add-and-commit@v9`, and `withastro/action@v3`. Git tags are mutable; only SHA pins are immutable. This is exactly the `tj-actions/changed-files` supply-chain incident vector.
+
+**Fix:** Pin all third-party actions (ideally `actions/*` too) to full commit SHAs with a version comment, and add a Dependabot `github-actions` config to keep pins fresh.
+
+### H9 — `CleanerService` destructive deletion paths have zero test coverage
+**File:** [cleaner_service.cpp:297-436](shared/nexis/Managers/cleaner_service.cpp) · **Dimension:** tests
+
+The riskiest code in the product — `clean()`, `cleanFiles()` (which ends in a single batched root `sudo rm -rf`), and `cleanTrash()` — is completely untested; `tests/CMakeLists.txt` itself documents that tests only cover `isExcluded()` and exclusion CRUD. Worse, the well-tested exclusion guarantee is **not verified on the actual deletion path**: `scan()` filters only top-level entries through `isExcluded()`, but `cleanFiles()` then recursively deletes directory contents *without re-checking exclusions*, so an excluded child inside a scanned directory can still be deleted. The unit tests on `isExcluded()` give false confidence; no test exercises `clean()` end-to-end. `minFileAgeSecs`, the move-to-trash branch, and `cleanTrash()` are likewise untested.
+
+**Fix:** Add an integration test running `clean()`/`cleanFiles()` against a `QTemporaryDir` tree, asserting excluded files *and excluded children of scanned directories* survive, the age cutoff is honored, symlinks are removed-not-followed, and bytes-freed accounting matches. Inject an overridable `removeElevated()` seam (mirroring `TestableRepairEngine`'s pkexec bypass) so the `sudo rm -rf` branch is testable without root.
+
+### H10 — ScreenshotTests excluded from all CI and red for months; dashboard mismatch is stale baselines
+**File:** [build.yml:78-80](.github/workflows/build.yml) · **Dimension:** tests
+
+Every CI run uses `ctest ... -E ScreenshotTests`, so the only visual-regression suite runs nowhere automated — yet `docs/ARCHITECTURE_REVIEW.md:475` still claims "CI runs screenshot tests as non-blocking." The dashboard dark+light ~17–19 % failure is **stale baselines, not environment**: references were last regenerated 2026-04-24, and six dashboard-visual commits landed afterward (MetricTile background/chart-bg changes on 2026-05-04, health-tile anchoring `5c62651` on 2026-06-03), easily explaining the diff against the effective ~6 % threshold. It is not a missing-`Inter`-font issue — refs are generated by the same binary, so font rendering is self-consistent. A permanently-red test normalized for ~4 months is the worst state for a regression suite.
+
+> **Caveat from verification:** the exclusion was *deliberate* (commit `5c173c7` — the suite hangs on ARM64 Linux runners) and the step was `continue-on-error` even when present, so it never actually gated. The fix is to regenerate baselines and re-enable as a non-blocking step with failure artifacts uploaded, plus a release-runbook check.
+
+**Fix:** Regenerate baselines now (`scripts/update_screenshots.sh`, review the diff, commit), re-enable in CI as a separate `continue-on-error` step uploading `test_screenshots/failures/`, and add a rule that any PR changing page visuals regenerates affected refs in the same PR.
+
+### H11 — Bundled third-party fonts ship without license texts; `debian/copyright` misdeclares them as GPL-3.0
+**File:** [static.qrc:25](shared/nexis/static.qrc) · **Dimension:** docs-community
+
+Five third-party fonts (Inter Regular/Bold/SemiBold, JetBrains Mono — SIL OFL 1.1; Ubuntu-R — Ubuntu Font Licence 1.0) are embedded in every binary and loaded in `main.cpp`, but **no copy of the OFL or UFL text exists anywhere in the repo** (only the root GPL `LICENSE`). OFL 1.1 §2 and the UFL both require the license + copyright notice to accompany distributed copies. Compounding this, `linux/debian/copyright` declares `Files: * ... License: GPL-3.0`, affirmatively misstating the fonts' licensing in every `.deb`/PPA upload — and the UFL is a known reject-trigger in Debian ftp-master review.
+
+**Fix:** Add `LICENSE-OFL.txt` (Inter, JetBrains Mono) and `LICENSE-UFL.txt` (Ubuntu) under the font dir, reference them in a `THIRD_PARTY_LICENSES.md`, install them with packages, and add per-pattern `Files:` stanzas for the fonts in `debian/copyright`.
+
+---
+
+## Medium-severity findings
+
+### Security & privilege handling
+
+**S1 — AppleScript injection in macOS app trashing.** [package_tool.cpp:209-223](macos/nexis-core/Tools/package_tool.cpp) — `PackageToolMacOS::trashApps()` interpolates an app-bundle path into `tell application "Finder" to delete POSIX file "%1"` via `.arg(path)` with no escaping, then runs it through `osascript`. A bundle whose name contains a double quote (legal in macOS filenames; a downloaded archive can ship any name) breaks out of the string literal and injects arbitrary AppleScript — which can `do shell script` — the moment the user clicks Uninstall. The codebase's argv-based `QProcess::start` blocks *shell* injection but not AppleScript injection. **Fix:** use `QFile::moveToTrash(path)` (already used in `cleaner_service.cpp`), or bind the path through `osascript` argv (`on run argv`), never string concatenation.
+
+> Three further latent shell-construction issues (the `apt --dry-run` `bash -c` package-name interpolation, the `smartctl`/`setcap` device-path `sh -c` batch, and the cleaner escalating to root to delete *user-owned* files with a scan→clean TOCTOU and no `--` guard) were confirmed as **low** today because their inputs are kernel/Debian-policy constrained — but each is gratuitously inconsistent with the safe argv pattern used elsewhere and should be normalized. See the security section notes.
+
+### Memory, concurrency & responsiveness
+
+**M1 — Unchecked `.at(0)`/`.at(j+1)` on CPU lists that can be empty.** [dashboard_page.cpp:560](shared/nexis/Pages/Dashboard/dashboard_page.cpp) — `CpuInfoMacOS::getCpuPercents` returns an empty list on `host_processor_info` failure (Linux likewise on unreadable `/proc/stat`); `DataRefreshService::onFastTick` emits without an `isEmpty()` check; `DashboardPage`/`ResourcesPage` then index `.at(0)`/`.at(j+1)` — UB in release builds on a transient mach/proc failure. (`loadAvgs.at(j)` is safe — always 3 elements.) **Fix:** guard in `DataRefreshService` and/or bounds-check the consumers.
+
+**M2 — Synchronous fork/exec on the UI thread.** [process_info.cpp:26](macos/nexis-core/Info/process_info.cpp) — `onProcessTick` runs `updateProcesses()` on the UI thread; on macOS that is a blocking `ps` + `waitForFinished(30000)` once per second while the Processes page is open. Separately, `onUnlockSmartDrive` runs `pkexec smartctl` on the UI thread, and its 30 s timeout *races the user typing their polkit password* — taking too long kills `pkexec` and the unlock silently fails. The codebase already has a `NEXIS_ASSERT_ASYNC_EXEC` audit hook acknowledging this class. **Fix:** move both onto `QtConcurrent` workers; give the pkexec unlock a much larger/infinite timeout.
+
+**M3 — macOS `LogProvider` buffers the entire `log show --last 1h` in memory.** [log_provider.cpp:179](shared/nexis/Pages/SystemLogs/log_provider.cpp) — no line/level cap, nothing drained until `finished()`; on a busy Mac an hour of ndjson is hundreds of MB to >1 GB, copied twice and parsed on the main thread. Opening the page can spike memory and stall the UI. **Fix:** stream-parse from `readyReadStandardOutput` and stop once `maxEntries` is reached; shrink the window and add level filtering.
+
+**M4 — Wizard/repo-health workers read `InfoManager` providers while the UI thread mutates them.** [maintenance_wizard_dialog.cpp:173](shared/nexis/Pages/Dashboard/maintenance_wizard_dialog.cpp) — the health-score worker reads `getDisks()`/`getThermalTemperature(0)` on a worker thread while the medium tick reassigns `DiskInfo::disks` and reads SMC temps on the UI thread; `DiskInfo` has no synchronization, and the SMC bridge has an unguarded static `io_connect_t` check-then-open race. **Fix:** snapshot the data on the UI thread before dispatching the worker, or add a mutex to `DiskInfo` and serialize SMC access (`std::call_once` for open).
+
+### Qt patterns, UI & theming
+
+**Q1 — `@networkDownloadColor` token read in code but defined in no theme.** [network_usage_page.cpp:492](shared/nexis/Pages/Network/network_usage_page.cpp) — the RX bar reads a token absent from both `values.ini` files, so it always falls back to the legacy Stacer blue `#5294e2` and ignores theme switching, while the TX series uses the proper `@networkUploadColor`. `test_theme_tokens.cpp` can't catch this — it only validates tokens in `style.qss`, not those read from C++ via `getStyleValues()`. **Fix:** add `@networkDownloadColor` to both themes; extend the token test to grep C++ `value("@…")` literals against both themes.
+
+**Q2 — Raw `@borderColor` token embedded in a widget `setStyleSheet`.** [network_usage_page.cpp:472](shared/nexis/Pages/Network/network_usage_page.cpp) — the data-cap progress bar's stylesheet contains the literal `background: @borderColor;`. Token substitution only runs on the *global* stylesheet, not per-widget strings, so Qt's QSS parser drops the invalid declaration and the groove renders unthemed. **Fix:** resolve the token via `sv->value()` first, as the surrounding code already does.
+
+**Q3 — Start page persisted as a translated display string.** [settings_page.cpp:136-141](shared/nexis/Pages/Settings/settings_page.cpp) — the start-page setting stores the localized combo text (`tr("Processus")`), and launch matches it against (also localized) sidebar titles, falling back to Dashboard on mismatch. A user who picks a start page in one language and switches languages is silently reset and the combo no longer reflects their choice. The page title even differs by platform (`Applications` on macOS vs `Uninstaller` on Linux). **Fix:** persist a stable untranslated page id via `QComboBox` item data (the same pattern used two lines down for the color scheme), with a one-time migration for legacy values.
+
+**Q4 — macOS screenshot baselines stale.** [tests/reference_screenshots/macos](tests/reference_screenshots) — same root cause as [H10](#h10--screenshottests-excluded-from-all-ci-and-red-for-months-dashboard-mismatch-is-stale-baselines); the diff regions correspond exactly to the intentional MetricTile/health-tile redesigns. Regenerate, don't chase a phantom regression.
+
+### Architecture & legacy debt
+
+<a name="a1"></a>**A1 — Three coexisting error-handling models in the exec layer.** [command_util.h:18](shared/nexis-core/Utils/command_util.h) — `exec()` throws `QString`; `execWithStatus()`/`execAsync()` return `ExecResult`; `sudoExec()` swallows all errors and returns `""`. `ARCHITECTURE_REVIEW.md` itself documents the resulting workaround ("because `sudoExec` swallows errors, every write is followed by a sysfs re-read"). This is the root cause of [H4/H5](#h4--h5--uncaught-qstring-exception-from-commandutilexec-on-the-ui-thread-deletetrash-path) and a per-call-site footgun. **Fix:** standardize on `ExecResult`/`execAsync`, convert `sudoExec` to return `ExecResult`, and burn down the throwing `exec()`'s 67 call sites incrementally.
+
+**A2 — Every-N-days schedules run daily on systemd.** [schedule_manager.cpp:466](shared/nexis/Managers/schedule_manager.cpp) — `createSystemdTimer` maps `EveryNDays` to a *daily* `OnCalendar` with a comment promising "a condition check inside the service" that was never implemented; `CleanerService::cleanSchedule` never compares `lastRun` against `everyNDays`. On any systemd distro (the default scheduler) a "every 7 days" config deletes the selected categories *every day*. The cron and launchd paths honor the interval correctly. **Fix:** add the `EveryNDays` gate in `cleanSchedule()` and a `ScheduleManager` test for it.
+
+**A3 — Shared pages instantiate platform `Info` subclasses directly.** [hardware_info_page.cpp:158](shared/nexis/Pages/HardwareInfo/hardware_info_page.cpp) — `HardwareInfoPage`, `DashboardPage`, and `BootAnalysisPage` stack-construct `…MacOS`/`…Linux` classes behind `#ifdef`s instead of going through the `InfoManager` facade (`BootAnalysisInfo`/`StartupInfo` aren't wired through it at all). 47 files under `shared/` carry `Q_OS_*` conditionals. Each is a site to find and edit to add a third platform. **Fix:** route reads through `InfoManager`; forbid `shared/nexis/Pages` from including `*_macos.h`/`*_linux.h` (enforceable with a CI grep).
+
+**A4 — macOS Homebrew page shoehorned into the APT-source abstraction.** [apt_source_tool.cpp:11](macos/nexis-core/Tools/apt_source_tool.cpp) — `AptSourceToolMacOS` pretends Homebrew packages are APT repos (`.uri` = package name, `.suites` = "formula"/"cask"), and the shared page branches around the mismatch with 32 preprocessor directives. This is the largest piece of unreconstructed Stacer architecture. **Fix:** split into a platform-neutral `RepositoryTool` interface (the `RepoHealthChecker` split is the in-repo template), or make Homebrew its own page backed by `PackageTool`.
+
+**A5 — Dead but dangerous `GnomeSettingsToolMacOS`.** [gnome_settings_constants.h:8](macos/nexis-core/Tools/gnome_settings_constants.h) — the GNOME Settings page is hidden on macOS, yet `ToolManager` still constructs the macOS adapter, whose mapping table collapses 9 distinct GNOME keys onto `AppleInterfaceStyle` and several onto dock `orientation`. If anyone removed the `#ifdef`, setting an "icon theme" would write arbitrary strings into `NSGlobalDomain`, corrupting real macOS prefs. **Fix:** make `mGnomeSettings` Linux-only (or a null stub whose `isAvailable()` returns false) and drop the macOS branch.
+
+**A6 — Living architecture docs have drifted materially.** [ARCHITECTURE_REVIEW.md:92](docs/ARCHITECTURE_REVIEW.md) — claims "~6,000–7,000 lines of C++" (actual shared+linux+macos ≈ 48,700); lists a removed `sigDashboardLayoutReset` signal and says "9 signals" (now 10); `APPLICATION_OVERVIEW.md` cites settings paths (`~/Library/Preferences/com.nexis.plist`, `~/.config/nexis/nexis.conf`) that don't match the actual `AppConfigLocation/settings.ini`; the `DataRefreshService` timer/signal counts are wrong (5 timers/15 signals vs "4/10"). CLAUDE.md mandates these docs stay in sync. **Fix:** one reconciliation pass regenerating the by-the-numbers sections; add a CI check on the version/date headers.
+
+### Build, packaging & release
+
+**B1 — GH#82 root cause still in-tree.** [UseFasterLinkers.cmake:15](shared/cmake/cxxbasics/accelerators/UseFasterLinkers.cmake) — the v2.3.13 fix (`PKGBUILD options=('!lto')` + `-DCXXBASICS_USE_FASTER_LINKERS=OFF`) is a per-channel workaround. The module still defaults **ON** and appends `-fuse-ld=lld` whenever lld is present; any environment with lld installed *and* `-flto` in CXXFLAGS (Fedora/openSUSE defaults, CachyOS, any downstream not using this exact PKGBUILD) reproduces the "undefined symbol: main" failure. The CHANGELOG concedes "the LLD half was self-inflicted." A dev-speed accelerator should never be on for release/packaged builds. **Fix:** default `CXXBASICS_USE_FASTER_LINKERS` to OFF (or gate on Debug/opt-in), or skip lld when `-flto` is present; then drop the per-channel workarounds.
+
+**B2 — Homebrew cask updater checksums whatever curl returns.** [homebrew.yml:31](.github/workflows/homebrew.yml) — `curl -sL` (no `--fail`) pipes the response straight into `sha256sum`; if the hard-coded asset name drifts or the download 404s, the GitHub error page's checksum is committed to the tap and `brew install nexis` fails for everyone, with the workflow staying green. (Also tracked under ci-release.) **Fix:** `curl -fsSL --retry 3` and a sanity check (`file … | grep zlib`, or minimum size) before hashing.
+
+**B3 — macOS bundle version comes from `PROJECT_VERSION`, not the tag override.** [CMakeLists.txt:631](CMakeLists.txt) — `release.yml` passes `-DAPP_VERSION_OVERRIDE=<tag>` and RELEASE.md calls tags "the single source of truth," but the `.app` Info.plist fields use `${PROJECT_VERSION}` (hardcoded in `project(Nexis VERSION …)`), which the override doesn't touch — and the RELEASE.md commit step omits `CMakeLists.txt`. Following the runbook verbatim ships a DMG whose `CFBundleShortVersionString` lags the release; versions match today only via undocumented manual bumps. The bundle id `com.nexis.app` is also a domain the project doesn't own and inconsistent with `io.github.s4solutionsllc.Nexis` used elsewhere. **Fix:** use `${APP_VERSION}` for the bundle version properties; add `CMakeLists.txt` to the RELEASE.md §1 `git add`; decide the bundle id before more signed releases accumulate.
+
+### CI/CD & release engineering
+
+**C1 — lupdate normalization workflow can never fire.** [lupdate.yml:3-6](.github/workflows/lupdate.yml) — it triggers only on push to `l10n_crowdin_translations`, but the only writer is `crowdin/github-action` authenticating with the default `GITHUB_TOKEN`, and GitHub deliberately suppresses workflow triggers for token-created pushes. The normalization loop silently never runs; translation PRs land un-normalized. **Fix:** run lupdate as a step inside `crowdin-sync.yml`, or push with a PAT/App token; add an explicit `permissions:` block.
+
+**C2 — Every tag treated as the newest release.** [release.yml:540-544](.github/workflows/release.yml) — `make_latest: true` is unconditional and the Homebrew/AUR bumps fire on any `v*` tag with no version comparison. RELEASE.md §6 plans security backports on older lines (e.g. `v2.3.x` after `v2.4.0`) — which would mark the old line "Latest" and downgrade every Homebrew/AUR user. The "delete pre-existing release" step compounds this on re-runs. **Fix:** compute `make_latest` by comparing to the current latest (or use `legacy`); gate the package bumps on the tag being ≥ the published version.
+
+**C3 — 7-day CVE SLA with zero automated vulnerability detection.** [MAINTAINER_SOP.md:80-83](docs/MAINTAINER_SOP.md) — no `dependabot.yml`, no CodeQL, no dependency/SAST scanning anywhere; the SLA clock can only start if the maintainer happens to be reading Qt security lists. `linuxdeploy` is also pulled from mutable `continuous` tags at release time. **Fix:** add `dependabot.yml` (github-actions at minimum), a CodeQL C/C++ workflow, subscribe a monitored channel to Qt advisories, and pin `linuxdeploy` with checksum verification.
+
+### Tests
+
+**T1 — Release workflow publishes without running any tests.** [release.yml](.github/workflows/release.yml) — no `ctest` step in any of its four jobs; tests run only on push/PR via `build.yml`. A directly-tagged hotfix (the CVE-SLA path) ships to all package channels untested. *(Verification note: the Linux `.deb` jobs do run `ctest` via `debian/rules override_dh_auto_test`, so this is narrower than "no tests at all" — but the AppImage, raw-binary, and macOS jobs run none.)* **Fix:** add a `ctest` step mirroring `build.yml` to each release job, or gate the release on a green Build run for the tagged commit.
+
+**T2 — Screenshot comparison is simultaneously brittle and insensitive.** [test_screenshots.cpp:96-109](tests/screenshots/test_screenshots.cpp) — exact pixel equality with no per-channel fuzz means any AA/font drift flips many pixels at once (hence the 10 % tolerances on live-data pages, which then let a real regression touching ~10 % of a page pass silently); missing page classes or reference PNGs are a `qWarning` + `continue`, not a failure, and the Linux reference dirs contain only `.gitkeep` so the suite vacuously passes there. **Fix:** `QFAIL` on missing page/reference; mask known-dynamic rectangles + small per-channel fuzz so the threshold can drop to ~1 %; generate Linux baselines or delete the empty dirs.
+
+**T3 — macOS parsers and the uninstaller/privileged paths are untested.** [nettop_streamer.cpp:91](macos/nexis-core/Info/nettop_streamer.cpp) — all fixtures are Linux-shaped; the macOS `nettop` CSV split, `parsePlist()`, ioreg/pmset battery, and boot-analysis parsers have zero fixture tests despite macOS being a release platform. `PackageService::uninstall*`/`removeOrphanPackages` and both `sudoExec` implementations are exercised only by one test that `QSKIP`s without `pkexec`. **Fix:** capture real `nettop`/`ioreg`/`pmset`/`diskutil` output as macOS fixtures (the FR-127 compile-source-into-test pattern already exists); test the uninstall command-construction layer via a seam.
+
+### Docs, licensing & project health
+
+**D1 — Inconsistent GPL version.** [LICENSE:5](LICENSE) — `GPL-3.0-or-later` is claimed in metainfo.xml, PKGBUILD, and the SOP, but the `LICENSE` preamble uses GPL-3.0-**only** wording ("version 3 of the License" with the "or any later version" clause deliberately absent) and `debian/copyright` says `GPL-3.0`. As a fork, the outbound license can't exceed upstream Stacer's grant. **Fix:** verify upstream's grant, pick one SPDX id, and align `LICENSE`, `debian/copyright`, PKGBUILD, metainfo.xml, and the SOP.
+
+**D2 — No `SECURITY.md` despite a 7-day CVE SLA.** [RELEASE.md:255](RELEASE.md) — RELEASE.md §6 names a private channel and its day-6–7 step says to "update `SECURITY.md`," but no such file exists; GitHub shows no Security Policy and reporters default to public issues. **Fix:** create `SECURITY.md` (supported versions, `security@s4solutions.ai`, GHSA private reporting, the 7-day SLA) and enable private vulnerability reporting on the repo.
+
+**D3 — Living docs carry stale "Last updated" headers.** [APPLICATION_OVERVIEW.md:4](docs/APPLICATION_OVERVIEW.md) — reads "2026-04-23 | Version 2.3.1" though last modified 2026-06-04 at v2.3.13 (12 patch releases of drift); `ARCHITECTURE_REVIEW.md` similarly stale — a direct violation of CLAUDE.md's own pre-commit checklist. **Fix:** refresh both, sync content, and add a CI check on the header vs `PROJECT_VERSION`.
+
+**D4 — `FUNDING.yml` enables GitHub Sponsors, against the SOP's "no monetization, ever."** [FUNDING.yml:3](.github/FUNDING.yml) — `MAINTAINER_SOP.md` §2 forbids monetization "Ever" and §5 reserves sponsorship to the CEO with a recorded rationale; the Sponsors button exists with no such rationale (and git history shows it was deliberately updated twice). The two artifacts contradict each other in public. **Fix:** delete `FUNDING.yml`, or record a CEO-approved exception in the SOP clarifying that repo-level donation links are permitted while in-app monetization stays prohibited.
+
+---
+
+## Confirmed low-severity findings
+
+- **L1 — No hardening flags in the build system.** [CMakeLists.txt:17](CMakeLists.txt) — only the `.deb` channel gets `hardening=+all`; AppImage, raw binary, and macOS inherit toolchain defaults. The Ubuntu-24.04 GCC defaults already provide PIE/stack-protector/FORTIFY, so the real gap is BIND_NOW/full RELRO and explicitness. **Fix:** add a Release-config hardening block (`-fstack-protector-strong`, `-D_FORTIFY_SOURCE=2/3`, `-Wl,-z,relro,-z,now`, PIE) for Linux GCC/Clang.
+- **L2 — ScreenshotTests gates nothing in CI** — the parked-suite half of [H10](#h10--screenshottests-excluded-from-all-ci-and-red-for-months-dashboard-mismatch-is-stale-baselines); document the exclusion with a tracking ID, or re-enable with a non-comparing smoke mode.
+
+---
+
+## What was checked and found healthy (refuted findings)
+
+The adversarial pass killed several plausible-but-wrong findings — worth recording so they aren't re-raised:
+
+- **macOS `sudoExec` escaper is correct.** The two-layer escaping (POSIX single-quote `'\''` idiom, then AppleScript-literal escaping) round-trips all metacharacters; `osascript … with administrator privileges` is the standard, intentional macOS GUI-elevation mechanism with no non-deprecated argv equivalent. (The separate *AppleScript* injection in `trashApps`, S1, is real — different code path.)
+- **`QProcess` `delete`-in-`finished()`-slot in the nvidia-smi streamers is safe on Qt 6** — signal activation holds a refcounted `ConnectionData` that survives sender deletion.
+- **Release `.deb` jobs do run tests** via `debian/rules override_dh_auto_test` (so [T1](#t1--release-workflow-publishes-without-running-any-tests) is narrower than first claimed).
+- **Notarization tilde-key path works** — `xcrun notarytool` expands `~` in `--key` itself.
+
+Linux privilege escalation (package removal, service control, kill, gsettings, snapshot, fstrim) was specifically audited and uses safe `pkexec` argv vectors throughout; no hardcoded secrets or insecure config permissions were found; theming discipline (no old-style SIGNAL/SLOT, consistent `refreshThemeColors` wiring, correct DPI handling) is largely intact; and the i18n sweep (#87) left no untranslated user-visible strings.
+
+---
+
+## Suggested remediation order
+
+1. **Crash-class bugs first** (H1, H2, H3, H4/H5) — small, localized, and each can take down the app.
+2. **The exec-layer contract** (A1) — fixing it retires the H4/H5 footgun permanently and removes the verify-after-write boilerplate.
+3. **Scheduled-clean correctness** (H6, A2) — silent data deletion on the wrong cadence and silent no-runs are user-trust issues.
+4. **Test the destructive paths** (H9) before touching cleaner logic for anything else.
+5. **Supply-chain & compliance** (H8, H11, D1, D2, C3) — cheap, high-leverage, and gate-keeping for distro submission.
+6. **Packaging truth** (H7, B1, B2, B3) — decide Flatpak's fate; fix the linker default; harden the release pipeline.
+7. **Visual-regression hygiene** (H10, T2) and **doc reconciliation** (A6, D3) — ongoing maintenance cost otherwise.
+
+Feature recommendations (including Ubuntu 26.04- and macOS 26/27-driven opportunities) are in the companion document: [2026-06-10-feature-recommendations.md](2026-06-10-feature-recommendations.md).

--- a/docs/plans/2026-06-10-feature-recommendations.md
+++ b/docs/plans/2026-06-10-feature-recommendations.md
@@ -1,0 +1,156 @@
+# Nexis — Feature Recommendations
+
+> **Date:** 2026-06-10
+> **Inputs:** Ubuntu 26.04 LTS "Resolute Raccoon" (released 2026-04-23: GNOME 50, kernel 7.0, systemd 259, APT 3.1), macOS 26 "Tahoe" (shipping) and macOS 27 "Golden Gate" (announced WWDC 2026-06-08), plus [docs/COMPETITIVE_LANDSCAPE.md](docs/COMPETITIVE_LANDSCAPE.md).
+> **Goal:** position Nexis as the preeminent cross-platform system optimizer. Recommendations are grouped **Both platforms / Linux / macOS**, each tagged **Defensive** (a platform change Nexis must react to or it breaks/regresses) or **Offensive** (a new capability that widens the moat).
+> Companion: the audit findings are in [2026-06-10-audit.md](2026-06-10-audit.md). **Note:** several audit fixes (H6 headless `--clean`, H7 Flatpak, A2 every-N-days) are prerequisites for features below — flagged inline.
+
+---
+
+## How to read this
+
+Each item lists **why now** (the platform fact that motivates it), **what to build**, and a rough **effort** (S/M/L). Sources for every platform claim are in the research appendix at the end. Priority tiers at the very bottom.
+
+The single most important strategic fact: **Ubuntu 26.04's default install now ships "Resources"** (replacing GNOME System Monitor *and* Power Statistics) **with GPU/NPU monitoring built in**, and **dropped the "Software & Updates" GUI entirely**. The in-box monitor got better — so Nexis's monitoring must go deeper than table-stakes — but Ubuntu simultaneously *removed* the GUI for managing APT repositories, PPAs, and mirrors. That repo-management vacuum on a stock 26.04 desktop is the clearest greenfield opportunity Nexis has.
+
+---
+
+## Both platforms
+
+### BP1 — Duplicate & large-file finder *(Offensive, M)*
+**Why now:** the single most-cited gap vs competitors — Czkawka (Linux/macOS/Windows) and CleanMyMac X both have it; Nexis has none. It's also platform-neutral (pure filesystem + hashing), so one implementation serves both OSes.
+**What:** a new cleaner sub-page that finds duplicate files (size pre-filter → partial hash → full hash), large files, and empty folders, with a results table and safe-delete-to-trash. Reuse the exclusion engine and the move-to-trash path already in `CleanerService`.
+**Note:** build on top of the [H9](2026-06-10-audit.md) test harness — this is destructive code and must ship with coverage.
+
+### BP2 — App-specific cleaning profiles *(Offensive, M→L)*
+**Why now:** BleachBit has 1,000+ profiles, CleanMyMac X has deep macOS-specific cleaners; Nexis has 6 general categories — its biggest cleaning-depth weakness. A small data-driven profile format (declarative JSON/INI of glob patterns + safety class) lets the community contribute profiles without C++ changes.
+**What:** a profile schema + loader, seeded with the top 20–30 apps per platform (browsers, IDEs, Docker, package-manager caches). Each profile declares paths, an age policy, and whether it's "safe" vs "aggressive."
+
+### BP3 — Disk space visualizer (sunburst/treemap) *(Offensive, M)*
+**Why now:** today Nexis only *launches* external tools (Filelight/Baobab); DaisyDisk's sunburst is a flagship paid-macOS feature and a recurring "why isn't this built in" request. A built-in `QGraphicsView` treemap is cross-platform and pairs naturally with the cleaner.
+**What:** recursive size scan on a worker thread (reuse the async patterns), rendered as an interactive treemap with drill-down and "reveal in file manager"/"move to trash."
+
+### BP4 — Software updater surfacing *(Offensive, M)*
+**Why now:** CleanMyMac X has it; on Linux it maps to `apt`/`snap`/`flatpak` upgrades, on macOS to `brew outdated` + `softwareupdate`. Nexis already brokers these package managers — exposing "what's upgradable" is incremental.
+**What:** an "Updates" view aggregating outdated packages across the platform's managers with one-click upgrade (reusing existing privilege paths).
+
+### BP5 — Health-report export & scheduled reports *(Offensive, S)*
+**Why now:** differentiator vs every single-purpose competitor; trivially cross-platform; pairs with the existing dashboard + maintenance wizard.
+**What:** "Export system health report" (Markdown/PDF) summarizing CPU/mem/disk/battery/SMART/thermal + cleanable space, optionally on the existing schedule.
+
+---
+
+## Linux
+
+### LX1 — deb822 APT source editor + the "Software & Updates" vacuum *(Defensive + Offensive, L) — flagship opportunity*
+**Why now:** **APT 3.1 made deb822 `.sources` the default format** and **removed `apt-key`** (keys must live in `/etc/apt/keyrings/` or `/usr/share/keyrings/` with `Signed-By:`). Simultaneously, **Ubuntu 26.04 dropped the "Software & Updates" GUI from the default install** — a stock desktop now has *no graphical way* to manage PPAs, mirrors, or repo components. Nexis's APT-sources page must be updated to parse/write deb822 and handle `Signed-By` keyrings (the old one-line `.list` + `apt-key` model is deprecated/removed) — and once it does, **it becomes the only repo-management GUI on a stock 26.04 desktop.**
+**What:** (1) read/write deb822 `ubuntu.sources`; (2) manage `Signed-By` keyrings without `apt-key`; (3) PPA add/remove via the retained `add-apt-repository` CLI; (4) component/mirror toggles. This is both a correctness fix (the current page will mis-handle 26.04 sources) and the highest-leverage new-user acquisition feature available.
+
+### LX2 — APT history: undo / rollback / why *(Offensive, M)*
+**Why now:** **APT 3.1 added dnf-style transaction history** — `apt history-list/info/undo/redo/rollback` and `apt why`/`apt why-not`. No GUI surfaces these yet.
+**What:** a transaction-history view in the uninstaller/sources area with one-click undo of the last operation and a "why is this installed?" dependency explainer. A genuinely novel GUI feature on Ubuntu 26.04.
+
+### LX3 — Wayland-only readiness audit *(Defensive, S→M) — must-do*
+**Why now:** **GNOME 50 removed the X11 session entirely** (Mutter/Shell/GDM); 26.04 GNOME is Wayland-only (XWayland remains for app compatibility). Any X11-specific code path in Nexis (screenshot capture, window/screen enumeration via X11, `XTest`) is dead on a stock 26.04 GNOME session.
+**What:** audit for X11 assumptions; confirm the Qt6 app runs as a native Wayland client; ensure the screenshot test harness and any window-geometry logic work under Wayland/XWayland. Low feature value, high "doesn't silently break" value.
+
+### LX4 — cgroup v2 / systemd-oomd observability *(Defensive + Offensive, M)*
+**Why now:** **systemd 259 removed cgroup v1 entirely** — 26.04 refuses to run on v1 hosts, so any per-process accounting that assumes v1 paths breaks; and **systemd-oomd now exposes `OOMKills`/`ManagedOOMKills` properties** per unit. Kernel 7.0 also added a generic FS-error-reporting channel.
+**What:** ensure process/dashboard accounting reads cgroup v2 paths only (defensive), then surface OOM-kill counts and recent OOM events as a new dashboard signal and a "what got killed and why" panel (offensive — the in-box Resources app doesn't show this).
+
+### LX5 — Services page: SysV deprecation + soft-reboot / run0 *(Defensive + Offensive, M)*
+**Why now:** **systemd 260 will remove SysV init-script compatibility** (259 is the last with it), so the services page must not assume `/etc/init.d` generators persist. systemd also gained `soft-reboot` (userspace-only restart) and `run0` (the `sudo` alternative, now with `--empower`); 26.04 ships `sudo-rs` as the default sudo.
+**What:** drop SysV assumptions; optionally add a "soft-reboot" action (faster than full reboot after updates) and validate elevation against `run0`/`sudo-rs` environments.
+
+### LX6 — Battery charge-threshold control *(Offensive, S→M)*
+**Why now:** GNOME 50's Power panel added firmware charge modes ("Maximize Charge" / "Preserve Battery Health"), but the stock UI is limited and has a **known bug where the mode reverts on some Dell XPS**. Custom thresholds live in `/sys/class/power_supply/BATx/charge_control_end_threshold`. Nexis already reads battery health.
+**What:** expose a charge-threshold slider/control writing the sysfs threshold (via the existing pkexec path), filling a gap the stock GNOME UI handles poorly.
+
+### LX7 — New hwmon/WMI sensor surfaces *(Offensive, S)*
+**Why now:** kernel 7.0 added vendor WMI sensors — **ASUS WMI** (fan/backlight/kbd hotkeys), **HP WMI manual fan control** (Victus), **Lenovo WMI extra HWMON sensors** (Legion). These are new readable sysfs/hwmon nodes.
+**What:** extend the hardware-info/thermal pages to enumerate and display these vendor sensors when present (gaming-laptop audience overlaps heavily with "system optimizer" users).
+
+### LX8 — Removable-media path fix *(Defensive, S) — quiet correctness bug*
+**Why now:** GNOME 50 **mounts removable media under `/run/media` instead of `/media`.** Any cleaner/disk code scanning `/media` mount points will miss removable drives on 26.04.
+**What:** update mount-point scanning to handle `/run/media` (keep `/media` for older distros).
+
+### LX9 — Snap-packaging reality check *(Defensive, M)*
+**Why now:** 26.04 ships **AppArmor/snapd permission prompting** (opt-in but expanding); a strict snap with Nexis's broad system access (process kill, file cleaning, service control) would collide with prompting rules — and there are known 26.04.0 kernel-panic bugs with prompting on Downloads access. The **App Center now manages debs**, overlapping the uninstaller. Packaging Nexis as a **deb avoids snapd prompting friction entirely.**
+**What:** confirm the deb is the primary Ubuntu distribution channel; if a snap is ever pursued, design for prompting. (Relatedly, audit [H7](2026-06-10-audit.md) settles Flatpak's fate.)
+
+---
+
+## macOS
+
+### MX1 — macOS 27 launchd quarantine-xattr handling *(Defensive, S) — will break startup items & scheduled cleaning*
+**Why now:** **macOS 27 (Golden Gate) refuses to load launchd plists carrying the `com.apple.quarantine` xattr.** Nexis writes launchd plists for startup-items management *and* for scheduled cleaning agents; any such plist that inherits quarantine will silently fail to load on macOS 27.
+**What:** strip the quarantine xattr from every plist Nexis writes (and document the requirement). This is small but the failure is silent and high-impact on the two macOS scheduling features.
+
+### MX2 — macOS 27 cross-team container access *(Defensive, M) — cache cleaning regression*
+**Why now:** **macOS 27 denies cross-team app-container access by default with no prompt** — scanning/deleting other apps' `~/Library/Containers` data silently fails unless the user enables access in Privacy & Security. This directly degrades cache cleaning on macOS 27.
+**What:** detect denied container access, and instead of silently skipping, surface a clear "grant Full Disk Access / enable in Privacy & Security" prompt with a deep link. Verify actual behavior against the macOS 27 beta before GA.
+
+### MX3 — Background Task Management (btm) startup-items integration *(Offensive, M)*
+**Why now:** `SMAppService` is the blessed API; `sfltool dumpbtm` is the diagnostic for login items / background tasks, and Tahoe 26.4 has a **known bug where `backgroundtaskmanagementd` pegs 400 % CPU** and login items fail. Nexis's startup-apps page can be the best GUI for this messy area.
+**What:** parse `sfltool dumpbtm` to show *all* background task manager items (not just user login items), flag orphaned/duplicate entries, and offer `sfltool resetbtm` as a repair action — directly addressing a real, current Tahoe pain point. Ensure the scanner doesn't choke on the new `/System/Library/LaunchAngels` directory.
+
+### MX4 — Menu-bar live monitor (iStat-Menus-style) *(Offensive, L)*
+**Why now:** the most-cited macOS monitoring gap vs iStat Menus (always-on menu-bar CPU/mem/net/temp). Tahoe added a **Menu Bar section in System Settings** that OS-manages per-item visibility, so a new `NSStatusItem` integrates cleanly with the platform.
+**What:** an optional menu-bar agent showing live CPU/mem/network/thermal, clicking through to the dashboard. Pairs with Nexis's existing kiosk mode as the "always visible" story. Significant effort (a separate status-item lifecycle), so tier-2.
+
+### MX5 — macOS deep-maintenance tasks (OnyX-style) *(Offensive, M)*
+**Why now:** OnyX's signature features — Spotlight index rebuild, disk-structure verification, flushing system caches, hidden Finder/Dock/Safari settings — are absent in Nexis and are exactly what macOS power users reach for. They map to `mdutil`, `diskutil verifyVolume`, and `defaults`.
+**What:** a "Maintenance" panel exposing safe, well-labeled versions of these (Spotlight reindex, verify disk, rebuild Launch Services, toggle common hidden defaults), reusing the maintenance-wizard UI pattern.
+
+### MX6 — App-uninstall leftover thoroughness (AppCleaner-parity) *(Offensive, M)*
+**Why now:** AppCleaner is noted as likely more thorough than Nexis at finding an app's scattered support files. With the AppleScript-injection fix ([S1](2026-06-10-audit.md)) landing in the uninstaller anyway, it's a natural time to deepen it.
+**What:** when uninstalling a `.app`, scan the standard leftover locations (`~/Library/{Application Support,Caches,Preferences,Logs,Containers,Saved Application State}`, LaunchAgents) for matching bundle-id artifacts and offer them for removal.
+
+### MX7 — Intel/Apple-silicon & Qt-version strategy *(Defensive, S — planning)*
+**Why now:** **macOS 26 is the last to support Intel; macOS 27 is Apple-silicon-only** and Rosetta is being phased out (through macOS 27 only). **Qt supports macOS 26 from Qt 6.10** (backported to 6.8 LTS / 6.5 patches); Liquid Glass forced rendering changes (a compatibility mode preserves the pre-Tahoe look). Xcode 26 no longer bundles the Metal toolchain by default.
+**What:** decide the Intel-build sunset timeline (Intel matters only for ≤26 users); pin the macOS build to Qt ≥6.8-latest-patch (ideally 6.10/6.11); test the UI under Tahoe's Liquid Glass and macOS 27's transparency slider; keep the notarized `.dmg` channel (Tahoe skips first-run XProtect scan for notarized apps) and **avoid `.pkg`** until the 26.3 Gatekeeper-rejection issue clears.
+
+---
+
+## Cross-cutting / strategic
+
+- **Don't chase remote/web monitoring or Windows.** The competitive doc positions Nexis as a local, native, cross-platform (Linux+macOS) tool; Glances/Netdata/Cockpit own remote, and Windows would triple the platform-matrix cost the audit already flags ([A3](2026-06-10-audit.md)). Stay in lane.
+- **Lead the Ubuntu 26.04 narrative.** "The repo-management GUI Ubuntu removed, plus OOM/GPU observability the stock Resources app doesn't show" (LX1+LX2+LX4) is a launch story for the next release window. The 4–6 week cadence in the SOP fits a "Nexis 2.4 — Ubuntu 26.04 ready" themed release.
+- **Use the audit fixes as feature enablers.** Headless `--clean` ([H6](2026-06-10-audit.md)) unlocks reliable scheduled cleaning (and a future CLI); the `RepositoryTool` refactor ([A4](2026-06-10-audit.md)) is the natural home for LX1/LX2; the destructive-path test harness ([H9](2026-06-10-audit.md)) is a prerequisite for BP1/BP2.
+
+---
+
+## Suggested priority tiers
+
+**Tier 1 — defensive must-dos (ship before/with 26.04 + macOS 27 support):**
+LX1 (deb822/keyrings — also a correctness bug), LX3 (Wayland readiness), LX8 (`/run/media`), MX1 (quarantine xattr), MX2 (container access), MX7 (Qt/Intel strategy).
+
+**Tier 2 — high-leverage offensive (the moat-wideners):**
+LX1's "vacuum" framing + LX2 (APT history GUI), BP1 (duplicate finder), BP3 (disk visualizer), MX3 (btm startup items), LX4 (OOM observability).
+
+**Tier 3 — depth & polish:**
+BP2 (cleaning profiles), BP4 (updater), BP5 (health report), LX6 (charge thresholds), LX7 (vendor sensors), MX5 (OnyX-style maintenance), MX6 (uninstall thoroughness).
+
+**Tier 4 — larger bets:**
+MX4 (menu-bar monitor), LX5 (soft-reboot/run0 services rework).
+
+---
+
+## Research appendix — platform facts & sources
+
+### Ubuntu 26.04 LTS "Resolute Raccoon" (2026-04-23)
+- **GNOME 50 "Tokyo":** Wayland-only (X11 session removed from Mutter/Shell/GDM; XWayland retained); fractional scaling/VRR default; new **Resources** app replaces System Monitor + Power Statistics with **GPU/NPU monitoring**; removable media moves to **`/run/media`**; Power panel adds firmware charge modes. Sources: [release-notes 26.04](https://documentation.ubuntu.com/release-notes/26.04/), [GNOME 50 (Register)](https://www.theregister.com/2026/03/19/gnome_50/), [9to5linux GNOME 50](https://9to5linux.com/gnome-50-tokyo-desktop-environment-officially-released-this-is-whats-new).
+- **Kernel 7.0:** sched_ext stable, Rust non-experimental, kdump default; new vendor WMI hwmon sensors (ASUS/HP/Lenovo); generic FS error reporting. Sources: [kernelnewbies 7.0](https://kernelnewbies.org/Linux_7.0), [9to5linux kernel 7.0](https://9to5linux.com/linux-kernel-7-0-officially-released-this-is-whats-new).
+- **systemd 259:** cgroup v1 removed (won't run on v1 hosts); last release with SysV compat (gone in 260); `run0 --empower`; `soft-reboot`; oomd `OOMKills`/`ManagedOOMKills`. Sources: [systemd v259 release](https://github.com/systemd/systemd/releases/tag/v259), [LWN 1051235](https://lwn.net/Articles/1051235/).
+- **APT 3.1:** solver3 default; **`apt-key` removed** (Signed-By keyrings); **deb822 `.sources` default**; `apt history` undo/rollback/redo; `apt why`/`why-not`. Sources: [linuxconfig APT 3.1](https://linuxconfig.org/what-is-new-in-apt-3-1-on-ubuntu-26-04), [LWN 1017315](https://lwn.net/Articles/1017315/).
+- **Software & Updates GUI removed from default install** (repo-management vacuum); **App Center now manages debs**; AppArmor/snapd permission prompting expanding; new **Security Center**. Sources: [omgubuntu S&U removal](https://www.omgubuntu.co.uk/2026/02/ubuntu-26-04-drops-software-and-updates-gui), [Launchpad #2140527](https://bugs.launchpad.net/ubuntu/+source/software-properties/+bug/2140527), [itsfoss deb in App Center](https://itsfoss.com/news/ubuntu-26-04-deb-in-app-center/), [permissions prompting deep-dive](https://discourse.ubuntu.com/t/permissions-prompting-a-deep-dive/81785).
+- **sudo-rs default**; **battery charge-mode UI bug on some Dell XPS**. Sources: [canonical 26.04 blog](https://canonical.com/blog/canonical-releases-ubuntu-26-04-lts-resolute-raccoon), [charge-options UI bug](https://discourse.ubuntu.com/t/ubuntu-26-04-lts-battery-charging-options-user-interface-bug/81113).
+
+### macOS 26 "Tahoe" (shipping) / macOS 27 "Golden Gate" (WWDC 2026-06-08)
+- **macOS 26:** last Intel-supporting release; Menu Bar section in System Settings (OS-managed `NSStatusItem` visibility); skips first-run XProtect scan for notarized apps; Tahoe 26.4 `backgroundtaskmanagementd` 400% CPU bug; new `/System/Library/LaunchAngels`. Sources: [Macworld Tahoe](https://www.macworld.com/article/2644146/macos-26-features-latest-update-release-date-beta.html), [Eclectic Light XProtect](https://eclecticlight.co/2025/09/30/do-apps-launch-faster-in-macos-tahoe/), [Eclectic Light LaunchAngels](https://eclecticlight.co/2025/10/03/welcome-to-tahoes-launch-angels/), [MacRumors btm bug](https://forums.macrumors.com/threads/problem-with-background-tasks-login-items-after-upgrade-to-macos-26-4.2480630/).
+- **macOS 27:** Apple-silicon-only (Intel dropped); **launchd refuses quarantine-xattr plists**; **cross-team container access denied by default, no prompt**; TCC.db locked down (API-only checks). Sources: [TechRadar macOS 27](https://www.techradar.com/computing/mac-os/macos-27-golden-gate-announced-at-wwdc-2026-heres-everything-you-need-to-know), [Michael Tsai roundup](https://mjtsai.com/blog/2026/06/09/macos-golden-gate-27-announced/), [Apple macOS 27 release notes](https://developer.apple.com/documentation/macos-release-notes/macos-27-release-notes).
+- **Qt:** macOS 26 supported from **Qt 6.10** (backported to 6.8 LTS/6.5); Liquid Glass rendering changes + compatibility mode; Xcode 26 drops bundled Metal toolchain. Sources: [Qt on macOS 26 Tahoe](https://www.qt.io/blog/qt-on-macos-26-tahoe), [Qt supported platforms](https://doc.qt.io/qt-6/supported-platforms.html).
+- **Gatekeeper:** tightened quarantine enforcement; active 26.3 reports of notarized `.pkg` rejections — prefer notarized `.dmg`. Source: [Apple dev forums — Gatekeeper](https://developer.apple.com/forums/tags/gatekeeper).
+
+### Competitor gaps (from [docs/COMPETITIVE_LANDSCAPE.md](docs/COMPETITIVE_LANDSCAPE.md), Feb 2026)
+Duplicate detection (Czkawka, CleanMyMac X); app-specific cleaning profiles (BleachBit 1,000+); disk visualizer (DaisyDisk); software updater + malware scan (CleanMyMac X); menu-bar monitoring/per-app bandwidth/fan control (iStat Menus); deep maintenance tasks (OnyX); uninstall leftover thoroughness (AppCleaner); advanced package management (Synaptic). Nexis deliberately cedes remote/web monitoring (Glances/Netdata/Cockpit) and Windows.


### PR DESCRIPTION
## Summary

Read-only project audit (no code changed) plus a platform-driven feature roadmap, both as committed markdown under `docs/plans/`.

- **[docs/plans/2026-06-10-audit.md](../blob/claude/full-audit-2026-06-10/docs/plans/2026-06-10-audit.md)** — findings from 8 specialist reviewers (security, memory/concurrency, Qt/UI, architecture, build/packaging, CI/release, tests, docs/community), each non-low finding adversarially verified against the cited code.
- **[docs/plans/2026-06-10-feature-recommendations.md](../blob/claude/full-audit-2026-06-10/docs/plans/2026-06-10-feature-recommendations.md)** — recommendations grouped by platform (Both / Linux / macOS), tagged Defensive vs Offensive, driven by Ubuntu 26.04 (GNOME 50, kernel 7.0, systemd 259, APT 3.1) and macOS 26/27.

## Audit headline

**0 critical · 11 high · 29 medium · 2 low** (confirmed). Nexis is in good shape; risk concentrates in:

1. **Crash-class concurrency/exception bugs** — UAF in the maintenance wizard, null-deref in `LogProvider::cancel()`, an unguarded `DiskHealthInfo::mDrives` data race, and an uncaught `QString` exception on the UI-thread delete path.
2. **Untested destructive code** — `CleanerService` `rm -rf` paths have zero coverage; the only visual-regression suite is excluded from CI and red for ~4 months on stale baselines.
3. **Broken Flatpak premise** — host tools aren't on the sandbox PATH and setuid `pkexec` is inert; the manifest can't work as written.
4. **Supply-chain & compliance** — CI actions pinned by mutable tag while holding publishing secrets; bundled OFL/UFL fonts ship without license texts and are misdeclared GPL-3.0 in `debian/copyright`; no `SECURITY.md` despite a 7-day CVE SLA.

A suggested remediation order is at the end of the audit doc. None of these map to existing `NEX`/`GH#` issues yet — filing them is a good follow-up.

## Feature roadmap headline

The strategic opening: Ubuntu 26.04 **removed the "Software & Updates" GUI** from the default install while APT 3.1 moved to **deb822 + `Signed-By` keyrings (no `apt-key`)**. Nexis's APT-sources page must adapt anyway — and once it does, it becomes the only repo-management GUI on a stock 26.04 desktop. macOS 27 brings two silent-breakage items (quarantine-xattr launchd plists, cross-team container denial) that Nexis must handle defensively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)