### PR TITLE
docs(homebrew): brew trust for HB 6.0 + sync AUR files to 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,16 @@ Also works with `paru` or any other AUR helper. Builds from source — requires 
 
 ```bash
 brew tap s4solutionsllc/nexis
+brew trust s4solutionsllc/nexis        # required on Homebrew 6.0+ (third-party tap)
 brew install --cask nexis
 ```
 
 Requires macOS 12+ (Monterey) on Apple Silicon. Updates are delivered via `brew upgrade --cask nexis`.
+
+> **Homebrew 6.0+** requires third-party taps to be trusted before their casks
+> will load. Without `brew trust`, `brew install`/`upgrade`/`outdated` refuse the
+> cask with `Refusing to load cask … from untrusted tap`, so new releases never
+> appear. Trusting the tap once is sufficient; future upgrades work normally.
 
 ## Screenshots
 

--- a/linux/aur/.SRCINFO
+++ b/linux/aur/.SRCINFO
@@ -1,12 +1,11 @@
 pkgbase = nexis
 	pkgdesc = Linux system optimizer and monitoring tool
-	pkgver = 2.3.3
+	pkgver = 2.4.0
 	pkgrel = 1
 	url = https://github.com/s4solutionsllc/Nexis
 	arch = x86_64
 	arch = aarch64
 	license = GPL-3.0-only
-	checkdepends = xorg-server-xvfb
 	makedepends = cmake
 	makedepends = gcc
 	makedepends = make
@@ -14,7 +13,8 @@ pkgbase = nexis
 	depends = qt6-base
 	depends = qt6-charts
 	depends = qt6-svg
-	source = nexis-2.3.3.tar.gz::https://github.com/s4solutionsllc/Nexis/archive/refs/tags/v2.3.3.tar.gz
-	sha256sums = SKIP
+	options = !lto
+	source = nexis-2.4.0.tar.gz::https://github.com/s4solutionsllc/Nexis/archive/refs/tags/v2.4.0.tar.gz
+	sha256sums = 688a58f90a609f277eed460bc69ce82ce28241822f213c378bc80410b68b5d7b
 
 pkgname = nexis

--- a/linux/aur/PKGBUILD
+++ b/linux/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Luke Simpson <luke@s4solutions.ai>
 pkgname=nexis
-pkgver=2.3.13
+pkgver=2.4.0
 pkgrel=1
 pkgdesc="Linux system optimizer and monitoring tool"
 arch=('x86_64' 'aarch64')
@@ -15,7 +15,7 @@ makedepends=('cmake' 'gcc' 'make' 'qt6-tools')
 # build using plain objects that any linker handles.
 options=('!lto')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/s4solutionsllc/Nexis/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('688a58f90a609f277eed460bc69ce82ce28241822f213c378bc80410b68b5d7b')
 
 build() {
     # GH#82: in-tree LLD auto-selection is now OFF by default (see

--- a/website/src/components/PackageManagerInstall.astro
+++ b/website/src/components/PackageManagerInstall.astro
@@ -15,9 +15,10 @@ sudo apt install nexis`,
     label: 'Homebrew (macOS)',
     platform: 'macos',
     install: `brew tap s4solutionsllc/nexis
+brew trust s4solutionsllc/nexis
 brew install --cask nexis`,
     upgrade: `brew upgrade --cask nexis`,
-    note: 'Requires macOS 12+ on Apple Silicon. The tap is updated automatically on each release.',
+    note: 'Requires macOS 12+ on Apple Silicon. The tap is updated automatically on each release. Homebrew 6.0+ requires the one-time "brew trust" above before it will load the cask.',
   },
 ];
 ---


### PR DESCRIPTION
## Context

After the v2.4.0 release, all three package channels' publish jobs ran green, and the **published** state is current everywhere:

| Channel | Published | Status |
|---|---|---|
| APT / PPA | 2.4.0 | ✅ |
| AUR (`.SRCINFO` / RPC) | 2.4.0-1 | ✅ |
| Homebrew tap cask | 2.4.0 | ✅ (content correct) |

The reported "Homebrew isn't showing the latest release" is **not** a stale tap — it's that **Homebrew 6.0 refuses to load casks from untrusted third-party taps by default** (`HOMEBREW_REQUIRE_TAP_TRUST` is now the default; the opt-out `HOMEBREW_NO_REQUIRE_TAP_TRUST` is documented as "not recommended and will be [removed]"). So `brew install --cask nexis` / `brew upgrade` / `brew outdated` all error with:

> Error: Refusing to load cask s4solutionsllc/nexis/nexis from untrusted tap.

and 2.4.0 never surfaces. Trust is per-user (`~/.homebrew/trust.json`) — there is no maintainer-side global trust — so the only fix is to document the one-time `brew trust` step.

## Changes

- **README.md** — add `brew trust s4solutionsllc/nexis` to the Homebrew install block + an explanatory note.
- **website/src/components/PackageManagerInstall.astro** — same trust step in the Homebrew tab + note.
- **linux/aur/PKGBUILD, linux/aur/.SRCINFO** — resync the checked-in copies (were 2.3.13 / 2.3.3 and internally inconsistent) to mirror exactly what's published on AUR for 2.4.0. AUR itself was already correct; this only fixes the drifted in-repo copies.

## Related

The tap cask's deprecated `depends_on macos:` syntax is fixed separately in s4solutionsllc/homebrew-nexis#2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)