### PR TITLE
fix(cleaner): Clean Selected button disabled when only Trash selected (GH#173)

### DIFF
--- a/shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp
+++ b/shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp
@@ -1016,6 +1016,7 @@ quint64 SystemCleanerPage::addTreeRoot(const CleanCategories &cat, const QString
         root->setText(0, title);
     }
     root->setText(1, FormatUtil::formatBytes(totalSize));
+    root->setData(1, SortRole, totalSize);
     return totalSize;
 }
 


### PR DESCRIPTION
## Summary

Fixes GitHub issue #173 — on Linux, the **Clean Selected** button remained
disabled even after a scan found Trash files.

**Root cause:** `addTreeRoot()` calls `root->setText(1, formattedSize)` to
display the size of TRASH and SNAP_FLATPAK_REVISIONS root items, but never
calls `root->setData(1, SortRole, totalSize)`. When `updateFooterTotal()`
sums up the total to decide whether to enable the button, it reads
`root->data(1, SortRole)` for those two categories — which returns 0 — so
the total is always 0 and the button never enables.

**Fix:** One line: store `totalSize` in `SortRole` on the root item in
`addTreeRoot()`, so `updateFooterTotal()` reads the correct value.

Fixes: https://github.com/s4solutionsllc/Nexis/issues/173

## Test plan

- [ ] Linux: scan system, check only Trash category — verify "Clean selected" button becomes enabled
- [ ] Linux: scan system, check only Snap/Flatpak Revisions (if present) — verify same
- [ ] Linux: scan system, check other categories (App Caches, etc.) — verify button still works as before
- [ ] macOS: scan system, check only Trash — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)