### PR TITLE
ci(macos): add one-shot release verifier (SSO-3493)

### DIFF
--- a/.github/workflows/verify-macos-release.yml
+++ b/.github/workflows/verify-macos-release.yml
@@ -1,0 +1,116 @@
+name: Verify macOS Release
+
+# One-shot verifier for macOS release artifacts (SSO-3493 / audit B3 follow-up).
+# Downloads the DMG from a published release on macos-14, mounts it, extracts the
+# .app, and runs the three notarization checks: CFBundleIdentifier, stapler
+# validate, spctl --assess. Output goes to the run summary and job log.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to verify (e.g. v2.3.14)'
+        required: true
+        type: string
+      expected_bundle_id:
+        description: 'Expected CFBundleIdentifier'
+        required: false
+        default: 'io.github.s4solutionsllc.Nexis'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify ${{ inputs.tag }} on macos-14
+    runs-on: macos-14
+    timeout-minutes: 15
+
+    steps:
+      - name: Download DMG from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifact
+          cd artifact
+          gh release download "${{ inputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'Nexis-*-macOS-arm64.dmg' \
+            --clobber
+          ls -la
+
+      - name: Mount DMG and stage .app
+        id: stage
+        run: |
+          set -euo pipefail
+          DMG=$(ls artifact/Nexis-*-macOS-arm64.dmg | head -1)
+          echo "DMG=$DMG"
+          MOUNT=$(hdiutil attach -nobrowse -readonly "$DMG" | tail -1 | awk '{print $3}')
+          echo "MOUNT=$MOUNT"
+          APP=$(ls -d "$MOUNT"/*.app | head -1)
+          echo "APP=$APP"
+          mkdir -p staged
+          ditto "$APP" "staged/$(basename "$APP")"
+          hdiutil detach "$MOUNT"
+          STAGED_APP="$(pwd)/staged/$(basename "$APP")"
+          echo "STAGED_APP=$STAGED_APP" >> "$GITHUB_OUTPUT"
+          echo "DMG_PATH=$(pwd)/$DMG" >> "$GITHUB_OUTPUT"
+
+      - name: 1) PlistBuddy — CFBundleIdentifier
+        id: bundle_id
+        run: |
+          set -euo pipefail
+          APP="${{ steps.stage.outputs.STAGED_APP }}"
+          ACTUAL=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$APP/Contents/Info.plist")
+          echo "actual=$ACTUAL" >> "$GITHUB_OUTPUT"
+          EXPECTED='${{ inputs.expected_bundle_id }}'
+          echo "Expected: $EXPECTED"
+          echo "Actual:   $ACTUAL"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::CFBundleIdentifier mismatch (expected $EXPECTED, got $ACTUAL)"
+            exit 1
+          fi
+
+      - name: 2) stapler validate — .app
+        id: stapler_app
+        continue-on-error: true
+        run: |
+          set +e
+          APP="${{ steps.stage.outputs.STAGED_APP }}"
+          xcrun stapler validate "$APP"
+          echo "exit_app=$?" >> "$GITHUB_OUTPUT"
+
+      - name: 2b) stapler validate — .dmg (fallback view)
+        id: stapler_dmg
+        run: |
+          set -euo pipefail
+          DMG="${{ steps.stage.outputs.DMG_PATH }}"
+          xcrun stapler validate "$DMG"
+
+      - name: 3) spctl --assess
+        id: spctl
+        run: |
+          set -euo pipefail
+          APP="${{ steps.stage.outputs.STAGED_APP }}"
+          spctl --assess --type execute -vv "$APP"
+
+      - name: 4) codesign -dvv (informational)
+        run: |
+          set -euo pipefail
+          APP="${{ steps.stage.outputs.STAGED_APP }}"
+          codesign -dvv --entitlements - "$APP" 2>&1 | head -40 || true
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## SSO-3493 verification — ${{ inputs.tag }}"
+            echo ""
+            echo "- CFBundleIdentifier (actual): \`${{ steps.bundle_id.outputs.actual }}\`"
+            echo "- Expected: \`${{ inputs.expected_bundle_id }}\`"
+            echo "- stapler validate (.app) exit: \`${{ steps.stapler_app.outputs.exit_app }}\` (0 = stapled, non-zero = not stapled directly; check DMG step)"
+            echo "- stapler validate (.dmg): see step output"
+            echo "- spctl --assess: see step output"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/verify-macos-release.yml` — a `workflow_dispatch` verifier that runs on `macos-14` and executes the three SSO-3493 / audit B3 acceptance commands against a published release artifact:

1. `/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier"` against the .app extracted from the DMG (asserts match against expected `io.github.s4solutionsllc.Nexis`).
2. `xcrun stapler validate` against the .app *and* the DMG.
3. `spctl --assess --type execute -vv` against the .app.

Plus an informational `codesign -dvv --entitlements -` block.

## Why

[SSO-3493](/SSO/issues/SSO-3493) requires running these three commands on the first release tag that contains the [SSO-3487](/SSO/issues/SSO-3487) bundle-id change. They're macOS-only — without a verifier workflow, the only options are a maintainer's local Mac or this on-runner script. This automates the check for every release.

## Known finding the verifier will surface

`release.yml` `xcrun stapler staple`s the **.dmg**, not the .app inside it. So `xcrun stapler validate Nexis.app` will fail (no ticket stapled directly), while `xcrun stapler validate Nexis.dmg` will pass. The verifier runs both so we see the gap explicitly. Follow-up to consider amending `release.yml` to also `stapler staple` the inner .app (better UX for cask users on offline first-launch). Tracked separately.

## Test plan

- [ ] Merge this PR.
- [ ] Dispatch via `gh workflow run verify-macos-release.yml -f tag=v2.3.14` and confirm:
  - CFBundleIdentifier step prints `io.github.s4solutionsllc.Nexis`.
  - DMG stapler validate passes.
  - spctl --assess reports `accepted, source=Notarized Developer ID`.
  - .app stapler validate (gap step) reports non-zero — expected.

Refs: [SSO-3493](/SSO/issues/SSO-3493), [SSO-3487](/SSO/issues/SSO-3487), [SSO-3433](/SSO/issues/SSO-3433).

🤖 Generated with [Claude Code](https://claude.com/claude-code)