### PR TITLE
feat(ppa): add Ubuntu 26.04 Resolute to PPA build matrix (SSO-7305)

### DIFF
--- a/.github/workflows/ppa.yml
+++ b/.github/workflows/ppa.yml
@@ -73,11 +73,13 @@ jobs:
         # SSO-3733 / FW-06: Qt floor raised to 6.8 in CMakeLists.txt. Ubuntu
         # 24.04 (Noble) ships Qt 6.4 and 22.04 (Jammy) ships Qt 6.2, so
         # neither series can satisfy the floor from its archive Qt. Plucky
-        # (25.04) ships Qt 6.8+; Questing (25.10) ships Qt 6.8+. Users on
-        # Noble/Jammy can install via AppImage or AUR until they upgrade.
+        # (25.04) ships Qt 6.8+; Questing (25.10) ships Qt 6.8+; Resolute
+        # (26.04 LTS) ships Qt 6.8+. Users on Noble/Jammy can install via
+        # AppImage or AUR until they upgrade.
         # See RELEASE.md "Currently supported targets" and CHANGELOG.md
         # v2.6.0 [Unreleased] for the user-facing announcement.
-        series: [plucky, questing]
+        # SSO-7305: added resolute (26.04 LTS) — ships Qt 6.8+.
+        series: [plucky, questing, resolute]
 
     steps:
       - name: Checkout

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -121,7 +121,7 @@ Downstream-triggered (run on success of `Release`):
 
 - `homebrew.yml` — bumps the `s4solutionsllc/homebrew-nexis` Cask to the new DMG.
 - `aur.yml` — publishes the AUR `nexis` package via `KSXGitHub/github-actions-deploy-aur`.
-- `ppa.yml` — uploads source packages to the Launchpad PPA for `plucky`, `questing` (SSO-3733 / FW-06 dropped `noble` + `jammy`; see "Ubuntu 24.04 (Noble) dropped" below).
+- `ppa.yml` — uploads source packages to the Launchpad PPA for `plucky`, `questing`, `resolute` (SSO-3733 / FW-06 dropped `noble` + `jammy`; SSO-7305 added `resolute`; see "Ubuntu 24.04 (Noble) dropped" below).
 
 > **Action pins (WI-09 / SSO-3371).** Every `uses:` in `.github/workflows/` is
 > pinned to a full commit SHA with a trailing `# vX.Y.Z` comment — *never* a
@@ -140,11 +140,11 @@ Downstream-triggered (run on success of `Release`):
 - AppImage (any glibc-recent Linux)
 - macOS Apple Silicon (`arm64`) on macOS 14+ — **macOS Intel (`x86_64`) is sunset (SSO-3733 / FW-06)**, see below
 - AUR (Arch + derivatives)
-- Launchpad PPA (`plucky`, `questing`) — see "Ubuntu 24.04 (Noble) dropped" below
+- Launchpad PPA (`plucky`, `questing`, `resolute`) — see "Ubuntu 24.04 (Noble) dropped" below
 
 > **macOS Intel (`x86_64`) is formally sunset as of v2.6.0 (SSO-3733 / FW-06).** The CI matrix has produced **only** `Nexis-${VERSION}-macOS-arm64.dmg` since the macOS runner moved to `macos-14`; v2.6.0 codifies that as a supported-platform decision rather than an implicit CI artifact. macOS 26 ("Tahoe") is the last macOS to boot on Intel and Rosetta 2 is being phased out; macOS 27 ("Golden Gate") is Apple-silicon-only. No Intel runner will be added; no universal `.dmg` is planned. Intel users on macOS 26 can continue running prior `arm64` builds via Rosetta where supported, but `arm64`-only is the published target going forward.
 
-> **Ubuntu 24.04 (Noble) is no longer a supported PPA series as of v2.6.0 (SSO-3733 / FW-06).** Noble ships Qt 6.4, and the project's Qt floor is now 6.8 LTS (see `CMakeLists.txt`). The `noble` Launchpad source upload is removed from `ppa.yml`; PPA users on 24.04 should upgrade to 25.04 (Plucky) or 26.04 (Questing) — both ship a Qt that satisfies the 6.8 floor. AppImage and the AUR continue to cover older Ubuntu hosts that build against a newer Qt sysroot.
+> **Ubuntu 24.04 (Noble) is no longer a supported PPA series as of v2.6.0 (SSO-3733 / FW-06).** Noble ships Qt 6.4, and the project's Qt floor is now 6.8 LTS (see `CMakeLists.txt`). The `noble` Launchpad source upload is removed from `ppa.yml`; PPA users on 24.04 should upgrade to 25.04 (Plucky), 25.10 (Questing), or 26.04 (Resolute) — all ship a Qt that satisfies the 6.8 floor. AppImage and the AUR continue to cover older Ubuntu hosts that build against a newer Qt sysroot.
 
 > **macOS distribution format is `.dmg`, not `.pkg` (SSO-3733 / FW-06).** Tahoe (macOS 26) skips the first-run XProtect prompt for notarized `.dmg`/`.app` artifacts but **not** for `.pkg` installers, and Tahoe 26.3 saw `.pkg` Gatekeeper rejections in the field. Nexis is a drag-to-`/Applications` `.app` with no install-time launchd / scripting that would justify `.pkg` (the `ScheduleManager` plists are written at runtime to `~/Library/LaunchAgents/`, not at install time). Changing macOS distribution format is a maintainer-only scope decision and must be reopened explicitly — do not silently add a `.pkg` job to `release.yml`. See `docs/MAINTAINER_SOP.md` for the matching policy line.
 


### PR DESCRIPTION
## Summary

Fixes GH#186 — Ubuntu 26.04 (Resolute) users receive a "does not have a Release file" error when adding the Nexis PPA because `resolute` was not in the build matrix.

- Add `resolute` to `series:` in `.github/workflows/ppa.yml` alongside `plucky` and `questing`
- Update comment block in `ppa.yml` to document that Resolute ships Qt 6.8+
- Fix RELEASE.md: "26.04 (Questing)" was a typo — corrected to "25.10 (Questing) or 26.04 (Resolute)"
- Update RELEASE.md supported-targets list to include `resolute`

Resolute ships Qt 6.8+, satisfying the floor raised by SSO-3733 / FW-06. No series-specific `debian/control` patches are needed (the Jammy patch for `libqt6opengl6-dev` was jammy-only and does not apply to Resolute).

Closes SSO-7305 / GH#186.

## Test plan

- [ ] Verify ppa.yml lint passes (YAML syntax OK)
- [ ] After merge, trigger `ppa.yml` via `workflow_dispatch` with the current version to confirm `resolute` builds and uploads cleanly to Launchpad
- [ ] Confirm `https://ppa.launchpadcontent.net/s4solutionsllc/nexis/ubuntu/dists/resolute/` is populated after the upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)