### PR TITLE
docs: add qt6-qttools-devel to Fedora build deps (SSO-3946)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ sudo apt install cmake g++ qt6-base-dev qt6-charts-dev qt6-svg-dev \
 **Fedora / RHEL:**
 ```bash
 sudo dnf install cmake gcc-c++ qt6-qtbase-devel qt6-qtcharts-devel \
-  qt6-qtsvg-devel qt6-linguist
+  qt6-qtsvg-devel qt6-qttools-devel qt6-linguist
 ```
 
 **Arch Linux:**

--- a/website/src/components/BuildFromSource.astro
+++ b/website/src/components/BuildFromSource.astro
@@ -14,7 +14,7 @@ make -j$(nproc)`,
     id: 'fedora',
     label: 'Fedora',
     code: `sudo dnf install qt6-qtbase-devel qt6-qtcharts-devel qt6-qtsvg-devel \\
-  qt6-linguist adwaita-icon-theme cmake gcc-c++
+  qt6-qttools-devel qt6-linguist adwaita-icon-theme cmake gcc-c++
 
 mkdir -p build && cd build
 cmake ..


### PR DESCRIPTION
## Summary

Fixes #162.

The Fedora build instructions told users to install `qt6-linguist`, which ships the `lupdate`/`lrelease` binaries but **not** the CMake development files needed to link against Qt Linguist. Those live in `qt6-qttools-devel` (there is no `qt6-linguist-devel`), so building Nexis on a fresh Fedora install fails at configure time.

This PR adds `qt6-qttools-devel` to the Fedora `dnf install` command in:

- `README.md`
- `website/src/components/BuildFromSource.astro`

## Test plan

- [x] Updated commands match the reporter's correction in GH#162
- [ ] Reporter (or CI on a Fedora image) confirms a clean build from a fresh dnf install

Linked Paperclip issue: SSO-3946.