### PR TITLE
fix(ci): use absolute paths for linuxdeploy AppDir args (SSO-6441)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,11 +201,14 @@ jobs:
           # Without this flag linuxdeploy's "Deploying dependencies" phase only
           # processes files added in the current invocation, not pre-installed
           # AppDir contents, leaving the Qt plugin with nothing to scan.
+          # Use absolute paths: APPIMAGE_EXTRACT_AND_RUN resolves relative paths
+          # from the AppImage's extraction tmpdir, not the runner workspace.
+          APPDIR="${{ github.workspace }}/AppDir"
           ./linuxdeploy-${{ matrix.linuxdeploy-arch }}.AppImage \
-            --appdir AppDir \
-            --executable AppDir/usr/bin/nexis \
-            --desktop-file AppDir/usr/share/applications/nexis.desktop \
-            --icon-file AppDir/usr/share/icons/hicolor/256x256/apps/nexis.png \
+            --appdir "$APPDIR" \
+            --executable "$APPDIR/usr/bin/nexis" \
+            --desktop-file "$APPDIR/usr/share/applications/nexis.desktop" \
+            --icon-file "$APPDIR/usr/share/icons/hicolor/256x256/apps/nexis.png" \
             --plugin qt \
             --output appimage
 


### PR DESCRIPTION
## Problem

`release.yml` run [27910814102](https://github.com/s4solutionsllc/Nexis/actions/runs/27910814102) failed with:

```
ERROR: No such file or directory:  AppDir/usr/bin/nexis
```

## Root Cause

`APPIMAGE_EXTRACT_AND_RUN=1` causes linuxdeploy to extract itself to a temporary directory before executing. Relative paths passed as arguments (`--appdir AppDir`, `--executable AppDir/usr/bin/nexis`, etc.) are then resolved relative to the extraction tmpdir — not the runner's workspace — so the binary cannot be found.

The `cmake --install` step correctly installs the binary to `/home/runner/work/Nexis/Nexis/AppDir/usr/bin/nexis` (confirmed in CI logs), but linuxdeploy looks for it at `<tmpdir>/AppDir/usr/bin/nexis` which doesn't exist.

## Fix

Switch all four AppDir-relative arguments to absolute paths using `${{ github.workspace }}`:

```yaml
APPDIR="${{ github.workspace }}/AppDir"
./linuxdeploy-... \
  --appdir "$APPDIR" \
  --executable "$APPDIR/usr/bin/nexis" \
  --desktop-file "$APPDIR/usr/share/applications/nexis.desktop" \
  --icon-file "$APPDIR/usr/share/icons/hicolor/256x256/apps/nexis.png" \
  ...
```

## Context

- Tag `v2.6.0` is already pushed at `0c2ad16a` and waiting for a successful release.yml run
- Blocking: [SSO-6441](/SSO/issues/SSO-6441)

🤖 Generated with [Claude Code](https://claude.com/claude-code)