### PR TITLE
docs(architecture): reconcile living overview/architecture docs (SSO-3392 / WI-30)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # WI-30: keep the living architecture/overview docs in sync with the
+      # CMake project version. Cheap, no dependencies — runs on every matrix
+      # leg so a drift is caught on the same PR that introduces it.
+      - name: Doc version header check
+        run: bash scripts/check_doc_versions.sh
+
       # --- Linux dependencies ---
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Docs:** Reconciled `docs/ARCHITECTURE_REVIEW.md` and `docs/APPLICATION_OVERVIEW.md` against the live tree (SSO-3392 / WI-30). Consolidated by-the-numbers counts (LOC, page/service/signal/timer/test totals) into a single canonical table in `APPLICATION_OVERVIEW.md` and removed the duplicated hard counts that had drifted (notably the "~6,000–7,000 LOC" Scale line, the stale `sigDashboardLayoutReset` mention and "9 signals" / "13 info classes" / "4 timers / 10 signals" claims, the wrong `~/Library/Preferences/com.nexis.plist` / `~/.config/nexis/nexis.conf` settings paths, and the "CI runs screenshot tests" claim already invalidated by WI-19). Refreshed both `Last updated` / `Version` headers to match `PROJECT_VERSION`.
+- **CI:** New `scripts/check_doc_versions.sh` runs on every build matrix leg and fails the workflow if the doc version header drifts from `CMakeLists.txt`'s `project(... VERSION ...)`.
+
 ## [2.3.13] - 2026-06-05
 
 ### Fixed

--- a/docs/APPLICATION_OVERVIEW.md
+++ b/docs/APPLICATION_OVERVIEW.md
@@ -1,7 +1,7 @@
 # Nexis — Application Overview
 
 > A comprehensive reference for what Nexis does and how it is built.
-> Last updated: 2026-04-23 | Version 2.3.1
+> Last updated: 2026-06-10 | Version 2.3.13
 
 ---
 
@@ -45,18 +45,31 @@ Nexis is a **cross-platform (Linux + macOS) system optimizer and monitoring tool
 
 **Origin:** Nexis began as a fork of [Stacer](https://github.com/oguzhaninan/Stacer), the popular Linux system optimizer that went inactive in 2020 with 38+ known bugs. After porting to Qt 6, adding native macOS support, fixing those inherited bugs, and adding GPU monitoring, hardware health tracking, scheduled cleaning, Docker management, and more, the project was rebranded as **Nexis** to reflect that it had become something distinct.
 
-**By the numbers:**
-- ~37,000 lines of C++ code across 288 source files
-- 17 application pages
-- 16 system info providers (BatteryInfo, BootAnalysisInfo, CpuInfo, DiskHealthInfo, DiskInfo, FanInfo, GpuInfo, MemoryInfo, NetworkInfo, PowerProfileInfo, ProcessInfo, StartupInfo, SystemInfo, ThermalInfo, UpdateInfo) — 13 wired through InfoManager, BootAnalysisInfo/StartupInfo standalone, PowerProfileInfo added in v2.1.16
-- 6 tool classes (package management, services, Docker, APT sources, GNOME settings, file search)
-- 8 domain services (StartupService, FileSearchService, HostService, ProcessService, SystemServiceManager, DockerService, PackageService, DuplicateFinderService)
-- 3 utility classes
-- 7 manager singletons
-- 3 themes (Dark, Light, Auto)
-- 34 languages
-- 17 test suites with ~242 test methods (Qt Test + CTest)
-- 88 features implemented, 102 bugs fixed since fork
+**By the numbers (canonical table — referenced by [`ARCHITECTURE_REVIEW.md`](ARCHITECTURE_REVIEW.md)):**
+
+| Metric | Value | Source of truth |
+|--------|-------|-----------------|
+| Version | 2.3.13 | `project(... VERSION ...)` in `CMakeLists.txt` |
+| Source LOC (C++) | ~48,700 | `shared/`, `linux/`, `macos/` (`*.cpp`/`*.h`/`*.mm`) |
+| Source files (C++) | 338 | same |
+| Test LOC | ~6,050 | `tests/` |
+| Test executables | 30 (29 unit + 1 screenshot) | `tests/CMakeLists.txt` |
+| Test methods | ~418 | `private slots:` in `tests/*/test_*.cpp` |
+| Always-visible pages | 15 | `shared/nexis/Pages/` (Dashboard, HardwareInfo, StartupApps, BootAnalysis, SystemCleaner, DiskTools, Search, Services, Processes, Uninstaller, Resources, Network, Helpers, SystemLogs, Settings) |
+| Conditional pages | 3 | APTSourceManager / Docker / GnomeSettings — guarded in `app.cpp` by `ToolManager` capability checks |
+| Info providers | 16 | `shared/nexis-core/Info/` (15 cross-platform + `PsiInfo` Linux-only); 14 wired through `InfoManager`, `BootAnalysisInfo`/`StartupInfo` standalone |
+| Tool classes | 8 | `shared/nexis-core/Tools/` — 6 wired through `ToolManager` (`ServiceTool`, `PackageTool`, `AptSourceTool`, `GnomeSettingsTool`, `RepoHealthChecker`, `RepoRepairEngine`) plus `DockerTool` and `FileSearchTool` consumed directly by their services |
+| Utility classes | 3 | `CommandUtil`, `FileUtil`, `FormatUtil` in `shared/nexis-core/Utils/` |
+| Manager singletons | 8 | `shared/nexis/Managers/` (`AppManager`, `InfoManager`, `ToolManager`, `SettingManager`, `CleanerService`, `ScheduleManager`, `ProcessPrefsManager`, `DataRefreshService`) |
+| Domain services | 9 | `shared/nexis/Services/` (`StartupService`, `FileSearchService`, `HostService`, `ProcessService`, `SystemServiceManager`, `DockerService`, `PackageService`, `DuplicateFinderService`, `SnapshotService`) |
+| `SignalMapper` signals | 10 | `shared/nexis/signal_mapper.h` |
+| `DataRefreshService` QTimers | 5 | fast (1 s) / medium (5 s) / slow (30 s) / process (configurable) / update (1 h) |
+| `DataRefreshService` signals | 15 | 14 cross-platform + Linux-only `psiUpdated` |
+| Themes | 2 (Dark = `default/`, Light = `light/`) | `shared/nexis/static/themes/` |
+| Color schemes | 3 (Auto / Light / Dark) | `AppManager::resolveThemeName()` |
+| Translations | 34 languages | `shared/translations/*.ts` |
+
+Update the table whenever the underlying value changes — the same numbers are referenced verbatim by `docs/ARCHITECTURE_REVIEW.md`, so a single edit here keeps both docs honest.
 
 ---
 
@@ -333,7 +346,7 @@ Continuous per-interface network data usage tracker with monthly cap management.
 
 **Usage Tracking:** A `NetUsageTracker` singleton subscribes to `DataRefreshService::networkPerInterfaceUpdated` (1s fast tick) at startup — always accumulating even when the page is not open. Each tick carries a `QHash<QString, NetInterfaceStats>` snapshot of every non-loopback up+running interface; the tracker computes per-interface deltas, adds them to each interface's today bucket, and debounces a 60-second write to `SettingManager` as a JSON blob. The accumulator handles reboot/iface restart counter resets by detecting when a new absolute value is less than the previous one (skip the delta, update the baseline). Tracking the full snapshot (rather than just the default interface) means Wi-Fi (`wlp*`, `wlan0`) is recorded even when it isn't the system default route, and a newly-connected interface is picked up on the next tick (SSO-351).
 
-**History:** 90-day rolling window of daily RX+TX buckets, stored as compact JSON in `~/.config/nexis/nexis.conf`.
+**History:** 90-day rolling window of daily RX+TX buckets, stored as compact JSON in `SettingManager`'s INI file (see [Configuration and Settings](#configuration-and-settings) for the resolved path on each platform).
 
 **Page UI:**
 - Interface selector (All Interfaces or individual adapter)
@@ -515,24 +528,33 @@ Nexis follows a **three-tier architecture**:
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│                    UI Pages (16)                        │
-│  Dashboard, HardwareInfo, StartupApps, SystemCleaner,   │
-│  DiskTools, Search, Services, Processes, Uninstaller,   │
-│  Resources, Helpers, AptSourceManager, GnomeSettings,   │
-│  Docker, SystemLogs, Settings                           │
+│         UI Pages (15 always-visible + 3 conditional)    │
+│  Always: Dashboard, HardwareInfo, StartupApps,          │
+│    BootAnalysis, SystemCleaner, DiskTools, Search,      │
+│    Services, Processes, Uninstaller, Resources,         │
+│    Network (Usage), Helpers, SystemLogs, Settings       │
+│  Conditional: AptSourceManager, Docker, GnomeSettings   │
 ├─────────────────────────────────────────────────────────┤
 │                  Manager Layer (8)                       │
-│  InfoManager, AppManager, SettingManager, ToolManager,  │
-│  CleanerService, DuplicateFinderService,                │
-│  ScheduleManager, DataRefreshService                    │
+│  AppManager, InfoManager, ToolManager, SettingManager,  │
+│  CleanerService, ScheduleManager, ProcessPrefsManager,  │
+│  DataRefreshService                                     │
+├─────────────────────────────────────────────────────────┤
+│              Domain Services (9)                         │
+│  StartupService, FileSearchService, HostService,        │
+│  ProcessService, SystemServiceManager, DockerService,   │
+│  PackageService, DuplicateFinderService, SnapshotService│
 ├─────────────────────────────────────────────────────────┤
 │                Core Library (nexis-core)                 │
-│  Info: CpuInfo, MemoryInfo, DiskInfo, NetworkInfo,      │
-│        SystemInfo, ProcessInfo, ThermalInfo, GpuInfo,   │
-│        BatteryInfo, DiskHealthInfo, FanInfo              │
-│  Tools: ServiceTool, PackageTool, AptSourceTool,        │
-│         GnomeSettingsTool, DockerTool                    │
-│  Utils: FileUtil, CommandUtil, FormatUtil                │
+│  Info: BatteryInfo, BootAnalysisInfo, CpuInfo,          │
+│   DiskHealthInfo, DiskInfo, FanInfo, GpuInfo,           │
+│   MemoryInfo, NetworkInfo, PowerProfileInfo, ProcessInfo│
+│   StartupInfo, SystemInfo, ThermalInfo, UpdateInfo,     │
+│   PsiInfo (Linux only)                                  │
+│  Tools: AptSourceTool, DockerTool, FileSearchTool,      │
+│   GnomeSettingsTool, PackageTool, RepoHealthChecker,    │
+│   RepoRepairEngine, ServiceTool                         │
+│  Utils: CommandUtil, FileUtil, FormatUtil               │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -586,25 +608,26 @@ The `nexis-core` static library provides platform-abstracted system information 
 
 ## Manager Layer
 
-Seven singleton managers mediate between UI pages and the core library.
+Eight singleton managers mediate between UI pages and the core library (count: see the canonical table above).
 
 | Manager | Role |
 |---------|------|
-| `InfoManager` | Facade over all 15 Info classes via `std::unique_ptr<Interface>`. Centralized refresh methods (`updateMemoryInfo()`, `updateGpuInfo()`, etc.) ensure data consistency. |
+| `InfoManager` | Facade over the cross-platform Info classes via `std::unique_ptr<Interface>`. Centralized refresh methods (`updateMemoryInfo()`, `updateGpuInfo()`, etc.) ensure data consistency. |
 | `AppManager` | Theme/stylesheet loading, language management, system tray icon, color scheme detection. |
 | `SettingManager` | `QSettings` wrapper with 30+ typed getters/setters for persistent preferences. |
-| `ToolManager` | Facade over all 5 Tool classes via `std::unique_ptr<Interface>`. Platform-aware routing (e.g., `uninstallPackages()` calls Homebrew on macOS, APT on Debian). |
+| `ToolManager` | Facade over the cross-platform Tool classes via `std::unique_ptr<Interface>`. Platform-aware routing (e.g., `uninstallPackages()` calls Homebrew on macOS, APT on Debian). |
 | `CleanerService` | Reusable scan/clean logic shared between the System Cleaner UI and headless scheduled cleaning. |
-| `DuplicateFinderService` | 3-stage duplicate detection pipeline (size grouping → partial 4KB SHA-256 hash → full SHA-256 hash). Background thread via QtConcurrent with QAtomicInt cancellation. |
 | `ScheduleManager` | CRUD for cleaning schedules, JSON persistence via QSettings, OS-native scheduler sync (launchd/systemd/cron). |
-| `DataRefreshService` | Centralized polling service with 4 QTimers (1s/5s/30s/configurable). Polls InfoManager once per interval, emits 10 typed data-change signals. Pages subscribe as reactive consumers. Supports pause/resume on app minimize (kiosk mode overrides pause). |
+| `ProcessPrefsManager` | Persistent per-process state (pin flags, alert thresholds) used by `ProcessesPage`. JSON-in-QSettings, same shape as `ScheduleManager` / `CleanerExclusions`. |
+| `DataRefreshService` | Centralized polling service with 5 QTimers (fast/medium/slow/process/update). Polls InfoManager once per interval, emits 15 typed data-change signals (14 cross-platform + Linux-only `psiUpdated`). Pages subscribe as reactive consumers. Supports pause/resume on app minimize (kiosk mode overrides pause). |
 
-**Cross-component events** are handled by `SignalMapper`, a singleton `QObject` with 9 global signals:
+**Cross-component events** are handled by `SignalMapper`, a singleton `QObject` with 10 global signals (see `shared/nexis/signal_mapper.h`):
 - `sigChangedAppTheme()` — triggers stylesheet/icon refresh across all pages
 - `sigUninstallStarted()` / `sigUninstallFinished()` — progress feedback
 - `sigKioskToggleRequested()` — Dashboard button requests kiosk toggle from App
 - `sigKioskModeChanged(bool)` — App broadcasts kiosk state to Dashboard button and tray menu
 - `sigAppVisibilityChanged(bool)` — App broadcasts visibility state for DataRefreshService pause/resume
+- `sigAppFocusChanged(bool)` — App broadcasts main-window focus state so `DataRefreshService` can downshift cadence when another app has focus (FR-105)
 - `sigNavigateToPage(QString)` — CommandPalette triggers page navigation
 - `sigCleanableSizeChanged(quint64)` — System Cleaner broadcasts total cleanable size for cross-tile data flow
 - `sigDashboardFooterChanged(bool)` — Settings page broadcasts dashboard footer visibility preference
@@ -658,17 +681,11 @@ tests/
 - Linux PPA: `ppa:s4solutionsllc/nexis` — Ubuntu 22.04+ (Jammy, Noble, Plucky), amd64 and arm64, automatic updates via apt
 - macOS Homebrew: `brew tap s4solutionsllc/nexis && brew install --cask nexis` — Apple Silicon, auto-updated on new releases
 
-**Test executables** — 16 CTest-registered executables (Qt Test + CTest)
-- 15 unit test executables via `add_nexis_test()` CMake macro (QTEST_MAIN requires one main per executable)
-- 1 screenshot regression test executable linked against `nexis-gui`
-- ~214 unit test methods across 15 suites:
-  - Utilities: FormatUtil (10), FileUtil (10), CommandUtil (9)
-  - Core parsers (FR-76): MemoryInfo (14), CpuInfo (19), GpuInfo (23), AptSource (14), FanInfo (16), ThermalInfo (11), BatteryInfo (12), DiskInfo (17), DiskHealth (20), PowerProfile (24)
-  - Services: HostService (25)
-  - Managers: ScheduleManager (15)
-  - Theme: ThemeTokens (7)
+**Test executables** — see the canonical table at the top of this doc for counts
+- Unit test executables registered via the `add_nexis_test()` CMake macro (QTEST_MAIN requires one main per executable); plus one screenshot regression test linked against `nexis-gui`
 - Static parser pattern: parsing logic extracted into public static methods on shared base classes, tested with fixture data files in `tests/fixtures/`
-- Screenshot test: captures 11 pages × 2 themes, compares against reference PNGs with per-page pixel tolerance
+- Screenshot test: captures the always-visible pages in both Dark and Light themes and compares against reference PNGs with per-page pixel tolerance
+- The CI `Unit Tests` step explicitly excludes `ScreenshotTests` (`ctest -E ScreenshotTests`) — screenshot diffs are produced locally via `scripts/update_screenshots.sh` (WI-19)
 - Dependencies: `nexis-core`/`nexis-gui`, Qt6::Test
 - Gated behind `BUILD_TESTING` option (default ON)
 - Run via: `ctest --test-dir build --output-on-failure`
@@ -772,9 +789,11 @@ QSS tokens include `@dpN` values (e.g., `@dp8`, `@dp12`) that are computed at st
 
 ### Storage Backend
 
-`SettingManager` wraps Qt's `QSettings`:
-- **macOS:** `~/Library/Preferences/com.nexis.plist`
-- **Linux:** `~/.config/nexis/nexis.conf`
+`SettingManager` wraps Qt's `QSettings`, written explicitly as an INI file at `QStandardPaths::AppConfigLocation/settings.ini` (see `shared/nexis/Managers/setting_manager.cpp`). With `applicationName == "nexis"` (set in `main.cpp`) and no organization name, this resolves to:
+- **Linux:** `~/.config/nexis/settings.ini` (or `$XDG_CONFIG_HOME/nexis/settings.ini` if set)
+- **macOS:** `~/Library/Application Support/nexis/settings.ini`
+
+Forcing INI format on both platforms keeps the on-disk layout identical for both inspection and the headless `--clean` / `--check-threshold` codepaths. There is **no** `com.nexis.plist` and **no** `nexis.conf`; older docs that named those paths were stale.
 
 ### Settings Keys (30+)
 
@@ -826,7 +845,7 @@ Arabic, Afrikaans, Catalan, Chinese (Simplified/Traditional), Czech, Danish, Dut
 ### Main Window Initialization (`App`)
 
 1. Create `SlidingStackedWidget` (animated page container)
-2. Instantiate all 16 pages
+2. Instantiate every always-visible page (and the three conditional pages when their tools are detected)
 3. Conditionally show/hide pages based on platform and tool availability:
    - APT Source Manager: only if `ToolManager::checkSourceRepository()` returns true
    - Docker: only if `ToolManager::checkDocker()` returns true
@@ -839,7 +858,7 @@ Arabic, Afrikaans, Catalan, Chinese (Simplified/Traditional), Czech, Danish, Dut
 
 ### Navigation
 
-The sidebar is **collapsible**, organized into three labelled groups — **MONITOR**, **MANAGE**, and **SYSTEM** — matching the logical grouping of the 16 pages. Each group has a **clickable section header** with a chevron indicator that toggles the group's visibility. Collapsed groups hide their child buttons with a smooth 200ms height animation; the collapsed/expanded state is persisted per-section across sessions as JSON in QSettings. Navigating to a page in a collapsed group (via tray menu, command palette, or `sigNavigateToPage`) auto-expands that group. The full sidebar can also collapse to a 64 px icon-rail showing only page icons plus section indicator dots; the collapse and expand transitions use a smooth width animation. The sidebar can be toggled with the **Ctrl+B** keyboard shortcut or the collapse button at the top of the panel. The sidebar header displays a **gradient logo** (full wordmark when expanded, lettermark when collapsed) above a **separator line**, with a **version label** below. Active page badges use a cleaner dot indicator in collapsed mode and are hidden when their section is collapsed. The Homebrew/APT button displays an **updates badge** showing the pending update count when the sidebar is expanded, or a colored dot (using `@updatesColor`) when collapsed.
+The sidebar is **collapsible**, organized into three labelled groups — **MONITOR**, **MANAGE**, and **SYSTEM** — matching the logical grouping of the pages. Each group has a **clickable section header** with a chevron indicator that toggles the group's visibility. Collapsed groups hide their child buttons with a smooth 200ms height animation; the collapsed/expanded state is persisted per-section across sessions as JSON in QSettings. Navigating to a page in a collapsed group (via tray menu, command palette, or `sigNavigateToPage`) auto-expands that group. The full sidebar can also collapse to a 64 px icon-rail showing only page icons plus section indicator dots; the collapse and expand transitions use a smooth width animation. The sidebar can be toggled with the **Ctrl+B** keyboard shortcut or the collapse button at the top of the panel. The sidebar header displays a **gradient logo** (full wordmark when expanded, lettermark when collapsed) above a **separator line**, with a **version label** below. Active page badges use a cleaner dot indicator in collapsed mode and are hidden when their section is collapsed. The Homebrew/APT button displays an **updates badge** showing the pending update count when the sidebar is expanded, or a colored dot (using `@updatesColor`) when collapsed.
 
 A **Command Palette** (activated with **Ctrl+K**) provides a fuzzy-search popup for navigating directly to any page and executing common actions (e.g., "run clean", "toggle kiosk") without touching the sidebar.
 
@@ -896,22 +915,24 @@ qApp->setStyleSheet(processedQSS)     ← All widgets update immediately
     ↓
 emit SignalMapper::ins()->sigChangedAppTheme()  ← Global event
     ↓
-[All 16 pages reload theme-dependent assets (icons, GIF loaders, etc.)]
+[Every page reload theme-dependent assets (icons, GIF loaders, etc.)]
 ```
 
 ### Refresh Timing
 
-All periodic polling is centralized in `DataRefreshService`, which owns 5 QTimers and emits typed data signals. Pages subscribe as reactive consumers — no page owns a QTimer.
+All periodic polling is centralized in `DataRefreshService`, which owns 5 QTimers and emits 15 typed data signals (14 cross-platform + Linux-only `psiUpdated`). Pages subscribe as reactive consumers — no page owns a QTimer.
 
 | Data | Refresh Rate | Timer Tier | Signal |
 |------|-------------|------------|--------|
-| CPU, Memory, Network, Disk I/O, GPU, Temp, Battery | 1 second | Fast (mFastTimer) | `cpuUpdated`, `memoryUpdated`, `networkUpdated`, `diskIOUpdated`, `gpuUpdated`, `tempUpdated`, `batteryUpdated` |
-| Disk usage | 5 seconds | Medium (mMediumTimer) | `diskUsageUpdated` |
-| Disk health (SMART) | 30 seconds | Slow (mSlowTimer) | `diskHealthUpdated` |
-| Processes | 1–10 seconds | Configurable (mProcessTimer) | `processesUpdated` |
-| System updates | 1 hour | Update (mUpdateTimer) | `systemUpdatesChecked` |
+| CPU, Memory, Network (default + per-iface), Disk I/O, GPU, Temp, Fan, Battery, PSI (Linux) | 1 second (Normal mode) | Fast (`mFastTimer`) | `cpuUpdated`, `memoryUpdated`, `networkUpdated`, `networkPerInterfaceUpdated`, `diskIOUpdated`, `gpuUpdated`, `tempUpdated`, `fanUpdated`, `batteryUpdated`, `psiUpdated` (Linux only) |
+| Disk usage | 5 seconds | Medium (`mMediumTimer`) | `diskUsageUpdated` |
+| Disk health (SMART) | 30 seconds | Slow (`mSlowTimer`) | `diskHealthUpdated` |
+| Processes | 1–10 seconds | Configurable (`mProcessTimer`) | `processesUpdated` |
+| System updates + repo health (chained) | 1 hour | Update (`mUpdateTimer`) | `systemUpdatesChecked`, `repoHealthChecked` |
 | Services, packages | On demand | — | Manual refresh / page navigation |
 | Hardware info | Once | — | Page construction |
+
+FR-105 PowerMode tiers downshift the Fast timer cadence based on focus + battery state: Normal 1/5/30 s, Battery 2/10/60 s, Unfocused 5/30/60 s.
 
 **Battery optimization:** When the app is minimized to tray, `DataRefreshService::pause()` stops all timers (unless kiosk mode is active). On restore, `resume()` fires immediate ticks then restarts timers.
 
@@ -935,16 +956,17 @@ All periodic polling is centralized in `DataRefreshService`, which owns 5 QTimer
 │   └── Archive/                Completed research/plans
 ├── shared/
 │   ├── nexis-core/             Core library (shared)
-│   │   ├── Info/               15 system info providers (incl. StartupInfo)
-│   │   ├── Tools/              7 tool classes (incl. FileSearchTool)
-│   │   └── Utils/              3 utility classes
+│   │   ├── Info/               System info providers (see canonical table)
+│   │   ├── Tools/              Tool classes (see canonical table)
+│   │   └── Utils/              Utility classes (CommandUtil, FileUtil, FormatUtil)
 │   ├── nexis/                  GUI application (shared)
-│   │   ├── Managers/           7 manager singletons
-│   │   ├── Services/           7 domain services
-│   │   ├── Pages/              14 page implementations
+│   │   ├── Managers/           8 manager singletons
+│   │   ├── Services/           Domain services (see canonical table)
+│   │   ├── Pages/              Page implementations (see canonical table)
 │   │   │   ├── Dashboard/
 │   │   │   ├── HardwareInfo/
 │   │   │   ├── StartupApps/
+│   │   │   ├── BootAnalysis/
 │   │   │   ├── SystemCleaner/
 │   │   │   ├── DiskTools/
 │   │   │   ├── Search/
@@ -952,11 +974,13 @@ All periodic polling is centralized in `DataRefreshService`, which owns 5 QTimer
 │   │   │   ├── Processes/
 │   │   │   ├── Uninstaller/
 │   │   │   ├── Resources/
+│   │   │   ├── Network/             (Network Usage page)
 │   │   │   ├── Helpers/
-│   │   │   ├── AptSourceManager/
-│   │   │   ├── GnomeSettings/
-│   │   │   ├── Docker/
-│   │   │   └── Settings/ (placeholder — platform-split)
+│   │   │   ├── SystemLogs/
+│   │   │   ├── AptSourceManager/    (conditional — APT/Homebrew detected)
+│   │   │   ├── GnomeSettings/       (conditional — gsettings detected)
+│   │   │   ├── Docker/              (conditional — docker CLI detected)
+│   │   │   └── Settings/
 │   │   └── static/             Themes, icons, fonts, translations
 │   ├── translations/           34 language .ts files
 │   └── cmake/                  CMake modules

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -1,7 +1,9 @@
 # Nexis — Architecture Review
 
 > A deep and comprehensive review of the Nexis architecture: how logic and UI work together, what's working well, what should change, and where the application should go next.
-> Last updated: 2026-04-21 (Bundle F)
+> Last updated: 2026-06-10 | Version 2.3.13
+>
+> By-the-numbers counts (LOC, page/service/signal/timer/test totals) are kept in a **single canonical table** in [`APPLICATION_OVERVIEW.md` → "By the numbers"](APPLICATION_OVERVIEW.md#project-identity). This document references those figures rather than repeating them, so a single edit there keeps both docs in sync. The CI check `scripts/check_doc_versions.sh` fails the build if either header drifts from `PROJECT_VERSION`.
 
 ---
 
@@ -37,28 +39,29 @@
 
 ## Architecture at a Glance
 
-Nexis is structured as a **four-tier desktop application**:
+Nexis is structured as a **four-tier desktop application**. Tier sizes (page/service/manager/info/tool/util counts) come from the canonical table in [`APPLICATION_OVERVIEW.md`](APPLICATION_OVERVIEW.md#project-identity); the diagram below names the modules at each tier.
 
 ```
 ┌────────────────────────────────────────────────────────────────────┐
-│  UI Layer: 16 QWidget Pages                                       │
-│  Each page owns its .ui file and presentation logic               │
-│  Files: shared/nexis/Pages/*/*.cpp                                │
+│  UI Layer: 15 always-visible QWidget pages + 3 conditional         │
+│  Each page owns its .ui file and presentation logic                │
+│  Files: shared/nexis/Pages/*/*.cpp                                 │
 ├────────────────────────────────────────────────────────────────────┤
-│  Service Layer: 8 Domain Services + NexisPage base class          │
-│  StartupService, FileSearchService, HostService, ProcessService,  │
-│  SystemServiceManager, DockerService, PackageService,             │
-│  DuplicateFinderService                                           │
-│  Files: shared/nexis/Services/*.cpp                               │
+│  Service Layer: 9 Domain Services + NexisPage base class           │
+│  StartupService, FileSearchService, HostService, ProcessService,   │
+│  SystemServiceManager, DockerService, PackageService,              │
+│  DuplicateFinderService, SnapshotService                           │
+│  Files: shared/nexis/Services/*.cpp                                │
 ├────────────────────────────────────────────────────────────────────┤
-│  Manager Layer: 7 Singletons                                      │
-│  InfoManager, AppManager, SettingManager, ToolManager,            │
-│  CleanerService, ScheduleManager, DataRefreshService              │
-│  Files: shared/nexis/Managers/*.cpp                               │
+│  Manager Layer: 8 Singletons                                       │
+│  AppManager, InfoManager, ToolManager, SettingManager,             │
+│  CleanerService, ScheduleManager, ProcessPrefsManager,             │
+│  DataRefreshService                                                │
+│  Files: shared/nexis/Managers/*.cpp                                │
 ├────────────────────────────────────────────────────────────────────┤
-│  Core Library: nexis-core (static lib)                            │
-│  15 Info providers + 8 Tools + 3 Utils                            │
-│  Files: shared/nexis-core/**/*.cpp + {platform}/nexis-core/**     │
+│  Core Library: nexis-core (static lib)                             │
+│  Info providers + Tool classes + Utils (see canonical table)       │
+│  Files: shared/nexis-core/**/*.cpp + {platform}/nexis-core/**      │
 └────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -83,13 +86,13 @@ Nexis is structured as a **four-tier desktop application**:
 - **Root-file writer (FR-81)** — New `FileUtil::writeRootFile(path, content)` wraps `sudoExec("tee", {path}, content)` with a read-back byte compare. Linux-only; the macOS build compiles to a no-op returning false. Shared by FR-81's sysctl.d persistence.
 - **CPU tuning sysfs helper (FR-117)** — New `CpuTuning` namespace in `linux/nexis-core/Info/cpu_tuning.{h,cpp}` centralises sysfs reads/writes for scaling_{min,max}_freq, scaling_governor, intel_pstate/no_turbo, and cpufreq/boost. Handles both per-core and glob-write shell idioms with injection-safe governor validation. Used by `CpuTuningWidget` and by `App::init`'s persist-on-launch re-apply.
 - **QSS theming** — Single stylesheet template with `@token` replacement at runtime
-- **Qt signals** — `SignalMapper` singleton as a lightweight global event bus (9 signals after BUG-82 cleanup)
+- **Qt signals** — `SignalMapper` singleton as a lightweight global event bus (10 signals after BUG-82 cleanup + FR-105's `sigAppFocusChanged` — see canonical "By the numbers" table)
 - **Dashboard widgets** — Dashboard gauges replaced with a family of interchangeable tile widgets inheriting from `MetricTileBase` (abstract base class, FR-53). 8 widget styles available: `MetricTile` (sparkline), `GaugeTile` (¾-arc), `HybridTile` (arc + mini sparkline), `RingTile` (360° ring), `SpeedometerTile` (needle dial), `VuMeterTile` (segmented bar), `DiskTile` (donut chart), and `HealthScoreTile` (composite score). The base class provides 6 shared protected helpers — `createGearButton()`, `repositionGearButton()`, `createFooterLayout()`, `updateTrend()`, `updateGearIcon()`, `applyActionButtonStyle()` — and 5 shared UI members (`mGearButton`, `mLblSubtitle`, `mLblTrend`, `mBtnAction`, `mCurrentTrend`) so each subclass contains only its unique visualization code (FR-77). All styles support three `DisplayMode` values (Normal/Hero/Large) via QSS dynamic properties — mode changes trigger `unpolish()`/`polish()` to re-evaluate QSS selectors for per-mode font sizing. CPU and Memory are independent tile instances (the combined `HeroCard` was removed in FR-50). `NetworkTile` uses dual `QChart` instances (separate RX/TX sparklines) and is excluded from style switching. `DiskTile` uses custom `QPainter` donut chart and exposes `setDriveHealth()` for cross-tile data flow. `DashboardTileWrapper` (FR-51) uses the decorator pattern to add edit-mode mouse handling (drag-and-drop, snap-to-grid resizing) and style switching (`setInnerWidget()` swaps the inner tile at runtime, FR-53). Per-tile style persisted in layout JSON via SettingManager. `DashboardPage::createTile()` factory method instantiates the correct tile class by style string. `HealthScoreTile` (FR-73) is a specialized tile showing a composite 0–100 health score aggregated from 6 components (CPU, memory, disk, temperature, battery, SMART) via `HealthScoreCalculator` helper; unavailable components have their weights redistributed proportionally. In Large/Hero mode, per-component breakdown bars are drawn in `paintEvent`
 - **Maintenance Wizard** — `MaintenanceWizardDialog` (FR-83) is a modal QDialog launched from the Health Score tile's quick action button. It orchestrates 4 existing services (CleanerService, ToolManager, InfoManager, HealthScoreCalculator) via `QtConcurrent::run()` with `QMetaObject::invokeMethod()` for cross-thread result marshaling. Thread-safe completion counting via `QAtomicInt`. Custom types (`CleanerService::ScanResult`, `QList<OrphanPackage>`, `UpdateCheckResult`) registered with `qRegisterMetaType` for cross-thread signals. Follows the `ExclusionManagerDialog` pattern (programmatic QDialog, no .ui file, DI constructor with singleton fallbacks).
 - **Sidebar** — Sidebar navigation buttons are built programmatically in `app.cpp` (not defined in `.ui`) with grouped sections and collapse animation driven by sidebar collapse animation
 - **CommandPalette** — `Ctrl+K` global command palette widget (`command_palette.h/.cpp`) for keyboard-driven navigation and actions
 
-**Scale:** ~6,000–7,000 lines of C++ across core library + services + GUI, 16 pages, 34 translations, 3 themes.
+**Scale:** see the canonical "By the numbers" table in [`APPLICATION_OVERVIEW.md`](APPLICATION_OVERVIEW.md#project-identity) for LOC, page/service/manager counts, themes, translations, and tests.
 
 ---
 
@@ -137,10 +140,10 @@ class CpuInfoMacOS : public CpuInfo {
 
 ### 2. Singleton Manager Facades
 
-Six manager singletons act as **stable API surfaces** over the core library:
+Eight manager singletons (see canonical "By the numbers" table) act as **stable API surfaces** over the core library:
 
 ```cpp
-// shared/nexis/Managers/info_manager.h — facade over 13 Info classes
+// shared/nexis/Managers/info_manager.h — facade over the Info classes
 class InfoManager {
 public:
     static InfoManager *ins();
@@ -153,13 +156,13 @@ public:
     void updateMemoryInfo();
     quint64 getMemUsed() const;
     quint64 getMemTotal() const;
-    // ... 50+ methods across 13 info providers
+    // ... 50+ methods across the info providers
 
 private:
     std::unique_ptr<CpuInfo> ci;     // Platform subclass via factory
     std::unique_ptr<MemoryInfo> mi;
     std::unique_ptr<DiskInfo> di;
-    // ... 13 total — #ifdef Q_OS_MACOS in constructor
+    // ... one unique_ptr per Info class — #ifdef Q_OS_MACOS in constructor
 };
 ```
 
@@ -169,7 +172,7 @@ private:
 - **Centralized refresh** — `updateMemoryInfo()` ensures a single refresh call feeds all consumers
 - **Minimal boilerplate** — no DI frameworks, no factories, no configuration files
 
-**Assessment:** For a ~5,000-line desktop app with no unit tests, singletons are **pragmatically correct**. The anti-pattern critique of singletons assumes multi-threaded systems or test-heavy codebases. Nexis is single-threaded GUI with a single user. The managers are effectively namespaced globals — and that's fine at this scale.
+**Assessment:** For a single-process Qt desktop app with the test coverage tracked in the canonical "By the numbers" table, singletons are **pragmatically correct**. The anti-pattern critique of singletons assumes multi-threaded systems or test-heavy codebases. Nexis is single-threaded GUI with a single user. The managers are effectively namespaced globals — and that's fine at this scale.
 
 ---
 
@@ -247,7 +250,7 @@ if (ToolManager::ins()->checkDocker()) {
 A lightweight singleton event bus handles app-wide notifications:
 
 ```cpp
-// shared/nexis/Managers/signal_mapper.h
+// shared/nexis/signal_mapper.h
 class SignalMapper : public QObject {
     Q_OBJECT
 signals:
@@ -257,20 +260,21 @@ signals:
     void sigKioskToggleRequested();
     void sigKioskModeChanged(bool enabled);
     void sigAppVisibilityChanged(bool visible);
-    void sigCleanableSizeChanged(quint64 totalBytes);
-    void sigDashboardLayoutReset();
+    void sigAppFocusChanged(bool focused);         // FR-105: drives PowerMode cadence
+    void sigNavigateToPage(const QString &pageTitle);
+    void sigCleanableSizeChanged(quint64 bytes);
     void sigDashboardFooterChanged(bool visible);
 };
 ```
 
 **Usage pattern:**
 - Settings page changes theme → emits `sigChangedAppTheme()`
-- All 16 pages listen → reload theme-dependent icons, GIF loaders, and colors
+- Every page listens → reloads theme-dependent icons, GIF loaders, and colors
 - Dashboard kiosk button → emits `sigKioskToggleRequested()` → App toggles kiosk mode → emits `sigKioskModeChanged(bool)` → Dashboard button swaps icon, tray action syncs checkmark
 - App minimized/restored → emits `sigAppVisibilityChanged(bool)` → DataRefreshService pauses/resumes polling
 - No page needs a pointer to any other page — complete decoupling
 
-**Assessment:** With 9 signals (after BUG-82 cleanup removed unused signals), this is still **appropriately simple**. The kiosk mode signals (FR-30), visibility signal (FR-37), `sigNavigateToPage` (FR-42), cleanable-size signal (FR-44), and dashboard footer visibility signal (FR-75) demonstrate the pattern working well for decoupled communication between App, DashboardPage, DataRefreshService, SystemCleanerPage, SettingsPage, and the CommandPalette. A full event bus library (like eventpp) would be overkill until the signal count grows significantly (15+). SignalMapper remains stable and focused on app-wide lifecycle events, while DataRefreshService handles domain-specific data delivery signals (9 core system metrics + 1 per-interface network snapshot + 2 background checks + 1 background health check = 13 data signals).
+**Assessment:** With 10 signals today (BUG-82 cleanup removed unused signals; FR-105 added `sigAppFocusChanged`; the unused `sigDashboardLayoutReset` was removed when Reset Layout switched to a direct method call), this is still **appropriately simple**. The kiosk mode signals (FR-30), visibility signal (FR-37), focus signal (FR-105), `sigNavigateToPage` (FR-42), cleanable-size signal (FR-44), and dashboard footer visibility signal (FR-75) demonstrate the pattern working well for decoupled communication between App, DashboardPage, DataRefreshService, SystemCleanerPage, SettingsPage, and the CommandPalette. A full event bus library (like eventpp) would be overkill until the signal count grows significantly (15+). SignalMapper remains stable and focused on app-wide lifecycle events, while DataRefreshService handles domain-specific data delivery signals (see the canonical "By the numbers" table for the current `DataRefreshService` signal count).
 
 ---
 
@@ -431,7 +435,7 @@ Both checks emit `qWarning()` at runtime (visible in debug output) without alter
 
 #### ~~2A. Centralized DataRefreshService~~ (Done)
 
-**Status:** Completed in Phase 8 (FR-37). Created `DataRefreshService` singleton (`shared/nexis/Managers/data_refresh_service.{h,cpp}`) with 5 QTimers (1s fast, 5s medium, 30s slow, configurable process, 1h update) and 14 typed data signals (`cpuUpdated`, `memoryUpdated`, `networkUpdated`, `networkPerInterfaceUpdated`, `diskIOUpdated`, `gpuUpdated`, `tempUpdated`, `fanUpdated`, `batteryUpdated`, `diskUsageUpdated`, `diskHealthUpdated`, `processesUpdated`, `systemUpdatesChecked`, `repoHealthChecked`). `networkPerInterfaceUpdated` (SSO-351) carries a `QHash<QString, NetInterfaceStats>` snapshot so `NetUsageTracker` can record traffic for every up+running interface; the legacy `networkUpdated(rx, tx)` is retained for the live-rate displays which only need default-iface totals. The `memoryUpdated` signal was updated in FR-57 to use a `MemorySnapshot` struct (replacing 4 separate `quint64` parameters) carrying wired/active/inactive/compressed/available/pressureLevel fields alongside the original used/total/swapUsed/swapTotal. The `fanUpdated` signal was added in BUG-70 (previously fan updates piggybacked on `tempUpdated`). The `systemUpdatesChecked` signal was added in FR-60 for the hourly system update check, which runs via `QtConcurrent::run()` to avoid blocking the UI thread. This signal is consumed by `App` (sidebar badge update + tray notification) and `APTSourceManagerPage` (Available Updates tree widget), not by `DashboardPage` — the original dashboard tile approach was replaced with a sidebar badge + package page integration during the FR-60 redesign. The `repoHealthChecked` signal was added for repository health dashboard validation (chained after update checks, emits `RepoHealthCache` with per-repo health results), consumed by `APTSourceManagerPage` for card enrichment and side panel display.
+**Status:** Completed in Phase 8 (FR-37). Created `DataRefreshService` singleton (`shared/nexis/Managers/data_refresh_service.{h,cpp}`) with 5 QTimers (1s fast, 5s medium, 30s slow, configurable process, 1h update) and 15 typed data signals — `cpuUpdated`, `memoryUpdated`, `networkUpdated`, `networkPerInterfaceUpdated`, `diskIOUpdated`, `gpuUpdated`, `tempUpdated`, `fanUpdated`, `batteryUpdated`, `diskUsageUpdated`, `diskHealthUpdated`, `processesUpdated`, `systemUpdatesChecked`, `repoHealthChecked`, plus Linux-only `psiUpdated` (FR-124). `networkPerInterfaceUpdated` (SSO-351) carries a `QHash<QString, NetInterfaceStats>` snapshot so `NetUsageTracker` can record traffic for every up+running interface; the legacy `networkUpdated(rx, tx)` is retained for the live-rate displays which only need default-iface totals. The `memoryUpdated` signal was updated in FR-57 to use a `MemorySnapshot` struct (replacing 4 separate `quint64` parameters) carrying wired/active/inactive/compressed/available/pressureLevel fields alongside the original used/total/swapUsed/swapTotal. The `fanUpdated` signal was added in BUG-70 (previously fan updates piggybacked on `tempUpdated`). The `systemUpdatesChecked` signal was added in FR-60 for the hourly system update check, which runs via `QtConcurrent::run()` to avoid blocking the UI thread. This signal is consumed by `App` (sidebar badge update + tray notification) and `APTSourceManagerPage` (Available Updates tree widget), not by `DashboardPage` — the original dashboard tile approach was replaced with a sidebar badge + package page integration during the FR-60 redesign. The `repoHealthChecked` signal was added for repository health dashboard validation (chained after update checks, emits `RepoHealthCache` with per-repo health results), consumed by `APTSourceManagerPage` for card enrichment and side panel display.
 
 Converted Dashboard (removed 3 timers), Resources (removed 2 timers), and Processes (removed 1 timer) to reactive signal subscribers. Added `sigAppVisibilityChanged(bool)` to SignalMapper for pause/resume (kiosk mode overrides). DI constructor parameter follows FR-35 pattern.
 
@@ -470,9 +474,9 @@ Converted Dashboard (removed 3 timers), Resources (removed 2 timers), and Proces
 
 ---
 
-#### 3B. CI Screenshot Regression Tests ✅
+#### 3B. CI Screenshot Regression Tests (local-only)
 
-**Status:** Implemented (FR-41). The `test-ScreenshotTests` executable captures all 11 always-visible pages in both Dark and Light themes (22 screenshots per platform), compares against committed reference PNGs using a Qt-native pixel diff with configurable per-page tolerance, and uploads visual diff artifacts on failure. CI runs screenshot tests as non-blocking (`continue-on-error`) until references stabilize. Linux CI uses Xvfb for headless GUI rendering.
+**Status:** Implemented (FR-41), then **descoped from CI** in WI-19. The `test-ScreenshotTests` executable captures the always-visible pages in both Dark and Light themes, compares against committed reference PNGs using a Qt-native pixel diff with configurable per-page tolerance, and produces visual diff artifacts on failure. The build workflow now explicitly excludes the suite from `ctest` runs via `-E ScreenshotTests` (see `.github/workflows/build.yml`) — environment-dependent rendering on hosted runners produced too many false positives. Screenshot diffs are run locally via `scripts/update_screenshots.sh`; CI continues to assert the always-visible pages compile and link by building `test-ScreenshotTests` itself.
 
 **Architecture change:** The GUI sources were extracted into a `nexis-gui` static library so that both the `nexis` executable and the screenshot test can link against them without duplicating the source list. Reference images are stored in-repo under `tests/reference_screenshots/{platform}/{theme}/`.
 
@@ -505,7 +509,7 @@ public:
 
 **What:** Replace `SignalMapper` with a typed event bus library if the signal count grows beyond ~15.
 
-**When:** Currently 9 signals (SignalMapper) + 14 signals (DataRefreshService) — well within comfort zone. Only consider migration if the signal count grows significantly, or if events need filtering/prioritization.
+**When:** SignalMapper + DataRefreshService signal counts are tracked in the canonical "By the numbers" table — well within comfort zone. Only consider migration if those counts grow significantly, or if events need filtering/prioritization.
 
 **Candidate:** [eventpp](https://github.com/wqking/eventpp) (header-only, C++11+, well-tested).
 
@@ -526,7 +530,7 @@ public:
 | HiDPI | Solved via Dpi::scale() + @dpN tokens | Native support |
 | Animations | Basic (SlidingStackedWidget) | Rich, declarative |
 | Development speed | Qt Designer + QSS (familiar tooling) | QML + JavaScript (new skills) |
-| Existing investment | 16 pages, 29 .ui files, comprehensive QSS | Complete rewrite required |
+| Existing investment | All Pages (see canonical table), 29 .ui files, comprehensive QSS | Complete rewrite required |
 | Migration effort | N/A | 3-6 months minimum |
 | Community contributions | C++/QSS (common skills) | QML (niche skills) |
 
@@ -547,7 +551,7 @@ QML should only be reconsidered if a future feature genuinely requires it (e.g.,
 **Phase 3 (Done):** Expanded test coverage (FR-76) — 8 new test suites, ~151 additional test methods. Extracted parsing logic from 10 Info/Tool/Service classes into public static methods on shared base classes, created fixture data files in `tests/fixtures/`, and wrote comprehensive parser tests. Covers MemoryInfo, CpuInfo, GpuInfo, AptSourceTool, FanInfo, ThermalInfo, BatteryInfo, DiskInfo, and HostService.
 
 **Phase 4 (Done):** UI regression testing (FR-41):
-- Screenshot comparison in CI — 11 pages × 2 themes per platform
+- Screenshot comparison (local-only since WI-19) — always-visible pages × Dark/Light per platform
 - Qt-native pixel diff with configurable per-page tolerance
 - Visual diff artifact upload on CI failure for manual review
 - Non-blocking initially (`continue-on-error`) until references stabilize
@@ -559,7 +563,7 @@ QML should only be reconsidered if a future feature genuinely requires it (e.g.,
 - SettingManager defaults and overrides
 - Integration tests for manager CRUD operations
 
-**Current state:** 21 CTest executables — ~293 unit test methods across 20 suites covering core library parsers, utilities, tool parsing, widget parsing, service logic, manager logic, and theme validation, plus 1 screenshot regression test covering 22 page/theme combinations. Build system refactored to extract `nexis-gui` static library for test linkage. Static parser extraction pattern established for future test additions.
+**Current state:** see the canonical "By the numbers" table in [`APPLICATION_OVERVIEW.md`](APPLICATION_OVERVIEW.md#project-identity) for the live CTest executable / test-method counts. The suites cover core library parsers, utilities, tool parsing, widget parsing, service logic, manager logic, and theme validation, plus 1 screenshot regression test. Build system refactored to extract `nexis-gui` static library for test linkage. Static parser extraction pattern established for future test additions.
 
 ---
 
@@ -592,9 +596,9 @@ QML should only be reconsidered if a future feature genuinely requires it (e.g.,
 1. ~~**Explicit source lists in CMake**~~ — Done (Phase 2)
 2. **Abstract base classes for all platform code** — Compile-time enforcement of platform parity
 3. ~~**Dependency injection on all page constructors**~~ — Done (Phase 6, FR-35): testable without framework overhead
-4. ~~**Centralized DataRefreshService**~~ — Done (Phase 8, FR-37): 4 timers instead of 6 per-page, with pause/resume for battery optimization
+4. ~~**Centralized DataRefreshService**~~ — Done (Phase 8, FR-37): 5 centralized timers (fast/medium/slow/process/update) instead of 6 per-page QTimers, with pause/resume for battery optimization
 5. **QSS token validation** — Build-time warnings for theme inconsistencies
-6. ~~**20-30 unit tests**~~ — Done (Phase 7, FR-36; expanded FR-76, FR-79/FR-80, FR-82, FR-66, FR-68): ~293 test methods across 21 executables covering core parsers, utilities, tools, widget parsers, services, managers, and theme validation
+6. ~~**20-30 unit tests**~~ — Done (Phase 7, FR-36; expanded FR-76, FR-79/FR-80, FR-82, FR-66, FR-68): see the canonical "By the numbers" table in [`APPLICATION_OVERVIEW.md`](APPLICATION_OVERVIEW.md#project-identity) for the live test-method count; coverage spans core parsers, utilities, tools, widget parsers, services, managers, and theme validation
 7. **Still QWidgets** — Proven, stable, with the HiDPI problem solved
 8. **Still singletons** — But with DI constructors as escape hatches for testing
 
@@ -612,7 +616,7 @@ The architecture doesn't need a revolution. It needs **targeted reinforcements**
 | `shared/nexis/Managers/app_manager.cpp` | ~~Add QSS token validation (§2C)~~ Done — token + color format validation added |
 | `shared/nexis/Pages/Dashboard/dashboard_page.cpp` | ~~Primary refactor target for DataRefreshService (§2A)~~ Done — subscribes to DataRefreshService signals, zero timers |
 | `shared/nexis/Pages/Resources/resources_page.cpp` | ~~Secondary refactor target~~ Done — subscribes to DataRefreshService signals, zero timers |
-| `shared/nexis/signal_mapper.h` | Global event bus (9 signals after BUG-82 cleanup) — monitor signal count growth |
+| `shared/nexis/signal_mapper.h` | Global event bus (10 signals — see canonical "By the numbers" table) — monitor signal count growth |
 | `shared/nexis/Pages/Dashboard/metric_tile_base.h/.cpp` | Abstract base class for all dashboard tile styles; defines common interface (setValue, addDataPoint, setDisplayMode, etc.), 6 shared helpers (gear button, footer layout, trend computation, action button styling), and 5 shared UI members (FR-53, FR-77) |
 | `shared/nexis/Pages/Dashboard/metric_tile.h/.cpp` | Sparkline style: QtCharts sparkline + progress bar + trend indicator; DisplayMode (Normal/Hero/Large) via QSS dynamic properties |
 | `shared/nexis/Pages/Dashboard/gauge_tile.h/.cpp` | Gauge style: ¾-circle arc with conical gradient, percentage centered, QPainter-based (FR-53) |

--- a/scripts/check_doc_versions.sh
+++ b/scripts/check_doc_versions.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Verify that the "Version X.Y.Z" header in the living architecture/overview
+# docs matches the CMake PROJECT_VERSION. CLAUDE.md's pre-commit checklist
+# requires these be kept in sync; this script enforces it in CI.
+#
+# Usage: scripts/check_doc_versions.sh
+# Exits 0 on match, 1 on mismatch or missing fields.
+#
+# WI-30 (SSO-3392): added to catch the kind of drift that motivated the
+# audit reconciliation.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+cmake_version="$(sed -n 's/^project([^)]*VERSION \([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' CMakeLists.txt | head -1)"
+if [[ -z "$cmake_version" ]]; then
+  echo "check_doc_versions: could not parse VERSION from CMakeLists.txt project()" >&2
+  exit 1
+fi
+
+mismatch=0
+
+check_doc() {
+  local doc="$1"
+  if [[ ! -f "$doc" ]]; then
+    echo "check_doc_versions: $doc not found" >&2
+    mismatch=1
+    return
+  fi
+
+  # Find a line like "Version 2.3.13" (with optional leading "> Last updated: ... |")
+  local doc_version
+  doc_version="$(grep -oE 'Version [0-9]+\.[0-9]+\.[0-9]+' "$doc" | head -1 | awk '{print $2}')"
+
+  if [[ -z "$doc_version" ]]; then
+    echo "check_doc_versions: $doc has no 'Version X.Y.Z' header" >&2
+    mismatch=1
+    return
+  fi
+
+  if [[ "$doc_version" != "$cmake_version" ]]; then
+    echo "check_doc_versions: $doc header is Version $doc_version, expected $cmake_version (from CMakeLists.txt)" >&2
+    mismatch=1
+    return
+  fi
+
+  echo "check_doc_versions: $doc OK (Version $doc_version)"
+}
+
+check_doc "docs/APPLICATION_OVERVIEW.md"
+check_doc "docs/ARCHITECTURE_REVIEW.md"
+
+if [[ "$mismatch" -ne 0 ]]; then
+  echo "check_doc_versions: one or more docs are out of sync with PROJECT_VERSION ($cmake_version)." >&2
+  echo "  Update the 'Last updated: YYYY-MM-DD | Version X.Y.Z' header in each listed file." >&2
+  exit 1
+fi

--- a/scripts/check_doc_versions.sh
+++ b/scripts/check_doc_versions.sh
@@ -14,7 +14,11 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
-cmake_version="$(sed -n 's/^project([^)]*VERSION \([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' CMakeLists.txt | head -1)"
+# Use grep -oE (POSIX ERE) so this works under both GNU and BSD userlands;
+# `sed -E` with `\+` is GNU-only and silently fails to match on macOS.
+cmake_version="$(grep -oE 'project\([^)]*VERSION [0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt \
+  | head -1 \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
 if [[ -z "$cmake_version" ]]; then
   echo "check_doc_versions: could not parse VERSION from CMakeLists.txt project()" >&2
   exit 1


### PR DESCRIPTION
## Summary

Reconciles `docs/ARCHITECTURE_REVIEW.md` and `docs/APPLICATION_OVERVIEW.md` against the live tree per **SSO-3392 / WI-30** (Audit Remediation, A6 + D3).

Both docs had drifted materially from the code:

- `ARCHITECTURE_REVIEW.md` claimed `~6,000–7,000 LOC` (actual `≈48,700` shared+linux+macos), listed a removed `sigDashboardLayoutReset` and said `"9 signals"` (now 10), and said `DataRefreshService` had `4 timers / 10 signals` (actual `5 / 15` — 14 cross-platform plus Linux-only `psiUpdated`).
- `APPLICATION_OVERVIEW.md` cited settings paths (`~/Library/Preferences/com.nexis.plist`, `~/.config/nexis/nexis.conf`) that don't match the actual `QStandardPaths::AppConfigLocation/settings.ini`, counted `"16 pages"` (now `15 always-visible + 3 conditional`), and repeated the `"CI runs screenshot tests"` claim already invalidated by WI-19 (`ctest -E ScreenshotTests`).
- Both `Last updated` / `Version` headers were stale (`2026-04-21` / `2026-04-23` and `2.3.1` vs `PROJECT_VERSION` `2.3.13`).

## What this PR does

- **Regenerates** the by-the-numbers fields from the tree (LOC counts, signal/timer/test totals) and **consolidates** them into a single canonical "By the numbers" table in `APPLICATION_OVERVIEW.md`. `ARCHITECTURE_REVIEW.md` now links to that table instead of repeating its own (drifted) numbers.
- **Fixes** the settings-path section, the `SignalMapper` signal list (now lists all 10 incl. FR-105's `sigAppFocusChanged`), the `DataRefreshService` timer/signal section, the screenshot-CI claim, and the architecture-at-a-glance diagrams in both docs.
- **Refreshes** both `Last updated: 2026-06-10 | Version 2.3.13` headers.
- **Adds** `scripts/check_doc_versions.sh` (parses `Version X.Y.Z` from each doc, compares to `project(... VERSION ...)` in `CMakeLists.txt`) and wires it into `.github/workflows/build.yml` as a cheap CI step so a drift between the doc header and `PROJECT_VERSION` fails CI on the same PR that introduces it. Verified locally that it passes on the reconciled docs and fails when the header is mutated.

Branched from `native` per the parent plan's "How to work a sub-issue" workflow; **PR, not merge**.

## Test plan

- [x] `bash scripts/check_doc_versions.sh` — passes on the reconciled docs (`Version 2.3.13` in both).
- [x] Drift test: temporarily mutating the doc header to `Version 1.0.0` causes the script to exit non-zero with a precise diff message; restoring the header makes it pass again.
- [ ] CI green on this PR (build + the new `Doc version header check` step on all three matrix legs).
- [ ] Reviewer spot-check that the canonical "By the numbers" table in `APPLICATION_OVERVIEW.md` matches the live tree.

Refs: [SSO-3392](/SSO/issues/SSO-3392), parent [SSO-3360](/SSO/issues/SSO-3360), audit ref A6 / D3, related [SSO-3381 (WI-19)](/SSO/issues/SSO-3381).

🤖 Generated with [Claude Code](https://claude.com/claude-code)