### PR TITLE
feat/fix: GH#182 mounted-filesystem trash, GH#185 docs, GH#186 Ubuntu 26.04 PPA

### DIFF
--- a/.github/workflows/ppa.yml
+++ b/.github/workflows/ppa.yml
@@ -73,11 +73,12 @@ jobs:
         # SSO-3733 / FW-06: Qt floor raised to 6.8 in CMakeLists.txt. Ubuntu
         # 24.04 (Noble) ships Qt 6.4 and 22.04 (Jammy) ships Qt 6.2, so
         # neither series can satisfy the floor from its archive Qt. Plucky
-        # (25.04) ships Qt 6.8+; Questing (25.10) ships Qt 6.8+. Users on
-        # Noble/Jammy can install via AppImage or AUR until they upgrade.
+        # (25.04) ships Qt 6.8+; Questing (25.10) ships Qt 6.8+. Resolute
+        # (26.04 LTS) ships Qt 6.8+. Users on Noble/Jammy can install via
+        # AppImage or AUR until they upgrade.
         # See RELEASE.md "Currently supported targets" and CHANGELOG.md
-        # v2.6.0 [Unreleased] for the user-facing announcement.
-        series: [plucky, questing]
+        # v2.6.0 for the user-facing announcement. GH#186.
+        series: [plucky, questing, resolute]
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Trash: enumerate mounted-filesystem trash directories (GH#182):** `CleanerService` now enumerates `QStorageInfo::mountedVolumes()` and includes any `.Trash-<UID>/` and `.Trash/<UID>/` directories found on non-home mounts in both the Trash scan (size accounting) and `cleanTrash()` (deletion). Implements the FreeDesktop Trash Specification for files deleted from external USB drives and secondary internal drives. Virtual `mountedFilesystemTrashDirs()` test seam added alongside the existing `trashRoot()` seam; `test_cleaner_service.cpp` covers the new path.
+
+### Fixed
+- **Ubuntu 26.04 (Resolute) added to PPA build matrix (GH#186):** The Launchpad PPA now publishes `.deb` packages for Ubuntu 26.04 LTS ("Resolute"). The `ppa.yml` `series` matrix is extended to `[plucky, questing, resolute]`.
+- **Correct supported Ubuntu versions in README and APPLICATION_OVERVIEW (GH#185 / GH#186):** The README and `APPLICATION_OVERVIEW.md` previously advertised Ubuntu 22.04 (Jammy) and 24.04 (Noble) as PPA-supported, but both were dropped in v2.6.0 when Qt was raised to the 6.8 LTS floor (neither distro ships Qt 6.8). Documentation now correctly lists Ubuntu 25.04 (Plucky), 25.10 (Questing), and 26.04 (Resolute). A note directs Jammy/Noble and Linux Mint Zena users to the AppImage.
+
+### CI / Internal
+- **PPA matrix extended to Ubuntu 26.04 Resolute (GH#186):** Added `resolute` series to `ppa.yml` alongside existing `plucky` and `questing` entries.
+
 ## [2.6.0] - 2026-06-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ sudo apt update
 sudo apt install nexis
 ```
 
-Supports Ubuntu 22.04 (Jammy), 24.04 (Noble), and 25.04 (Plucky) on both x86_64 and ARM64. Updates are delivered automatically via `apt upgrade`.
+Supports Ubuntu 25.04 (Plucky), 25.10 (Questing), and 26.04 (Resolute) on both x86_64 and ARM64. Updates are delivered automatically via `apt upgrade`.
+
+> **Ubuntu 22.04 / 24.04 (and Linux Mint Zena):** Nexis 2.6+ requires Qt 6.8 LTS, which is not available in those repositories. Install via [AppImage](https://github.com/s4solutionsllc/Nexis/releases/latest) or upgrade to Ubuntu 25.04+.
 
 ### Install via AUR (Arch Linux)
 

--- a/docs/APPLICATION_OVERVIEW.md
+++ b/docs/APPLICATION_OVERVIEW.md
@@ -233,7 +233,7 @@ Scan and remove system junk files across 10 categories.
 2. **Crash Reports** — System crash dumps
 3. **Application Logs** — `/var/log`, `~/.local/share/**/logs`
 4. **Application Caches** — `~/.cache` (Linux), `~/Library/Caches` (macOS)
-5. **Trash** — User trash bin contents
+5. **Trash** — User trash bin contents (`~/.local/share/Trash` on Linux, `~/.Trash` on macOS) plus any `.Trash-<UID>` / `.Trash/<UID>` directories found on mounted filesystems (external drives, secondary internal drives) per the FreeDesktop Trash Specification (GH#182)
 6. **Dev Tool Caches** — npm, cargo, gradle, Electron app caches, pip cache
 7. **Broken Symlinks** — Detects broken symbolic links in `~/.local/`, `~/bin/`, Homebrew prefix (macOS) or `/usr/local/bin` (Linux)
 8. **Browser Privacy** — Browser caches (Chrome, Edge, Brave, Firefox, Safari), session data, and OS-level recent file lists (macOS LSSharedFileList, Linux recently-used.xbel)
@@ -736,7 +736,7 @@ tests/
 - Dependencies: `nexis-gui` (inherits all Qt and core dependencies)
 - macOS: `.app` bundle with icon, installs to `/Applications`. Signed with Developer ID and notarized by Apple (no Gatekeeper warnings)
 - Linux: Binary to `/usr/bin`, `.desktop` file, hicolor icons (16x16 through 256x256)
-- Linux PPA: `ppa:s4solutionsllc/nexis` — Ubuntu 22.04+ (Jammy, Noble, Plucky), amd64 and arm64, automatic updates via apt
+- Linux PPA: `ppa:s4solutionsllc/nexis` — Ubuntu 25.04+ (Plucky, Questing, Resolute), amd64 and arm64, automatic updates via apt. Requires Qt 6.8 LTS; Ubuntu 22.04 (Jammy) and 24.04 (Noble) are not supported via PPA — use AppImage instead.
 - macOS Homebrew: `brew tap s4solutionsllc/nexis && brew install --cask nexis` — Apple Silicon, auto-updated on new releases
 
 **Linux distribution channels:** `.deb` (PPA + GitHub releases), AppImage, AUR. The Flatpak (Flathub) channel was retired in 2026-06; the sandbox model is incompatible with Nexis's system-maintenance feature set (privileged host operations like `systemctl`, `pkexec`, `smartctl`, `fstrim` are unavailable or no-ops inside bubblewrap). The product feature that detects and cleans unused Flatpak runtimes installed on the host is unaffected.

--- a/shared/nexis/Managers/cleaner_service.cpp
+++ b/shared/nexis/Managers/cleaner_service.cpp
@@ -10,6 +10,7 @@
 #include <Utils/format_util.h>
 #include <QDir>
 #include <QStandardPaths>
+#include <QStorageInfo>
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QJsonObject>
@@ -225,6 +226,12 @@ CleanerService::ScanResult CleanerService::scan(const QList<CleanCategory> &cate
                 QString trashPath = QDir::homePath() + "/.local/share/Trash/";
 #endif
                 files = { QFileInfo(trashPath) };
+#ifndef Q_OS_MACOS
+                // GH#182: include .Trash-$UID directories on mounted
+                // filesystems per the FreeDesktop Trash Specification.
+                for (const QString &mountTrash : mountedFilesystemTrashDirs())
+                    files.append(QFileInfo(mountTrash));
+#endif
                 break;
             }
             case DOWNLOADS_AGED: {
@@ -393,6 +400,35 @@ QString CleanerService::trashRoot() const
 #endif
 }
 
+QStringList CleanerService::mountedFilesystemTrashDirs() const
+{
+    QStringList result;
+#ifdef Q_OS_LINUX
+    const QString homeMount = QStorageInfo(QDir::homePath()).rootPath();
+    const QString uid = QString::number(static_cast<uint>(getuid()));
+
+    for (const QStorageInfo &vol : QStorageInfo::mountedVolumes()) {
+        if (!vol.isValid() || !vol.isReady())
+            continue;
+        const QString mountRoot = vol.rootPath();
+        // Skip the filesystem that already contains ~/.local/share/Trash
+        if (mountRoot == homeMount)
+            continue;
+
+        // FreeDesktop Trash Spec §1.1: .Trash-$UID on the volume root
+        const QString trashDash = mountRoot + "/.Trash-" + uid;
+        if (QDir(trashDash).exists())
+            result << trashDash;
+
+        // FreeDesktop Trash Spec §1.2: .Trash/$UID when .Trash is sticky+group
+        const QString trashUid = mountRoot + "/.Trash/" + uid;
+        if (QDir(trashUid).exists())
+            result << trashUid;
+    }
+#endif
+    return result;
+}
+
 quint64 CleanerService::cleanTrash()
 {
     const QString trashPath = trashRoot();
@@ -418,6 +454,13 @@ quint64 CleanerService::cleanTrash()
 #else
     emptyDir(trashPath + "/files");
     emptyDir(trashPath + "/info");
+
+    // GH#182: also empty any .Trash-$UID directories on mounted filesystems
+    // per the FreeDesktop Trash Specification.
+    for (const QString &mountTrash : mountedFilesystemTrashDirs()) {
+        emptyDir(mountTrash + "/files");
+        emptyDir(mountTrash + "/info");
+    }
 #endif
 
     return sizeBefore;

--- a/shared/nexis/Managers/cleaner_service.h
+++ b/shared/nexis/Managers/cleaner_service.h
@@ -138,6 +138,12 @@ protected:
     // user Trash directory; tests override to point at a QTemporaryDir.
     virtual QString trashRoot() const;
 
+    // GH#182: test seam for mounted-filesystem trash directories. Production
+    // enumerates QStorageInfo::mountedVolumes() and returns any
+    // .Trash-<UID> / .Trash/<UID> directories found on non-home mounts.
+    // Tests override to inject synthetic mount-point trash roots.
+    virtual QStringList mountedFilesystemTrashDirs() const;
+
     // SSO-3399 / SSO-3704: test seam for the user-vs-root ownership split in
     // cleanFiles(). Production compares ownerId() to geteuid(); tests override
     // to force paths through the elevated branch (or keep them in the user

--- a/tests/managers/test_cleaner_service.cpp
+++ b/tests/managers/test_cleaner_service.cpp
@@ -18,6 +18,7 @@ public:
 
     QStringList elevatedPaths;
     QString mockTrashRoot;
+    QStringList mockMountedTrashDirs;
     // SSO-3704: default to "not user-owned" so the elevated branch is reachable
     // under CI (where temp files are always owned by the CI user). Individual
     // tests can flip this to true to exercise the user-owned branch.
@@ -48,6 +49,12 @@ protected:
     QString trashRoot() const override
     {
         return mockTrashRoot;
+    }
+
+    // GH#182: test seam — inject synthetic mounted-filesystem trash dirs
+    QStringList mountedFilesystemTrashDirs() const override
+    {
+        return mockMountedTrashDirs;
     }
 };
 
@@ -104,6 +111,7 @@ private slots:
     void cleanFiles_elevatedBranch_routesThroughSeam();
     void cleanFiles_elevatedBranch_argvHasEndOfOptionsGuard();
     void cleanTrash_removesContents_viaSeam();
+    void cleanTrash_includesMountedFilesystemTrashDirs(); // GH#182
 };
 
 void TestCleanerService::initTestCase()
@@ -335,6 +343,43 @@ void TestCleanerService::cleanTrash_removesContents_viaSeam()
     QCOMPARE(QDir(tmp.path() + "/files").entryList(QDir::AllEntries | QDir::Hidden | QDir::NoDotAndDotDot).size(), 0);
     QCOMPARE(QDir(tmp.path() + "/info").entryList(QDir::AllEntries | QDir::Hidden | QDir::NoDotAndDotDot).size(), 0);
 #endif
+}
+
+void TestCleanerService::cleanTrash_includesMountedFilesystemTrashDirs()
+{
+    // GH#182: cleanTrash() must also empty .Trash-$UID/files and
+    // .Trash-$UID/info on mounted filesystems, not just the home trash.
+    QTemporaryDir homeTrash;
+    QVERIFY(homeTrash.isValid());
+
+    QTemporaryDir mountTrash;
+    QVERIFY(mountTrash.isValid());
+
+    // Set up the home trash structure
+    const QString homeFile = writeFile(homeTrash.path() + "/files/home.txt", "home");
+    const QString homeInfo = writeFile(homeTrash.path() + "/info/home.trashinfo", "INFO");
+
+    // Set up a mounted-filesystem trash dir (.Trash-$UID/files and /info)
+    const QString mountFile = writeFile(mountTrash.path() + "/files/mount.txt", "mounted");
+    const QString mountInfo = writeFile(mountTrash.path() + "/info/mount.trashinfo", "INFO2");
+
+    TestableCleanerService cs;
+    cs.mockTrashRoot = homeTrash.path();
+    cs.mockMountedTrashDirs = { mountTrash.path() };
+
+    cs.cleanTrash();
+
+    // Home trash must be empty
+    QCOMPARE(QDir(homeTrash.path() + "/files").entryList(
+        QDir::AllEntries | QDir::Hidden | QDir::NoDotAndDotDot).size(), 0);
+    QCOMPARE(QDir(homeTrash.path() + "/info").entryList(
+        QDir::AllEntries | QDir::Hidden | QDir::NoDotAndDotDot).size(), 0);
+
+    // Mounted-filesystem trash must also be empty
+    QVERIFY2(!QFile::exists(mountFile),
+             "cleanTrash must empty files/ in mounted-filesystem .Trash-$UID");
+    QVERIFY2(!QFile::exists(mountInfo),
+             "cleanTrash must empty info/ in mounted-filesystem .Trash-$UID");
 }
 
 QTEST_MAIN(TestCleanerService)


### PR DESCRIPTION
## Summary

Addresses three GitHub issues triaged from the community issue tracker (SSO-7302).

- **GH#182 — Trash: enumerate mounted-filesystem trash dirs** (`feat`): `CleanerService` now enumerates `QStorageInfo::mountedVolumes()` and includes `.Trash-<UID>/` and `.Trash/<UID>/` directories on non-home mounts in both the Trash size scan and `cleanTrash()`. Implements the FreeDesktop Trash Specification so files deleted from USB drives and secondary internal drives are visible and cleanable in Nexis. Virtual `mountedFilesystemTrashDirs()` test seam added; one new test slot in `test_cleaner_service.cpp`.

- **GH#185 — Docs: correct supported Ubuntu versions** (`fix`): README.md still advertised Ubuntu 22.04 (Jammy) and 24.04 (Noble) as PPA-supported; both were dropped in v2.6.0 when Qt was raised to 6.8 LTS. Updated to list Plucky/Questing/Resolute and added a note directing Jammy/Noble/Mint Zena users to the AppImage.

- **GH#186 — PPA: add Ubuntu 26.04 (Resolute) to build matrix** (`fix`): `ppa.yml` series extended from `[plucky, questing]` to `[plucky, questing, resolute]` so apt users on Ubuntu 26.04 LTS receive packages automatically.

## Files changed

| File | Change |
|------|--------|
| `shared/nexis/Managers/cleaner_service.h` | `mountedFilesystemTrashDirs()` virtual seam |
| `shared/nexis/Managers/cleaner_service.cpp` | Implementation + scan/clean updates |
| `tests/managers/test_cleaner_service.cpp` | New test + seam override |
| `.github/workflows/ppa.yml` | Add `resolute` to series matrix |
| `README.md` | Correct PPA-supported Ubuntu versions |
| `docs/APPLICATION_OVERVIEW.md` | Update PPA line + Trash category description |
| `CHANGELOG.md` | Entries under `[Unreleased]` |

## Test plan

- [ ] Build passes on Linux: `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)`
- [ ] CTest passes: `ctest --test-dir build --output-on-failure` — especially `CleanerServiceTests`
- [ ] Verify new `cleanTrash_includesMountedFilesystemTrashDirs` test slot appears and passes
- [ ] PPA CI run on `resolute` series succeeds after merge + tag

Closes #182, #185, #186. Tracked in Paperclip as SSO-7303, SSO-7304, SSO-7305 (children of SSO-7302).

🤖 Generated with [Claude Code](https://claude.com/claude-code)