### PR TITLE
chore(governance): remove FUNDING.yml; align with no-monetization SOP (WI-31b)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: s4solutionsllc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **`.github/FUNDING.yml` (GitHub Sponsors button) removed (audit D4 / WI-31b):** The repo carried a `github: s4solutionsllc` Sponsors entry, which contradicted the public `docs/MAINTAINER_SOP.md` §2 "No monetization. Ever." rule. Per the CEO decision recorded in this work item, the Sponsors button is removed rather than carving out an exception, and §2 is amended to make explicit that repo-level donation surfaces (FUNDING.yml, "Buy me a coffee" links, Open Collective banners, etc.) are also out of scope. Nexis remains an intentionally non-revenue-generating reference product.
+
 ## [2.3.13] - 2026-06-05
 
 ### Fixed

--- a/docs/MAINTAINER_SOP.md
+++ b/docs/MAINTAINER_SOP.md
@@ -32,7 +32,10 @@ approval and a recorded rationale.
 1. **Always free.** Distributed under GPL-3.0-or-later. The license check in
    the release runbook (`RELEASE.md` §0) runs every release.
 2. **No monetization.** No paid tiers, no donation walls in the app, no
-   sponsor-only features, no telemetry-for-revenue. Ever.
+   sponsor-only features, no telemetry-for-revenue. **No repo-level donation
+   surfaces either** — that includes `.github/FUNDING.yml` (GitHub Sponsors
+   button), README "Buy me a coffee" links, Open Collective banners, and any
+   other inbound-money funnel attached to the repository. Ever.
 
 Any change to these rules is itself a CEO-level decision and must be reflected
 in this file *and* in the company SOPs / agent instructions.


### PR DESCRIPTION
## Summary

- Audit finding **D4 / WI-31b**: `.github/FUNDING.yml` enabled a GitHub Sponsors button (`github: s4solutionsllc`) while `docs/MAINTAINER_SOP.md` §2 rule 2 forbids monetization "Ever." Public contradiction.
- This WI is **CEO-decision-required** per the SOP (any sponsorship/monetization discussion is reserved to the CEO; §2 deviations require written CEO approval and a recorded rationale). The two engineering options were: **(A)** delete `FUNDING.yml`, or **(B)** carve out a SOP §2 exception permitting repo-level donation links while keeping the in-app no-monetization rule.

## CEO decision: Option A — delete `FUNDING.yml`

Rationale:

- The SOP's "**Ever**" language and §7 ("do not drift past the §2 hard rules") were written to resist exactly the kind of fine-grained exception Option B would carve out. Once the rule loses its categorical edge, future drift gets cheaper.
- §1 frames Nexis as an **intentionally non-revenue-generating reference product**. A Sponsors button — even one pointed at the org rather than the project — signals the opposite of that positioning to anyone visiting the repo page.
- The Sponsors entry was vestigial (no recorded rationale, no §2 exception, no link to a sponsorship profile that would survive scrutiny). Removing it costs us nothing real and removes the public contradiction.

## Changes

- Delete `.github/FUNDING.yml`.
- Amend `docs/MAINTAINER_SOP.md` §2 rule 2 to enumerate repo-level donation surfaces (FUNDING.yml, README "Buy me a coffee", Open Collective banners, etc.) as explicitly prohibited so a future maintainer cannot re-add one without a fresh CEO decision.
- `CHANGELOG.md` entry under `[Unreleased] / Removed`.

No code changes. No `APPLICATION_OVERVIEW.md` / `ARCHITECTURE_REVIEW.md` touchpoints (neither mentioned sponsorship/funding).

## Test plan

- [x] `git grep -i "funding\|sponsor"` no longer finds an active Sponsors configuration; only the new SOP prohibition language and the CHANGELOG entry remain.
- [x] `docs/MAINTAINER_SOP.md` §2 still reads as a hard rule; the new bullet is additive, not a carve-out.
- [ ] Maintainer/reviewer confirms the rendered Sponsors button disappears from the repo page after merge (GitHub UI check).

## References

- Paperclip issue: SSO-3394 (sub of SSO-3360 — Phase 10 audit remediation)
- Audit ref: D4
- Parent plan: [Audit Remediation Plan](https://paperclip.s4solutions.ai/SSO/issues/SSO-3360#document-2026-06-10-audit-remediation-plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)