### PR TITLE
fix(tests): gate FW-15 battery-threshold test to Linux (SSO-3743)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,8 +46,17 @@ add_nexis_test(NAME RepoRepairEngineTests SOURCES core/test_repo_repair_engine.c
 add_nexis_test(NAME FanInfoTests      SOURCES core/test_fan_info.cpp)
 add_nexis_test(NAME ThermalInfoTests  SOURCES core/test_thermal_info.cpp)
 add_nexis_test(NAME BatteryInfoTests  SOURCES core/test_battery_info.cpp)
-add_nexis_test(NAME BatteryChargeThresholdTests SOURCES core/test_battery_charge_threshold.cpp)
 add_nexis_test(NAME DiskInfoTests     SOURCES core/test_disk_info.cpp)
+
+# FW-15 (SSO-3743): battery charge-threshold control is Linux-only — the
+# header/source live under linux/nexis-core and are compiled into nexis-core
+# only on Linux (see CMakeLists.txt CORE_PLAT_SRCS). The test links nexis-core
+# and includes Info/battery_charge_threshold.h, so registering it on macOS
+# breaks the build (header not found). Gate it to Linux like NetworkInfoTests.
+if(UNIX AND NOT APPLE)
+  add_nexis_test(NAME BatteryChargeThresholdTests
+    SOURCES core/test_battery_charge_threshold.cpp)
+endif()
 add_nexis_test(NAME PowerProfileTests SOURCES core/test_power_profile_info.cpp)
 add_nexis_test(NAME PackageToolTests  SOURCES core/test_package_tool.cpp)
 add_nexis_test(NAME DockerToolTests   SOURCES core/test_docker_tool.cpp)


### PR DESCRIPTION
## Problem

`macOS (ARM64)` CI has been failing on `native` since d76023a6 (FW-15
battery charge-threshold feature), which breaks **every** open PR — including
the unrelated AUR write-back PR #166 where this surfaced.

```
tests/core/test_battery_charge_threshold.cpp:9:10: fatal error:
'Info/battery_charge_threshold.h' file not found
```

## Root cause

`BatteryChargeThresholdTests` was registered unconditionally in
`tests/CMakeLists.txt`, but battery charge-threshold control is **Linux-only**:
the header/source live under `linux/nexis-core/Info/` and are compiled into
`nexis-core` only on the non-APPLE branch (`CORE_PLAT_SRCS` in the root
`CMakeLists.txt`). The test links `nexis-core` and includes
`Info/battery_charge_threshold.h`, so on macOS the header isn't on the include
path and the build fails.

The "compile the source directly" pattern (ProcInfoParserTests) doesn't apply
here because the `add_nexis_test` macro always links `nexis-core`, which on
Linux already contains the symbols — compiling the source again would cause
duplicate-symbol link errors.

## Fix

Gate the test with `if(UNIX AND NOT APPLE)`, matching the existing
`NetworkInfoTests` precedent for Linux-only sources.

## Verification

Clean macOS Release build (`cmake -B build … && cmake --build build`) completes
with exit 0 and no compile errors; the full test suite builds. The gated target
is correctly absent from the macOS configure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)