### PR TITLE
ci: migrate Linux build matrix to Plucky container (SSO-4093)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,28 +7,38 @@ on:
     branches: [native, master, main]
 
 jobs:
-  build:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
+  # Linux build matrix runs inside a Plucky (25.04) container — see SSO-4093.
+  # FW-06 raised the Qt floor to 6.8 LTS (SSO-3733), which Noble's apt does
+  # not ship. Plucky is the oldest Ubuntu series whose qt6-base-dev satisfies
+  # the floor, so we drop the bare ubuntu-24.04 runner + Noble apt path. The
+  # runner itself stays on ubuntu-24.04 / ubuntu-24.04-arm because that is
+  # what GitHub provides for the matching arch — the build environment comes
+  # from the container image.
+  build-linux:
+    name: Linux (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ubuntu:25.04
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04
-            name: Linux (x64)
+          - arch: x64
+            runner: ubuntu-24.04
             artifact-name: nexis-linux-x64
-            artifact-path: build/output/nexis
-          - os: ubuntu-24.04-arm
-            name: Linux (ARM64)
+          - arch: ARM64
+            runner: ubuntu-24.04-arm
             artifact-name: nexis-linux-arm64
-            artifact-path: build/output/nexis
-          - os: macos-14
-            name: macOS (ARM64)
-            artifact-name: nexis-macos-arm64
-            artifact-path: build/output/nexis.app
 
     steps:
+      # The base ubuntu:25.04 image is minimal — install the bits actions/checkout
+      # and the architecture-gate scripts rely on before any other step runs.
+      - name: Install git and ca-certificates
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq git ca-certificates
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -44,12 +54,10 @@ jobs:
       - name: Architecture gate — no platform headers in shared/Pages
         run: bash scripts/check-pages-no-platform-headers.sh
 
-      # --- Linux dependencies ---
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
+      - name: Install build dependencies
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
+          apt-get install -y -qq \
+            build-essential \
             cmake \
             g++ \
             libgl1-mesa-dev \
@@ -63,56 +71,31 @@ jobs:
             libqt6svg6-dev \
             xvfb
 
-      # --- macOS dependencies ---
-      - name: Install dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          for i in 1 2 3; do
-            brew install qt@6 && break
-            echo "brew install attempt $i failed, retrying in 15s..."
-            sleep 15
-          done
-
-      - name: Configure (Linux)
-        if: runner.os == 'Linux'
+      - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release
 
-      - name: Configure (macOS)
-        if: runner.os == 'macOS'
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(brew --prefix qt@6)
-
       - name: Build
-        run: cmake --build build -j$(sysctl -n hw.ncpu 2>/dev/null || nproc)
+        run: cmake --build build -j$(nproc)
 
       - name: Unit Tests
-        run: |
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            xvfb-run -a ctest --test-dir build --output-on-failure -E ScreenshotTests
-          else
-            ctest --test-dir build --output-on-failure -E ScreenshotTests
-          fi
+        run: xvfb-run -a ctest --test-dir build --output-on-failure -E ScreenshotTests
 
       # ScreenshotTests are kept out of the gating "Unit Tests" step above and
       # run here as a separate, non-blocking step (NEX-3381). They hang
       # indefinitely on ARM64 Linux runners under xvfb (the original reason for
-      # commit 5c173c7), so we skip them on `ubuntu-24.04-arm` and run on
-      # platforms that render deterministically: Linux x64 (xvfb) and macOS.
+      # commit 5c173c7), so we skip them on the ARM64 leg and run on platforms
+      # that render deterministically: Linux x64 (xvfb) and macOS.
       # On failure the test writes actual/reference/diff PNGs to
       # build/tests/test_screenshots/failures/; we upload that directory so the
       # maintainer can review drift and (after visual confirmation) commit the
       # captured actuals as the new baselines via scripts/update_screenshots.sh.
       - name: Screenshot regression tests (non-blocking)
-        if: matrix.os != 'ubuntu-24.04-arm'
+        if: matrix.arch != 'ARM64'
         continue-on-error: true
-        run: |
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            xvfb-run -a ctest --test-dir build --output-on-failure -R ScreenshotTests
-          else
-            ctest --test-dir build --output-on-failure -R ScreenshotTests
-          fi
+        run: xvfb-run -a ctest --test-dir build --output-on-failure -R ScreenshotTests
 
       - name: Upload screenshot diffs
-        if: matrix.os != 'ubuntu-24.04-arm' && !cancelled()
+        if: matrix.arch != 'ARM64' && !cancelled()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshot-diffs-${{ matrix.artifact-name }}
@@ -125,5 +108,57 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.artifact-name }}
-          path: ${{ matrix.artifact-path }}
+          path: build/output/nexis
+          retention-days: 14
+
+  build-macos:
+    name: macOS (ARM64)
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Doc version header check
+        run: bash scripts/check_doc_versions.sh
+
+      - name: Architecture gate — no platform headers in shared/Pages
+        run: bash scripts/check-pages-no-platform-headers.sh
+
+      - name: Install dependencies
+        run: |
+          for i in 1 2 3; do
+            brew install qt@6 && break
+            echo "brew install attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(brew --prefix qt@6)
+
+      - name: Build
+        run: cmake --build build -j$(sysctl -n hw.ncpu)
+
+      - name: Unit Tests
+        run: ctest --test-dir build --output-on-failure -E ScreenshotTests
+
+      - name: Screenshot regression tests (non-blocking)
+        continue-on-error: true
+        run: ctest --test-dir build --output-on-failure -R ScreenshotTests
+
+      - name: Upload screenshot diffs
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: screenshot-diffs-nexis-macos-arm64
+          path: build/tests/test_screenshots/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload build artifact
+        if: success()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nexis-macos-arm64
+          path: build/output/nexis.app
           retention-days: 14

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,11 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-24.04
+    # SSO-4093: run inside the same Plucky (25.04) container build.yml uses
+    # so the CodeQL build path picks up Qt 6.8 (FW-06 floor). Noble's qt6-base-dev
+    # is 6.4 and no longer satisfies CMake's minimum.
+    container:
+      image: ubuntu:25.04
     permissions:
       security-events: write
       packages: read
@@ -37,6 +42,11 @@ jobs:
             build-mode: manual
 
     steps:
+      - name: Install git and ca-certificates
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq git ca-certificates
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -44,8 +54,8 @@ jobs:
       # real build, not a stub.
       - name: Install build dependencies
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
+          apt-get install -y -qq \
+            build-essential \
             cmake \
             g++ \
             libgl1-mesa-dev \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,20 @@ permissions:
 
 jobs:
   # ============================================================================
-  # Linux build matrix: x86_64 + ARM64 — .deb + AppImage + raw binary
+  # Linux build matrix: x86_64 + ARM64 — .deb (Plucky-built) + AppImage + raw
+  # binary. SSO-4093 collapsed the previous Noble `build-linux` + Plucky
+  # `build-linux-deb-plucky` pair into a single Plucky-container job because
+  # FW-06 (SSO-3733) raised the Qt floor to 6.8, which Noble's apt does not
+  # ship. Plucky (Ubuntu 25.04) is the oldest series whose qt6-base-dev
+  # satisfies the floor, AND it produces the correct non-t64 dependency names
+  # required by users on 25.04+ (the original BUG-75 motivation for the split
+  # Plucky job). Result: one .deb per arch (`_ubuntu2504.deb`).
   # ============================================================================
   build-linux:
     name: Linux Build (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    container:
+      image: ubuntu:25.04
 
     strategy:
       fail-fast: false
@@ -34,18 +43,24 @@ jobs:
             deb-arch: arm64
 
     steps:
+      # The base ubuntu:25.04 image is minimal. Install git + wget + ca-certs
+      # before any action that needs them (actions/checkout uses git when
+      # available; the linuxdeploy download uses wget).
+      - name: Install git, wget, and ca-certificates
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq git wget ca-certificates file
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
+          apt-get install -y -qq \
             build-essential \
             cmake \
             g++ \
             libgl1-mesa-dev \
-            libfuse2 \
             qt6-base-dev \
             qt6-charts-dev \
             qt6-svg-dev \
@@ -92,14 +107,18 @@ jobs:
 
       - name: Build .deb package
         run: dpkg-buildpackage -us -uc -b
+        env:
+          APP_VERSION_OVERRIDE: ${{ steps.version.outputs.VERSION }}
 
       - name: Collect and rename .deb file
         id: deb
         run: |
           cp ../nexis_*.deb .
           SRC=$(ls nexis_*.deb | head -1)
-          # Rename to include ubuntu2404 suffix for clarity (BUG-75)
-          DEST=$(echo "$SRC" | sed 's/\.deb$/_ubuntu2404.deb/')
+          # Plucky-built .deb — non-t64 dependency names (BUG-75); naming kept
+          # for downstream consumers that key off the suffix (release notes,
+          # PPA, downloads page).
+          DEST=$(echo "$SRC" | sed 's/\.deb$/_ubuntu2504.deb/')
           mv "$SRC" "$DEST"
           echo "DEB_PATH=$DEST" >> "$GITHUB_OUTPUT"
           echo "DEB_NAME=$DEST" >> "$GITHUB_OUTPUT"
@@ -158,6 +177,11 @@ jobs:
         env:
           QMAKE: /usr/bin/qmake6
           VERSION: ${{ steps.version.outputs.VERSION }}
+          # Non-privileged GitHub Actions containers do not expose /dev/fuse,
+          # so the linuxdeploy AppImage cannot self-mount. APPIMAGE_EXTRACT_AND_RUN
+          # extracts to a tmpdir and execs directly — the produced Nexis AppImage
+          # is still a normal AppImage that uses FUSE on the user's system.
+          APPIMAGE_EXTRACT_AND_RUN: "1"
         run: |
           ./linuxdeploy-${{ matrix.linuxdeploy-arch }}.AppImage \
             --appdir AppDir \
@@ -184,95 +208,6 @@ jobs:
             ${{ steps.deb.outputs.DEB_PATH }}
             ${{ steps.appimage.outputs.APPIMAGE_PATH }}
             build/output/nexis-${{ matrix.arch }}
-
-  # ============================================================================
-  # Linux .deb for Ubuntu 25.04+ (Plucky) — built inside container to get
-  # correct non-t64 dependency names (BUG-75)
-  # ============================================================================
-  build-linux-deb-plucky:
-    name: Linux .deb Plucky (${{ matrix.arch }})
-    runs-on: ${{ matrix.runner }}
-    container:
-      image: ubuntu:25.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x86_64
-            runner: ubuntu-24.04
-            deb-arch: amd64
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-            deb-arch: arm64
-
-    steps:
-      - name: Install git for checkout
-        run: |
-          apt-get update -qq
-          apt-get install -y -qq git
-
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Install build dependencies
-        run: |
-          apt-get install -y -qq \
-            build-essential \
-            cmake \
-            g++ \
-            libgl1-mesa-dev \
-            qt6-base-dev \
-            qt6-charts-dev \
-            qt6-svg-dev \
-            qt6-tools-dev \
-            qt6-tools-dev-tools \
-            qt6-l10n-tools \
-            libqt6charts6-dev \
-            libqt6svg6-dev \
-            devscripts \
-            debhelper \
-            debhelper-compat \
-            fakeroot \
-            xvfb
-
-      - name: Symlink debian packaging directory
-        run: ln -s linux/debian debian
-
-      - name: Sync debian changelog version from tag
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
-          CURRENT_DEB_VERSION=$(head -1 debian/changelog | grep -oP '\(\K[^)]+' | cut -d- -f1)
-          if [ "$CURRENT_DEB_VERSION" != "$TAG_VERSION" ]; then
-            echo "Updating debian/changelog from $CURRENT_DEB_VERSION to $TAG_VERSION"
-            sed -i "1s/($CURRENT_DEB_VERSION-/(${TAG_VERSION}-/" debian/changelog
-          fi
-
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Build .deb package
-        run: dpkg-buildpackage -us -uc -b
-        env:
-          APP_VERSION_OVERRIDE: ${{ steps.version.outputs.VERSION }}
-
-      - name: Collect and rename .deb file
-        id: deb
-        run: |
-          cp ../nexis_*.deb .
-          SRC=$(ls nexis_*.deb | head -1)
-          # Rename to include ubuntu2504 suffix for clarity
-          DEST=$(echo "$SRC" | sed 's/\.deb$/_ubuntu2504.deb/')
-          mv "$SRC" "$DEST"
-          echo "DEB_PATH=$DEST" >> "$GITHUB_OUTPUT"
-          echo "DEB_NAME=$DEST" >> "$GITHUB_OUTPUT"
-
-      - name: Upload .deb artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: linux-deb-plucky-${{ matrix.arch }}
-          path: ${{ steps.deb.outputs.DEB_PATH }}
 
   # ============================================================================
   # macOS build: .app bundle + .dmg
@@ -457,7 +392,7 @@ jobs:
   # ============================================================================
   release:
     name: Create Release
-    needs: [build-linux, build-linux-deb-plucky, build-macos]
+    needs: [build-linux, build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -478,18 +413,6 @@ jobs:
         with:
           name: linux-artifacts-arm64
           path: artifacts/linux-arm64
-
-      - name: Download Linux x86_64 Plucky .deb
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: linux-deb-plucky-x86_64
-          path: artifacts/linux-deb-plucky-x86_64
-
-      - name: Download Linux ARM64 Plucky .deb
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: linux-deb-plucky-arm64
-          path: artifacts/linux-deb-plucky-arm64
 
       - name: Download macOS artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -522,15 +445,6 @@ jobs:
           echo "APPIMAGE_ARM64_PATH=$APPIMAGE_ARM64" >> "$GITHUB_OUTPUT"
           echo "APPIMAGE_ARM64_NAME=$(basename $APPIMAGE_ARM64)" >> "$GITHUB_OUTPUT"
           echo "BINARY_ARM64_PATH=$BINARY_ARM64" >> "$GITHUB_OUTPUT"
-
-          # Plucky .deb (Ubuntu 25.04+)
-          DEB_X64_PLUCKY=$(find artifacts/linux-deb-plucky-x86_64 -name '*.deb' | head -1)
-          echo "DEB_X64_PLUCKY_PATH=$DEB_X64_PLUCKY" >> "$GITHUB_OUTPUT"
-          echo "DEB_X64_PLUCKY_NAME=$(basename $DEB_X64_PLUCKY)" >> "$GITHUB_OUTPUT"
-
-          DEB_ARM64_PLUCKY=$(find artifacts/linux-deb-plucky-arm64 -name '*.deb' | head -1)
-          echo "DEB_ARM64_PLUCKY_PATH=$DEB_ARM64_PLUCKY" >> "$GITHUB_OUTPUT"
-          echo "DEB_ARM64_PLUCKY_NAME=$(basename $DEB_ARM64_PLUCKY)" >> "$GITHUB_OUTPUT"
 
           # macOS
           DMG=$(find artifacts/macos -name '*.dmg' | head -1)
@@ -588,18 +502,16 @@ jobs:
             echo "#### Linux (x86_64)"
             echo "| Format | File | Description |"
             echo "|--------|------|-------------|"
-            echo "| \`.deb\` | \`$(basename ${{ steps.files.outputs.DEB_X64_PATH }})\` | For Ubuntu 24.04–24.10, Debian 12+, Linux Mint 22 |"
-            echo "| \`.deb\` | \`$(basename ${{ steps.files.outputs.DEB_X64_PLUCKY_PATH }})\` | For Ubuntu 25.04+ (Plucky and newer) |"
-            echo "| \`.AppImage\` | \`$(basename ${{ steps.files.outputs.APPIMAGE_X64_PATH }})\` | Portable — runs on any Linux distro |"
-            echo "| Binary | \`nexis\` | Standalone executable (requires Qt6 runtime) |"
+            echo "| \`.deb\` | \`$(basename ${{ steps.files.outputs.DEB_X64_PATH }})\` | For Ubuntu 25.04+ (Plucky and newer) / Debian 13+ |"
+            echo "| \`.AppImage\` | \`$(basename ${{ steps.files.outputs.APPIMAGE_X64_PATH }})\` | Portable — runs on any Linux distro with a recent glibc |"
+            echo "| Binary | \`nexis\` | Standalone executable (requires Qt6 ≥ 6.8 runtime) |"
             echo ""
             echo "#### Linux (ARM64 / aarch64)"
             echo "| Format | File | Description |"
             echo "|--------|------|-------------|"
-            echo "| \`.deb\` | \`$(basename ${{ steps.files.outputs.DEB_ARM64_PATH }})\` | For Ubuntu 24.04–24.10 ARM64 (Raspberry Pi 5, Jetson, Graviton, etc.) |"
-            echo "| \`.deb\` | \`$(basename ${{ steps.files.outputs.DEB_ARM64_PLUCKY_PATH }})\` | For Ubuntu 25.04+ ARM64 |"
+            echo "| \`.deb\` | \`$(basename ${{ steps.files.outputs.DEB_ARM64_PATH }})\` | For Ubuntu 25.04+ ARM64 (Raspberry Pi 5, Jetson, Graviton) |"
             echo "| \`.AppImage\` | \`$(basename ${{ steps.files.outputs.APPIMAGE_ARM64_PATH }})\` | Portable ARM64 — runs on any ARM64 Linux distro |"
-            echo "| Binary | \`nexis\` | Standalone ARM64 executable (requires Qt6 runtime) |"
+            echo "| Binary | \`nexis\` | Standalone ARM64 executable (requires Qt6 ≥ 6.8 runtime) |"
             echo ""
             echo "#### macOS (Apple Silicon)"
             echo "| Format | File | Description |"
@@ -666,11 +578,9 @@ jobs:
           : > "$SUMS_FILE"
           for f in \
             "${{ steps.files.outputs.DEB_X64_PATH }}" \
-            "${{ steps.files.outputs.DEB_X64_PLUCKY_PATH }}" \
             "${{ steps.files.outputs.APPIMAGE_X64_PATH }}" \
             "${{ steps.files.outputs.BINARY_X64_PATH }}" \
             "${{ steps.files.outputs.DEB_ARM64_PATH }}" \
-            "${{ steps.files.outputs.DEB_ARM64_PLUCKY_PATH }}" \
             "${{ steps.files.outputs.APPIMAGE_ARM64_PATH }}" \
             "${{ steps.files.outputs.BINARY_ARM64_PATH }}" \
             "${{ steps.files.outputs.DMG_PATH }}"
@@ -694,11 +604,9 @@ jobs:
           body_path: /tmp/release_body.md
           files: |
             ${{ steps.files.outputs.DEB_X64_PATH }}
-            ${{ steps.files.outputs.DEB_X64_PLUCKY_PATH }}
             ${{ steps.files.outputs.APPIMAGE_X64_PATH }}
             ${{ steps.files.outputs.BINARY_X64_PATH }}
             ${{ steps.files.outputs.DEB_ARM64_PATH }}
-            ${{ steps.files.outputs.DEB_ARM64_PLUCKY_PATH }}
             ${{ steps.files.outputs.APPIMAGE_ARM64_PATH }}
             ${{ steps.files.outputs.BINARY_ARM64_PATH }}
             ${{ steps.files.outputs.DMG_PATH }}

--- a/.github/workflows/screenshot-baselines.yml
+++ b/.github/workflows/screenshot-baselines.yml
@@ -22,27 +22,77 @@ on:
         required: false
 
 jobs:
-  regenerate:
-    name: Regenerate (${{ matrix.name }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-24.04
-            name: linux-x64
-            platform-dir: linux
-          - os: macos-14
-            name: macos
-            platform-dir: macos
-
+  # SSO-4093: split linux/macos into separate jobs so the Linux leg can run
+  # inside a Plucky (25.04) container (Qt 6.8 — the FW-06 floor) without
+  # affecting the macos-14 runner, which can't use `container:`.
+  regenerate-linux:
+    name: Regenerate (linux-x64)
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:25.04
     steps:
       - name: Skip if not requested
         id: skip-check
         run: |
-          if ! echo "${{ inputs.platforms }}" | tr ',' '\n' | grep -qx "${{ matrix.name }}"; then
+          if ! echo "${{ inputs.platforms }}" | tr ',' '\n' | grep -qx "linux-x64"; then
             echo "skipped=true" >> "$GITHUB_OUTPUT"
-            echo "Platform ${{ matrix.name }} not in requested list; skipping."
+            echo "Platform linux-x64 not in requested list; skipping."
+          else
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install git and ca-certificates
+        if: steps.skip-check.outputs.skipped != 'true'
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq git ca-certificates
+
+      - name: Checkout
+        if: steps.skip-check.outputs.skipped != 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install dependencies
+        if: steps.skip-check.outputs.skipped != 'true'
+        run: |
+          apt-get install -y -qq \
+            build-essential \
+            cmake g++ libgl1-mesa-dev \
+            qt6-base-dev qt6-charts-dev qt6-svg-dev \
+            qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools \
+            libqt6charts6-dev libqt6svg6-dev \
+            xvfb
+
+      - name: Configure
+        if: steps.skip-check.outputs.skipped != 'true'
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build screenshot test
+        if: steps.skip-check.outputs.skipped != 'true'
+        run: cmake --build build --target test-ScreenshotTests -j$(nproc)
+
+      - name: Regenerate baselines
+        if: steps.skip-check.outputs.skipped != 'true'
+        run: xvfb-run -a ./scripts/update_screenshots.sh
+
+      - name: Upload regenerated baselines
+        if: steps.skip-check.outputs.skipped != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: reference-screenshots-linux
+          path: tests/reference_screenshots/linux/
+          retention-days: 30
+          if-no-files-found: error
+
+  regenerate-macos:
+    name: Regenerate (macos)
+    runs-on: macos-14
+    steps:
+      - name: Skip if not requested
+        id: skip-check
+        run: |
+          if ! echo "${{ inputs.platforms }}" | tr ',' '\n' | grep -qx "macos"; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "Platform macos not in requested list; skipping."
           else
             echo "skipped=false" >> "$GITHUB_OUTPUT"
           fi
@@ -51,19 +101,8 @@ jobs:
         if: steps.skip-check.outputs.skipped != 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Install dependencies (Linux)
-        if: steps.skip-check.outputs.skipped != 'true' && runner.os == 'Linux'
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq \
-            cmake g++ libgl1-mesa-dev \
-            qt6-base-dev qt6-charts-dev qt6-svg-dev \
-            qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools \
-            libqt6charts6-dev libqt6svg6-dev \
-            xvfb
-
-      - name: Install dependencies (macOS)
-        if: steps.skip-check.outputs.skipped != 'true' && runner.os == 'macOS'
+      - name: Install dependencies
+        if: steps.skip-check.outputs.skipped != 'true'
         run: |
           for i in 1 2 3; do
             brew install qt@6 && break
@@ -71,32 +110,23 @@ jobs:
             sleep 15
           done
 
-      - name: Configure (Linux)
-        if: steps.skip-check.outputs.skipped != 'true' && runner.os == 'Linux'
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
-
-      - name: Configure (macOS)
-        if: steps.skip-check.outputs.skipped != 'true' && runner.os == 'macOS'
+      - name: Configure
+        if: steps.skip-check.outputs.skipped != 'true'
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(brew --prefix qt@6)
 
       - name: Build screenshot test
         if: steps.skip-check.outputs.skipped != 'true'
-        run: cmake --build build --target test-ScreenshotTests -j$(sysctl -n hw.ncpu 2>/dev/null || nproc)
+        run: cmake --build build --target test-ScreenshotTests -j$(sysctl -n hw.ncpu)
 
       - name: Regenerate baselines
         if: steps.skip-check.outputs.skipped != 'true'
-        run: |
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            xvfb-run -a ./scripts/update_screenshots.sh
-          else
-            ./scripts/update_screenshots.sh
-          fi
+        run: ./scripts/update_screenshots.sh
 
       - name: Upload regenerated baselines
         if: steps.skip-check.outputs.skipped != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: reference-screenshots-${{ matrix.platform-dir }}
-          path: tests/reference_screenshots/${{ matrix.platform-dir }}/
+          name: reference-screenshots-macos
+          path: tests/reference_screenshots/macos/
           retention-days: 30
           if-no-files-found: error

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -99,16 +99,23 @@ that tag, a holdover from the pre-rebrand Stacer artifacts; see
 
 ## 2. Build matrix
 
-Defined in `.github/workflows/release.yml`. As of v2.3.x:
+Defined in `.github/workflows/release.yml`. As of v2.6.x (SSO-4093):
 
 | Job | Runner | Output | Notes |
 |---|---|---|---|
-| `build-linux (x86_64)` | `ubuntu-24.04` | `.deb` (24.04), AppImage, raw binary `nexis-x86_64` | linuxdeploy + qt plugin |
-| `build-linux (arm64)` | `ubuntu-24.04-arm` | `.deb` (24.04), AppImage, raw binary `nexis-arm64` | linuxdeploy aarch64 |
-| `build-linux-deb-plucky (x86_64)` | `ubuntu-24.04` (container `ubuntu:25.04`) | `.deb` (Plucky / 25.04+) | non-t64 dep names (BUG-75) |
-| `build-linux-deb-plucky (arm64)` | `ubuntu-24.04-arm` (container `ubuntu:25.04`) | `.deb` (Plucky / 25.04+) | non-t64 dep names (BUG-75) |
+| `build-linux (x86_64)` | `ubuntu-24.04` (container `ubuntu:25.04`) | `.deb` (`_ubuntu2504.deb`), AppImage, raw binary `nexis-x86_64` | linuxdeploy + qt plugin (run with `APPIMAGE_EXTRACT_AND_RUN=1` — no `/dev/fuse` in container) |
+| `build-linux (arm64)` | `ubuntu-24.04-arm` (container `ubuntu:25.04`) | `.deb` (`_ubuntu2504.deb`), AppImage, raw binary `nexis-arm64` | linuxdeploy aarch64 (same FUSE workaround) |
 | `build-macos` | `macos-14` (Apple Silicon) | `nexis.app`, `.dmg` | macdeployqt + notarized |
 | `release` | `ubuntu-latest` | GitHub Release, attaches all artifacts | extracts notes from `CHANGELOG.md` |
+
+> **Why Plucky containers (SSO-4093).** FW-06 (SSO-3733) raised the Qt floor
+> to 6.8 LTS. Noble (Ubuntu 24.04) ships Qt 6.4 via `qt6-base-dev`, so the
+> previous bare-runner `build-linux` job no longer satisfies the floor. We
+> now build inside `ubuntu:25.04` (Plucky), which ships Qt 6.8.x. This also
+> collapses the prior split where a separate `build-linux-deb-plucky` job
+> produced the non-t64 25.04 `.deb` — the unified job builds **only** the
+> Plucky `.deb` (`_ubuntu2504.deb`), and there is no longer a Noble `.deb`.
+> Ubuntu 24.04 users either upgrade or use the AppImage / AUR / PPA path.
 
 Downstream-triggered (run on success of `Release`):
 


### PR DESCRIPTION
## Summary

Migrates Nexis's Linux CI from the bare `ubuntu-24.04` runner + Noble apt path
to a `container: ubuntu:25.04` (Plucky) pattern across `build.yml`,
`release.yml`, `codeql.yml`, and `screenshot-baselines.yml`. Noble ships Qt 6.4
via `qt6-base-dev`; FW-06 ([SSO-3733](https://github.com/s4solutionsllc/Nexis/pull/170))
raised the project's Qt floor to 6.8 LTS, so the previous CI legs no longer
satisfy `CMakeLists.txt`. Plucky ships Qt 6.8.x — satisfies the floor.

This is a sibling PR of [#170](https://github.com/s4solutionsllc/Nexis/pull/170)
carved out of [SSO-4093](https://paperclip.app/SSO/issues/SSO-4093). It is
authored against `native` directly so it can land on its own merits and unblock
PR #170 once rebased.

## Changes

- **`build.yml`** — split the single matrix job into `build-linux` (Plucky
  container, `x64` + `ARM64`) and `build-macos`. Existing branch-protection
  check names `Linux (x64)`, `Linux (ARM64)`, `macOS (ARM64)` are preserved.
- **`release.yml`** — collapse `build-linux` + `build-linux-deb-plucky` into a
  single Plucky-container `build-linux`. The `.deb` is now exclusively
  `_ubuntu2504.deb` (non-t64 dep names per BUG-75); the Noble `_ubuntu2404.deb`
  is dropped. Updates `release` job `needs:`, downloads, release-notes table,
  SHA256SUMS list, and the uploaded `files:` list accordingly. AppImage build
  uses `APPIMAGE_EXTRACT_AND_RUN=1` because non-privileged GHA containers do
  not expose `/dev/fuse` — the produced AppImage is unchanged and still uses
  FUSE on the end user's machine.
- **`codeql.yml`** — runs inside the same Plucky container so the manual
  c-cpp build path picks up Qt 6.8. Without this, CodeQL was failing on PR
  #170 with `qt6-base-dev` 6.4.
- **`screenshot-baselines.yml`** — split into `regenerate-linux`
  (Plucky container) and `regenerate-macos`. Manual workflow_dispatch only,
  but it would have broken under the new Qt floor; fixing it in the same
  diff keeps the four Linux-Qt workflows consistent.
- **`RELEASE.md` § Build matrix** — refresh the table for the unified
  Plucky-container Linux job and the single `_ubuntu2504.deb` output. Adds
  a short rationale note explaining the SSO-4093 decision.

## Test plan

- [ ] CI on this PR passes all required checks: `Build / Linux (x64)`,
      `Build / Linux (ARM64)`, `Build / macOS (ARM64)`, `CodeQL / Analyze (c-cpp)`.
- [ ] Once merged, rebase PR #170 onto `native` — `Linux (x64)` / `Linux (ARM64)`
      / CodeQL legs flip green there.
- [ ] On next tag-driven release, `release.yml` produces:
      - `nexis_<ver>_amd64_ubuntu2504.deb`
      - `nexis_<ver>_arm64_ubuntu2504.deb`
      - x86_64 + arm64 AppImages, raw binaries, .dmg, SHA256SUMS.

## Notes

- `runs-on:` stays on `ubuntu-24.04` / `ubuntu-24.04-arm` because that is what
  GitHub provides for the matching arch — the build environment comes from the
  `ubuntu:25.04` container image, not the runner host.
- The base container image is minimal (no `git`, no `ca-certificates`),
  so the first step of each container job installs those before
  `actions/checkout` runs. The existing `build-linux-deb-plucky` job already
  used this pattern — proven path.
- `screenshot-baselines.yml` is split into two jobs (rather than a matrix with
  conditional container) because GitHub Actions does not support per-matrix
  `container:` on a single job — macOS would error on a `container` directive.

Closes [SSO-4093](https://paperclip.app/SSO/issues/SSO-4093). Unblocks
[SSO-3733](https://paperclip.app/SSO/issues/SSO-3733) (PR #170).

🤖 Generated with [Claude Code](https://claude.com/claude-code)