### PR TITLE
fix(release): cliff.toml — newline between commits (SSO-3839)

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -9,7 +9,8 @@ body = """
 {% if version %}## {{ version }} — {{ timestamp | date(format="%Y-%m-%d") }}{% else %}## Unreleased{% endif %}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
-{% for commit in commits %}- {{ commit.message | upper_first }}{% if commit.scope %} (*{{ commit.scope }}*){% endif %}{% endfor %}
+{% for commit in commits %}- {{ commit.message | upper_first }}{% if commit.scope %} (*{{ commit.scope }}*){% endif %}
+{% endfor -%}
 {% endfor %}
 """
 trim = true


### PR DESCRIPTION
## Summary

Defect in the shared `cliff.toml` body template: the inner Tera commit loop had no newline between iterations, so every bullet in a group concatenated onto one line. Discovered when DevOps generated Polymarket's v0.1.0 CHANGELOG.md from this template — Polymarket PR #19 fixes it there and regenerates the malformed v0.1.0 entry.

Nexis maintains a **hand-curated** Keep-a-Changelog `CHANGELOG.md` and does not generate it from git-cliff, so this PR only fixes the template — no CHANGELOG.md regen is needed.

## Test plan

- [x] Diff is a single 2-line change in `cliff.toml`, byte-identical to the Polymarket and Kinship sister PRs.
- [ ] DevOps merge gate (CTO-approved per separation of duties — DevOps-authored PR).

Closes part of SSO-3839.

🤖 Generated with [Claude Code](https://claude.com/claude-code)