### PR TITLE
chore(macos): bump Qt floor to 6.8 LTS; sunset Intel (SSO-3733)

### DIFF
--- a/.github/workflows/ppa.yml
+++ b/.github/workflows/ppa.yml
@@ -70,7 +70,14 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        series: [noble, questing, jammy]
+        # SSO-3733 / FW-06: Qt floor raised to 6.8 in CMakeLists.txt. Ubuntu
+        # 24.04 (Noble) ships Qt 6.4 and 22.04 (Jammy) ships Qt 6.2, so
+        # neither series can satisfy the floor from its archive Qt. Plucky
+        # (25.04) ships Qt 6.8+; Questing (25.10) ships Qt 6.8+. Users on
+        # Noble/Jammy can install via AppImage or AUR until they upgrade.
+        # See RELEASE.md "Currently supported targets" and CHANGELOG.md
+        # v2.6.0 [Unreleased] for the user-facing announcement.
+        series: [plucky, questing]
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **macOS Intel (x86_64) builds formally sunset; arm64-only floor codified (SSO-3733 / FW-06):** The macOS `.dmg` has been Apple Silicon (`arm64`) only since the CI matrix moved to `macos-14`; this release records that as a supported-platform decision rather than an implicit CI artifact. macOS 26 ("Tahoe") is the last macOS to boot on Intel and Rosetta 2 is being phased out; macOS 27 is Apple-silicon-only. No Intel runner is being added and no universal `.dmg` is being shipped — Intel users on macOS 26 can continue running prior builds, and macOS 27+ is Apple Silicon only. `RELEASE.md` § "Currently supported targets" and `docs/APPLICATION_OVERVIEW.md` now reflect the arm64-only macOS reality.
+- **Qt floor raised from 6.4 to 6.8 LTS (SSO-3733 / FW-06):** `find_package(Qt6 6.8 …)` in [CMakeLists.txt](CMakeLists.txt) is now the minimum. 6.8 is the current Qt LTS and backports the macOS 26 ("Tahoe") / Liquid Glass platform fixes — staying at 6.4 was no longer protective on macOS (Homebrew's `qt@6` has been past 6.4 for the entire `macos-14` runner lifetime) and excluded the LTS fix channel for Tahoe rendering. The bump applies globally (Linux + macOS); the practical Linux side-effect is that **Ubuntu 24.04 (Noble) is dropped from the supported PPA series** because Noble ships Qt 6.4 — Plucky (25.04) and Questing (26.04) carry the macOS-26-capable Qt forward. Qt 6.10 (first non-LTS with macOS 26 support) is tracked separately for a future bump once Homebrew and the supported Linux channels both ship it.
+- **`.pkg` macOS installer format explicitly out of scope (SSO-3733 / FW-06):** Recorded a "no `.pkg`" policy line in `RELEASE.md` and `docs/MAINTAINER_SOP.md`. Tahoe skips first-run XProtect for notarized `.dmg`/`.app` artifacts but not for `.pkg` installers, and Tahoe 26.3 saw `.pkg` Gatekeeper rejections in the field. Nexis is a drag-to-`/Applications` `.app`; it does no install-time launchd / scripting work that `.pkg` would justify. Changing macOS distribution format is now a maintainer-only scope decision and must be reopened explicitly.
+
 ## [2.5.0] - 2026-06-12
 
 > [!IMPORTANT]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,17 @@ set(SHARED_DIR   "${PROJECT_ROOT}/shared")
 
 # Activating MOC and searching for the Qt6 dependencies
 set(CMAKE_AUTOMOC ON)
-# SSO-3399: Qt 6.4 is the floor — we rely on QFile::moveToTrash (6.3+),
-# std::as_const usage in 6.x signal arg sets, and the Charts theme APIs
-# present in 6.4. Pin the minimum explicitly so configure fails early on
-# older Qt rather than producing cryptic build errors deep in moc/codegen.
-find_package(Qt6 6.4 COMPONENTS Core Gui Widgets Charts Svg Concurrent Network Test REQUIRED)
+# SSO-3399 / SSO-3733: Qt 6.8 LTS is the floor.
+#  - 6.3+: QFile::moveToTrash; 6.x: std::as_const signal arg sets; 6.4: Charts theme APIs.
+#  - 6.8: current Qt LTS; backports macOS 26 ("Tahoe") platform fixes including
+#    Liquid Glass compatibility. macOS 27 ("Golden Gate") is Apple-silicon-only,
+#    which (with CI already running arm64-only on macos-14) is why we formally
+#    sunset Intel x86_64 macOS builds in v2.6.0 (see RELEASE.md / CHANGELOG.md).
+#  - Tracking Qt 6.10 separately; bump when Homebrew qt@6 and the Linux
+#    channels we support both ship >= 6.10. Bumping past 6.4 drops Ubuntu
+#    24.04 (Noble) from the supported PPA series; Plucky (25.04) and
+#    Questing (26.04) cover the gap.
+find_package(Qt6 6.8 COMPONENTS Core Gui Widgets Charts Svg Concurrent Network Test REQUIRED)
 
 # Setting the minimum C++ standard
 set(CMAKE_CXX_STANDARD           17)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -121,7 +121,7 @@ Downstream-triggered (run on success of `Release`):
 
 - `homebrew.yml` — bumps the `s4solutionsllc/homebrew-nexis` Cask to the new DMG.
 - `aur.yml` — publishes the AUR `nexis` package via `KSXGitHub/github-actions-deploy-aur`.
-- `ppa.yml` — uploads source packages to the Launchpad PPA for `noble`, `jammy`, `questing`.
+- `ppa.yml` — uploads source packages to the Launchpad PPA for `plucky`, `questing` (SSO-3733 / FW-06 dropped `noble` + `jammy`; see "Ubuntu 24.04 (Noble) dropped" below).
 
 > **Action pins (WI-09 / SSO-3371).** Every `uses:` in `.github/workflows/` is
 > pinned to a full commit SHA with a trailing `# vX.Y.Z` comment — *never* a
@@ -135,13 +135,18 @@ Downstream-triggered (run on success of `Release`):
 
 ### Currently supported targets
 
-- Linux x86_64 (Ubuntu 24.04 / 24.10 / Debian 12+ / Mint 22)
-- Linux x86_64 (Ubuntu 25.04 Plucky and newer)
+- Linux x86_64 (Ubuntu 25.04 Plucky and newer / Debian 12+ / Mint 22)
 - Linux ARM64 (same matrix, for Pi 5 / Jetson / Graviton)
 - AppImage (any glibc-recent Linux)
-- macOS Apple Silicon (M1/M2/M3/M4) on macOS 14+
+- macOS Apple Silicon (`arm64`) on macOS 14+ — **macOS Intel (`x86_64`) is sunset (SSO-3733 / FW-06)**, see below
 - AUR (Arch + derivatives)
-- Launchpad PPA (`noble`, `jammy`, `questing`)
+- Launchpad PPA (`plucky`, `questing`) — see "Ubuntu 24.04 (Noble) dropped" below
+
+> **macOS Intel (`x86_64`) is formally sunset as of v2.6.0 (SSO-3733 / FW-06).** The CI matrix has produced **only** `Nexis-${VERSION}-macOS-arm64.dmg` since the macOS runner moved to `macos-14`; v2.6.0 codifies that as a supported-platform decision rather than an implicit CI artifact. macOS 26 ("Tahoe") is the last macOS to boot on Intel and Rosetta 2 is being phased out; macOS 27 ("Golden Gate") is Apple-silicon-only. No Intel runner will be added; no universal `.dmg` is planned. Intel users on macOS 26 can continue running prior `arm64` builds via Rosetta where supported, but `arm64`-only is the published target going forward.
+
+> **Ubuntu 24.04 (Noble) is no longer a supported PPA series as of v2.6.0 (SSO-3733 / FW-06).** Noble ships Qt 6.4, and the project's Qt floor is now 6.8 LTS (see `CMakeLists.txt`). The `noble` Launchpad source upload is removed from `ppa.yml`; PPA users on 24.04 should upgrade to 25.04 (Plucky) or 26.04 (Questing) — both ship a Qt that satisfies the 6.8 floor. AppImage and the AUR continue to cover older Ubuntu hosts that build against a newer Qt sysroot.
+
+> **macOS distribution format is `.dmg`, not `.pkg` (SSO-3733 / FW-06).** Tahoe (macOS 26) skips the first-run XProtect prompt for notarized `.dmg`/`.app` artifacts but **not** for `.pkg` installers, and Tahoe 26.3 saw `.pkg` Gatekeeper rejections in the field. Nexis is a drag-to-`/Applications` `.app` with no install-time launchd / scripting that would justify `.pkg` (the `ScheduleManager` plists are written at runtime to `~/Library/LaunchAgents/`, not at install time). Changing macOS distribution format is a maintainer-only scope decision and must be reopened explicitly — do not silently add a `.pkg` job to `release.yml`. See `docs/MAINTAINER_SOP.md` for the matching policy line.
 
 > **Windows is not a release target today.** The SSOA-31 issue mentions it;
 > the actual workflow does not produce Windows artifacts. Adding Windows is a

--- a/docs/APPLICATION_OVERVIEW.md
+++ b/docs/APPLICATION_OVERVIEW.md
@@ -87,7 +87,9 @@ Update the table whenever the underlying value changes — the same numbers are 
 
 ## Platform Support
 
-Nexis runs natively on **Linux** and **macOS** (Intel + Apple Silicon). The codebase uses compile-time platform selection: shared code in `shared/`, with platform-specific implementations in `linux/` and `macos/`.
+Nexis runs natively on **Linux** (`x86_64` + `arm64`) and **macOS** (**Apple Silicon `arm64` only** as of v2.6.0 / SSO-3733 / FW-06). The codebase uses compile-time platform selection: shared code in `shared/`, with platform-specific implementations in `linux/` and `macos/`.
+
+> **macOS Intel (`x86_64`) is sunset (SSO-3733 / FW-06).** The shipped `.dmg` has been `arm64`-only since the macOS CI runner moved to `macos-14`. macOS 26 ("Tahoe") is the last macOS to boot on Intel and Rosetta 2 is being phased out; macOS 27 ("Golden Gate") is Apple-silicon-only. The codebase itself remains architecture-agnostic, but the **supported release artifact** is `arm64` macOS only. See `RELEASE.md` § "Currently supported targets" and `CHANGELOG.md` v2.6.0 for details. Qt floor for the macOS build is **Qt 6.8 LTS** (`find_package(Qt6 6.8 …)` in [CMakeLists.txt](../CMakeLists.txt)), which backports macOS 26 / Liquid Glass platform fixes.
 
 ### Linux display server (Wayland / X11)
 

--- a/docs/MAINTAINER_SOP.md
+++ b/docs/MAINTAINER_SOP.md
@@ -133,6 +133,7 @@ during the quarterly release review.
 | Cut a release | Maintainer | Follows `RELEASE.md`. No external sign-off. |
 | Drop a supported platform | CEO | Material to users; needs a comms plan. |
 | Add a supported platform (e.g., Windows) | CEO | Scope authority unchanged by full-time staffing. |
+| Change the macOS distribution format (e.g., `.dmg` → `.pkg`) | Maintainer (re-open SSO-3733 / FW-06 decision) | **Default policy: keep `.dmg`. Do not switch to `.pkg`.** Tahoe (macOS 26) skips the first-run XProtect prompt for notarized `.dmg`/`.app` but **not** for `.pkg`, and Tahoe 26.3 had `.pkg` Gatekeeper rejections in the field. Nexis is a drag-to-`/Applications` `.app` with no install-time launchd/scripting that would justify `.pkg`. Re-opening this is a maintainer-only decision; document the change in `RELEASE.md` and `CHANGELOG.md`. |
 | Accept a CVE coordinated-disclosure embargo | Maintainer | Follow Qt/distro embargo dates. CEO informed. |
 | Change the GPL-3.0 license or "always free" rule | CEO | Hard rule per §2 — refuse politely if asked without CEO. |
 | Accept a third-party PR that adds a non-trivial feature | Maintainer | Standard review. |


### PR DESCRIPTION
## Summary

FW-06 / DECISION-REQUIRED — board accepted the three-question decision memo on [SSO-3733](https://paperclip.ing/SSO/issues/SSO-3733) on 2026-06-13. This PR is the **executor pass** the memo promised:

1. **Intel sunset (codifies CI reality):** the macOS `.dmg` has been `arm64`-only since the runner moved to `macos-14`; this codifies that decision. macOS 26 ("Tahoe") is the last Intel-capable macOS; macOS 27 is Apple-silicon-only and Rosetta 2 is being phased out. No Intel runner, no universal `.dmg`.
2. **Qt 6.8 LTS floor:** `find_package(Qt6 6.4 …)` → `find_package(Qt6 6.8 …)` in `CMakeLists.txt`. 6.8 LTS backports the macOS 26 / Liquid Glass platform fixes; 6.4 LTS is past its support window. Side-effect: Ubuntu 24.04 (Noble) and 22.04 (Jammy) drop from the supported PPA series.
3. **"No `.pkg`" policy:** recorded in `RELEASE.md` and `docs/MAINTAINER_SOP.md`. Tahoe skips the first-run XProtect prompt for notarized `.dmg`/`.app` artifacts but not for `.pkg` installers; Tahoe 26.3 saw `.pkg` Gatekeeper rejections in the field. Nexis is a drag-to-`/Applications` `.app` with no install-time launchd/scripting that would justify `.pkg`.

Full rationale lives in the issue's decision memo at SSO-3733#document-decision-memo. Files in this PR:

- `CMakeLists.txt` — Qt 6.8 floor + comment cross-references SSO-3399 and SSO-3733
- `CHANGELOG.md` `[Unreleased]` `### Changed` — three paragraphs for the three decisions
- `RELEASE.md` "Currently supported targets" — `arm64`-only macOS; PPA reduced to `plucky` + `questing`; explicit no-`.pkg` notice
- `docs/APPLICATION_OVERVIEW.md` "Platform Support" — `arm64`-only macOS line + Qt 6.8 note
- `docs/MAINTAINER_SOP.md` §5 Decision rights — new row "Change the macOS distribution format" defaulting to keep `.dmg`
- `.github/workflows/ppa.yml` — matrix drops `noble` and `jammy`; keeps `plucky` and `questing`

## Known follow-up

The Linux **release** matrix (`release.yml build-linux`, `build.yml`) currently installs `qt6-base-dev` from Noble's apt — that is Qt 6.4. Under the new floor those jobs will fail until migrated to a Plucky/Questing container (mirroring `release.yml build-linux-deb-plucky`). That CI migration is scope-creep for this PR and is being tracked as a sibling follow-up issue under SSO-3733. **Expect the Linux legs to go red on this PR until the sibling lands.** macOS CI (`build-macos`) is the gate for FW-06 acceptance — Homebrew's `qt@6` on `macos-14` is already ≥ 6.8.

## Test plan

- [ ] CI `build-macos` job: `cmake` configures with the new `find_package(Qt6 6.8 …)` floor against Homebrew `qt@6` on `macos-14`.
- [ ] CI `build-macos` job: `ctest` passes (no logic changes; just exercises the build against the new floor).
- [ ] macOS UAT (manual, attached as a PR comment by the maintainer): launch the notarized `.dmg` on macOS 26 ("Tahoe"); verify no XProtect first-run prompt; render check on Dashboard / Charts / Cleaner under Liquid Glass; toggle "Reduce Transparency" without artifacts. The UAT plan lives in `backlog/SSO-3733_uat.md` (gitignored, local to the maintainer worktree).
- [ ] `gh release` artifact list, after follow-up sibling lands: confirm only `.dmg` for macOS (no `.pkg`), and only `plucky` + `questing` PPA uploads (no `noble`, no `jammy`).
- [ ] Doc cross-references: `CHANGELOG.md` → `RELEASE.md` → `docs/APPLICATION_OVERVIEW.md` → `docs/MAINTAINER_SOP.md` all tell the same story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)