### PR TITLE
fix(ci): pass --executable to linuxdeploy for Qt 6.8 AppImage (SSO-6445)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,19 @@ jobs:
 
           chmod +x "${ld_file}" "${ldq_file}"
 
+      # SSO-6445: debug step confirms AppDir layout and qmake path before
+      # linuxdeploy runs, so future failures have a clear evidence trail.
+      - name: Debug AppDir layout and qmake
+        run: |
+          echo "=== AppDir/usr/bin ==="
+          ls -la AppDir/usr/bin/ || echo "WARN: AppDir/usr/bin not found"
+          echo "=== nexis ELF type ==="
+          file AppDir/usr/bin/nexis || echo "WARN: nexis binary not found"
+          echo "=== qmake6 ==="
+          which qmake6 && qmake6 -v || echo "WARN: qmake6 not found in PATH"
+          echo "=== ldd AppDir/usr/bin/nexis (Qt libs) ==="
+          ldd AppDir/usr/bin/nexis 2>&1 | grep -i qt || echo "(no Qt lines in ldd output)"
+
       - name: Build AppImage
         env:
           QMAKE: /usr/bin/qmake6
@@ -183,8 +196,14 @@ jobs:
           # is still a normal AppImage that uses FUSE on the user's system.
           APPIMAGE_EXTRACT_AND_RUN: "1"
         run: |
+          # SSO-6445: pass --executable explicitly so linuxdeploy deploys the
+          # binary's Qt dependencies into AppDir before the qt plugin runs.
+          # Without this flag linuxdeploy's "Deploying dependencies" phase only
+          # processes files added in the current invocation, not pre-installed
+          # AppDir contents, leaving the Qt plugin with nothing to scan.
           ./linuxdeploy-${{ matrix.linuxdeploy-arch }}.AppImage \
             --appdir AppDir \
+            --executable AppDir/usr/bin/nexis \
             --desktop-file AppDir/usr/share/applications/nexis.desktop \
             --icon-file AppDir/usr/share/icons/hicolor/256x256/apps/nexis.png \
             --plugin qt \


### PR DESCRIPTION
## Summary

- **Root cause:** After SSO-4093 moved the `build-linux` matrix into an `ubuntu:25.04` container (Qt 6.8.3), the `Build AppImage` step was missing `--executable`. Without it, linuxdeploy's "Deploying dependencies" phase processes only files added in the current invocation — it does **not** auto-deploy deps for pre-existing AppDir contents. The `linuxdeploy-plugin-qt` then scans AppDir, finds no `libQt6*.so` files, and exits with "Could not find Qt modules to deploy".
- **Fix:** Add `--executable AppDir/usr/bin/nexis` so linuxdeploy scans and deploys the binary's Qt dependencies into AppDir before the plugin runs.
- **Debug step:** Added a pre-flight step that logs AppDir/usr/bin contents, `file` output, `qmake6 -v`, and `ldd` Qt lines so future CI failures have an evidence trail.

## Test plan

- [ ] Merge to `native` and confirm the `v2.6.0` tag re-trigger (or a test tag) produces green `Linux Build (x86_64)` and `Linux Build (arm64)` jobs
- [ ] Confirm AppImage artifacts appear in the uploaded artifacts for both arches
- [ ] Confirm the debug step output shows `nexis` as ELF and `ldd` Qt lines present
- [ ] Confirm macOS build is unaffected (no changes there)

Unblocks: SSO-6441 (v2.6.0 release — requires AppImage artifacts)
Fixes: SSO-6445

🤖 Generated with [Claude Code](https://claude.com/claude-code)