### PR TITLE
fix(macos): make BTM headers self-contained so Q_OS_MACOS resolves (SSO-3766)

### DIFF
--- a/shared/nexis/Pages/StartupApps/btm_reset_dialog.h
+++ b/shared/nexis/Pages/StartupApps/btm_reset_dialog.h
@@ -6,6 +6,8 @@
 #ifndef BTM_RESET_DIALOG_H
 #define BTM_RESET_DIALOG_H
 
+#include <QtGlobal>
+
 #ifdef Q_OS_MACOS
 
 #include <QDialog>

--- a/shared/nexis/Pages/StartupApps/btm_row.h
+++ b/shared/nexis/Pages/StartupApps/btm_row.h
@@ -6,6 +6,8 @@
 #ifndef BTM_ROW_H
 #define BTM_ROW_H
 
+#include <QtGlobal>
+
 #ifdef Q_OS_MACOS
 
 #include <QWidget>


### PR DESCRIPTION
## Summary

- `shared/nexis/Pages/StartupApps/btm_row.h` and `btm_reset_dialog.h` wrap the class in `#ifdef Q_OS_MACOS` but don't include `<QtGlobal>` first.
- In the matching `.cpp` files the very first line is `#include \"btm_row.h\"` / `#include \"btm_reset_dialog.h\"` — at that point nothing has pulled in QtGlobal, so `Q_OS_MACOS` is undefined and the entire class declaration is hidden. The `#ifdef Q_OS_MACOS` block inside the `.cpp` then also evaluates false, so the constructor/methods are skipped. Both TUs compile to empty `.o` files on macOS (matches the run log: \"Building CXX object …/btm_row.cpp.o\" with no resulting symbols).
- AUTOMOC has the same problem: `moc` preprocesses `btm_row.h` without QtGlobal, never sees `Q_OBJECT`, and emits no `moc_btm_row.cpp` — which is why `BtmRow::staticMetaObject` is also undefined.
- That explains all four linker errors in [SSO-3766](https://github.com/s4solutionsllc/Nexis/issues) for runs against `526624b` and the current `native` HEAD `491e731`.

The bug report's hypothesis was a CMake target-membership mismatch — that's a red herring. `GUI_PLAT_SRCS` (under `if(APPLE)`) already lists both `.cpp` files (added in #152), and `add_library(nexis-gui STATIC … \${GUI_PLAT_SRCS} …)` consumes it. The sources ARE wired into `nexis-gui`; they just preprocess to nothing.

Fix: add `#include <QtGlobal>` immediately before the `#ifdef Q_OS_MACOS` guard in both BTM headers, making them self-contained regardless of include order. Other macOS-only widgets in this codebase (`macos/nexis/Pages/Homebrew/homebrew_page.h`, `macos/nexis/Pages/Uninstaller/crumbs_review_dialog.h`) need no guard at all because the whole `macos/` subtree is APPLE-only; BTM is the unusual case because it lives under `shared/nexis/Pages/...` per the FW-10 architecture-review exception, so the guard has to work.

Linux is unaffected — the BTM files aren't in `GUI_PLAT_SRCS` on Linux, so they never get compiled and the header change is invisible to the Linux leg.

## Test plan

- [ ] macOS (ARM64) CI green: `nexis.app` links, every test executable that pulls in `libnexis-gui.a` (CleanerExclusionTests, CleanerServiceTests, CleanerAccessNeededTests, InfoManagerWiringTests, DataRefreshServiceTests, FileSearchServiceTests, IndicatorFallbackTests) links.
- [ ] `ctest` runs end-to-end on macOS (previously the leg never reached `ctest`).
- [ ] Linux x64 / Linux ARM64 stay green (no behavior change — sources weren't compiled there).
- [ ] After merge, re-trigger CI on PR #145 (or any rebased PR) and confirm the macOS leg now goes green — this is the acceptance criterion called out in SSO-3766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)