### PR TITLE
docs(security): add SECURITY.md and document private reporting (SSO-3374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`SECURITY.md` security policy (SSO-3374):** Added a top-level `SECURITY.md` declaring supported versions (2.3.x), the `security@s4solutions.ai` private contact, support for GitHub private vulnerability reporting (GHSA), and the 7-day patch SLA from `RELEASE.md` §6. The §6 day-6–7 step that says "update `SECURITY.md`" now references a real file. Reporters who land on the repo's Security tab will get a private channel instead of defaulting to a public issue once the maintainer enables Private Vulnerability Reporting in repo settings.
+
 ### Fixed
 - **Default `CXXBASICS_USE_FASTER_LINKERS` to OFF in-tree, fixing GH#82 at the root (SSO-3377 / GH#82 / GH#88):** The in-tree linker accelerator (`shared/cmake/cxxbasics/accelerators/UseFasterLinkers.cmake`) defaulted **ON** and appended `-fuse-ld=lld` whenever LLD was present. Any environment with LLD and `-flto` in `CXXFLAGS` (Fedora/openSUSE defaults, CachyOS, downstreams not using our PKGBUILD) reproduced GH#82's "undefined symbol: main" — GCC emits slim LTO objects that LLD cannot resolve. A dev-speed accelerator should never be on for release or packaged builds. The default is now **OFF**; developers who want the LLD/gold speedup opt in with `-DCXXBASICS_USE_FASTER_LINKERS=ON`. The redundant `-DCXXBASICS_USE_FASTER_LINKERS=OFF` workaround was removed from `linux/aur/PKGBUILD` (the `options=('!lto')` decision stays with the maintainer per GH#82). The underlying GCC + LLD + LTO incompatibility tracked in GH#88 is unchanged; this change makes sure the default config can never recur it.
+
 ## [2.3.14] - 2026-06-11
 
 ### Changed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,79 @@
+# Security Policy
+
+Nexis is a Linux & macOS system optimizer and monitoring tool maintained by
+[S4 Solutions](https://s4solutions.ai). We take security reports seriously and
+patch credible vulnerabilities out within a fixed, published SLA.
+
+## Supported versions
+
+Security fixes ship on the current minor release line. The latest tagged
+release on `native` is always supported; the immediately preceding minor line
+is supported only for backports of credible CVEs while it is the most recent
+maintenance branch.
+
+| Version  | Supported          |
+| -------- | ------------------ |
+| 2.3.x    | :white_check_mark: |
+| < 2.3    | :x:                |
+
+Older versions do not receive patches. Upgrade to the current release line.
+
+## Reporting a vulnerability
+
+**Please do not open public GitHub issues for security reports.** Use one of
+the two private channels below.
+
+1. **GitHub private vulnerability reporting (preferred).** Open the repository's
+   **Security** tab and click **Report a vulnerability**. This creates a private
+   draft GitHub Security Advisory (GHSA) that only maintainers can see, lets us
+   credit you on publication, and threads the fix and CVE assignment together.
+2. **Email.** Send the report to **security@s4solutions.ai**. Include a clear
+   reproducer, the affected version (`nexis --version` or the package version),
+   the platform (Linux distribution + Qt version, or macOS version), and the
+   impact you observed. If you need encryption, ask in the first message and
+   we will arrange a key exchange.
+
+Please do not file a public GitHub issue, post to discussions, or share the
+report on social media until we have published a fix and a coordinated GHSA.
+
+## What to expect
+
+We follow the expedited path documented in
+[`RELEASE.md` §6](RELEASE.md#6-cve--security-fix-expedited-path):
+
+- **Acknowledgement within 48 hours** of receipt of a credible report.
+- **Patched build within 7 calendar days** of a credible disclosure. If a
+  working remote exploit is in the wild, we compress to ≤72 hours.
+- **Coordinated disclosure.** For multi-party issues (Qt upstream, distro
+  packagers), we follow the Qt embargo timeline and tag on the embargo date,
+  not before.
+- **Credit.** On publication of the GHSA we credit the reporter by name or
+  handle, with their permission.
+
+## Scope
+
+Security reports against the following are in scope:
+
+- The Nexis application source under `shared/`, `linux/`, and `macos/`.
+- The release pipeline (`.github/workflows/`) where it materially affects the
+  integrity of published artifacts.
+- Packaging recipes we publish (`linux/aur/`, `linux/debian/`,
+  `linux/flatpak/`, the macOS bundle).
+
+Out of scope:
+
+- Bugs in upstream dependencies (Qt, OpenSSL through Qt, third-party
+  CLIs such as `smartctl` or `flatpak`). Please report those to the
+  respective upstream first. We will track the impact on Nexis once an
+  upstream advisory exists.
+- Issues that require physical access to an already-compromised host or
+  require root to exploit a code path that already runs as root.
+- Social-engineering reports against contributors or maintainers.
+
+## Maintainer note — GitHub setting required
+
+The "Report a vulnerability" button above requires the repository's **Private
+vulnerability reporting** setting to be enabled (Settings → Code security and
+analysis → Private vulnerability reporting → Enable). This is a one-time
+maintainer-controlled toggle that cannot be set from a pull request; the
+maintainer should enable it alongside the merge of this file.


### PR DESCRIPTION
## Summary

Adds a top-level `SECURITY.md` that closes the WI-12 audit gap (D2 in
[`docs/plans/2026-06-10-audit.md`](docs/plans/2026-06-10-audit.md)). The
file declares supported versions, names the `security@s4solutions.ai`
private channel, points reporters at GitHub private vulnerability
reporting (GHSA), and aligns the patch SLA with
[`RELEASE.md` §6](RELEASE.md#6-cve--security-fix-expedited-path).

- New: `SECURITY.md` at repo root (where GitHub auto-discovers it; placing
  it under `.github/` would also work but the root location is more
  discoverable for contributors who clone the repo).
- `CHANGELOG.md` `## [Unreleased]` `### Added` entry.
- The `RELEASE.md` §6 day-6–7 step that says "update `SECURITY.md`" now
  references a real file — no edit needed there.

## ⚠️ Maintainer settings change required

This PR cannot enable GitHub's "Report a vulnerability" button on its
own. The repository's **Private vulnerability reporting** toggle is a
settings-only switch. After merge, please:

1. Open **Settings → Code security and analysis**.
2. Under **Private vulnerability reporting**, click **Enable**.

This makes the "Report a vulnerability" button appear on the repo's
Security tab and lets reporters open a private draft GHSA without going
through email. Until this is flipped, the email channel
(`security@s4solutions.ai`) still works — the file is correct, but the
GitHub-side surface is half-on.

## Other docs

- `docs/APPLICATION_OVERVIEW.md` / `docs/ARCHITECTURE_REVIEW.md` — not
  touched. This change does not affect features, UI, platform support,
  signals, singletons, timers, or cross-component patterns, so per the
  CLAUDE.md pre-commit checklist they do not need updates.

## Test plan

- [ ] N/A — documentation only. No build or test changes.
- [ ] After merge, confirm GitHub's Security tab shows the new policy
      (`https://github.com/s4solutionsllc/Nexis/security/policy`).
- [ ] After enabling Private vulnerability reporting in repo settings,
      confirm the "Report a vulnerability" button appears on the Security
      tab.

## Refs

- Paperclip issue: [SSO-3374](/SSO/issues/SSO-3374) (WI-12).
- Parent plan: [SSO-3360](/SSO/issues/SSO-3360) — Audit Remediation Plan
  (Phase 5 — Supply chain & compliance).
- Audit finding: D2 in `docs/plans/2026-06-10-audit.md`.

🤖 Generated with [Paperclip](https://paperclip.ing)