### PR TITLE
fix(macos): emit BTM widget symbols by dropping broken Q_OS_MACOS guards (SSO-3767)

### DIFF
--- a/shared/nexis/Pages/StartupApps/btm_reset_dialog.cpp
+++ b/shared/nexis/Pages/StartupApps/btm_reset_dialog.cpp
@@ -1,7 +1,5 @@
 #include "btm_reset_dialog.h"
 
-#ifdef Q_OS_MACOS
-
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QLineEdit>
@@ -70,5 +68,3 @@ void BtmResetDialog::onConfirmTextChanged(const QString &text)
 {
     mResetBtn->setEnabled(text.trimmed() == QLatin1String(kConfirmToken));
 }
-
-#endif // Q_OS_MACOS

--- a/shared/nexis/Pages/StartupApps/btm_reset_dialog.h
+++ b/shared/nexis/Pages/StartupApps/btm_reset_dialog.h
@@ -6,8 +6,6 @@
 #ifndef BTM_RESET_DIALOG_H
 #define BTM_RESET_DIALOG_H
 
-#ifdef Q_OS_MACOS
-
 #include <QDialog>
 
 class QLineEdit;
@@ -29,7 +27,5 @@ private:
     QLineEdit *mConfirmEdit = nullptr;
     QPushButton *mResetBtn = nullptr;
 };
-
-#endif // Q_OS_MACOS
 
 #endif // BTM_RESET_DIALOG_H

--- a/shared/nexis/Pages/StartupApps/btm_row.cpp
+++ b/shared/nexis/Pages/StartupApps/btm_row.cpp
@@ -1,7 +1,5 @@
 #include "btm_row.h"
 
-#ifdef Q_OS_MACOS
-
 #include "utilities.h"
 
 #include <QHBoxLayout>
@@ -110,5 +108,3 @@ bool BtmRow::matches(const QString &needle) const
         || mRecord.identifier.contains(needle, Qt::CaseInsensitive)
         || mRecord.executablePath.contains(needle, Qt::CaseInsensitive);
 }
-
-#endif // Q_OS_MACOS

--- a/shared/nexis/Pages/StartupApps/btm_row.h
+++ b/shared/nexis/Pages/StartupApps/btm_row.h
@@ -6,8 +6,6 @@
 #ifndef BTM_ROW_H
 #define BTM_ROW_H
 
-#ifdef Q_OS_MACOS
-
 #include <QWidget>
 
 #include <Info/btm_parser.h>
@@ -30,7 +28,5 @@ public:
 private:
     BtmRecord mRecord;
 };
-
-#endif // Q_OS_MACOS
 
 #endif // BTM_ROW_H


### PR DESCRIPTION
## Summary
- Fix the pre-existing macOS ARM64 linker error against `native` (Undefined symbols for `BtmResetDialog::BtmResetDialog`, `BtmRow::staticMetaObject`, `BtmRow::BtmRow`, `BtmRow::matches`).
- Root cause is **not** missing CMake entries — btm_reset_dialog.{cpp,h} and btm_row.{cpp,h} are already attached to `nexis-gui` under `if(APPLE)` at `CMakeLists.txt:482-497`/`596-602`.
- Each of the four BTM files wraps its body in `#ifdef Q_OS_MACOS` **before** any Qt header is pulled in. `Q_OS_MACOS` only becomes defined via `<QtGlobal>`, so the guard is always false at that point and the four translation units compile down to empty `.o` files on macOS. `startup_apps_page.cpp` references the symbols from inside its own `#ifdef Q_OS_MACOS` block (which works there because the page's own .h pulls in Qt first) — hence undefined-symbol errors at link.
- Removed the broken/redundant guards. CMakeLists already scopes the sources to APPLE; `startup_apps_page.{cpp,h}` continues to include the headers only inside `#ifdef Q_OS_MACOS`, so the headers stay invisible to the Linux build. Matches the convention used by `btm_parser.{h,cpp}` (also macOS-only, no guard).

## Test plan
- [ ] macOS ARM64 CI links `nexis-gui` / `nexis` against `native` cleanly (no Undefined-symbols failure for BtmRow / BtmResetDialog).
- [ ] Linux CI build still green — Linux compilation never includes the BTM headers (verified by grep: only consumer is `startup_apps_page.cpp`, guarded).
- [ ] StartupAppsPage on macOS still renders the BTM section and the "Repair BTM…" dialog.

Closes SSO-3767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)