### PR TITLE
feat(cleaner): support .Trash-$UID dirs on mounted filesystems (GH#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Trash support for mounted filesystems (GH#182):** Nexis now discovers and includes `.Trash-$UID` and `.Trash/$UID` directories on mounted volumes (USB drives, secondary drives) when scanning and emptying Trash, per the FreeDesktop Trash Specification § 1.2. Previously only `~/.local/share/Trash/` was considered. `CleanerService::trashRoots()` (virtual test seam) returns all applicable roots; `cleanTrash()` and `scan(TRASH)` iterate each discovered root. New `cleanTrash_multipleRoots_allCleaned` test covers the multi-root path.
+
 ## [2.6.0] - 2026-06-21
 
 ### Added

--- a/shared/nexis/Managers/cleaner_service.cpp
+++ b/shared/nexis/Managers/cleaner_service.cpp
@@ -10,6 +10,7 @@
 #include <Utils/format_util.h>
 #include <QDir>
 #include <QStandardPaths>
+#include <QStorageInfo>
 #include <QJsonDocument>
 #include <QJsonArray>
 #include <QJsonObject>
@@ -219,12 +220,13 @@ CleanerService::ScanResult CleanerService::scan(const QList<CleanCategory> &cate
                 break;
             }
             case TRASH: {
-#ifdef Q_OS_MACOS
-                QString trashPath = QDir::homePath() + "/.Trash/";
-#else
-                QString trashPath = QDir::homePath() + "/.local/share/Trash/";
-#endif
-                files = { QFileInfo(trashPath) };
+                // GH#182: include all trash roots — home trash plus any
+                // per-volume .Trash-$uid/.Trash/$uid dirs on mounted FSes.
+                for (const QString &trashPath : trashRoots()) {
+                    QFileInfo fi(trashPath);
+                    if (fi.exists())
+                        files.append(fi);
+                }
                 break;
             }
             case DOWNLOADS_AGED: {
@@ -384,19 +386,50 @@ CleanerService::CleanResult CleanerService::clean(const QList<CleanCategory> &ca
     return result;
 }
 
-QString CleanerService::trashRoot() const
+QStringList CleanerService::trashRoots() const
 {
+    QStringList roots;
+
 #ifdef Q_OS_MACOS
-    return QDir::homePath() + "/.Trash";
+    roots << QDir::homePath() + "/.Trash";
 #else
-    return QDir::homePath() + "/.local/share/Trash";
+    // Home trash (XDG base, always present even when empty)
+    roots << QDir::homePath() + "/.local/share/Trash";
+
+    // Per-volume trash directories — FreeDesktop Trash Specification § 1.2.
+    // Each mounted volume may have a .Trash-$uid/ sibling at its root
+    // (.Trash/$uid/ is the sticky-bit variant; both are checked).
+    const QString uidStr = QString::number(static_cast<uint>(geteuid()));
+    for (const QStorageInfo &vol : QStorageInfo::mountedVolumes()) {
+        if (!vol.isValid() || !vol.isReady())
+            continue;
+        const QString mp = vol.rootPath();
+        // Skip root (covered by home trash) and virtual/pseudo mounts.
+        if (mp.isEmpty() || mp == "/")
+            continue;
+        if (mp.startsWith("/proc") || mp.startsWith("/sys") ||
+            mp.startsWith("/dev")  || mp.startsWith("/run") ||
+            mp.startsWith("/snap") || vol.device().startsWith("/dev/loop"))
+            continue;
+
+        // $topdir/.Trash-$uid/
+        const QString trashUid = mp + "/.Trash-" + uidStr;
+        if (QDir(trashUid).exists())
+            roots << trashUid;
+
+        // $topdir/.Trash/$uid/
+        const QString trashSticky = mp + "/.Trash/" + uidStr;
+        if (QDir(trashSticky).exists())
+            roots << trashSticky;
+    }
 #endif
+
+    return roots;
 }
 
 quint64 CleanerService::cleanTrash()
 {
-    const QString trashPath = trashRoot();
-    const quint64 sizeBefore = FileUtil::getFileSize(trashPath);
+    quint64 totalSizeBefore = 0;
 
     auto emptyDir = [](const QString &dirPath) {
         QDir dir(dirPath);
@@ -413,14 +446,17 @@ quint64 CleanerService::cleanTrash()
         }
     };
 
+    for (const QString &trashPath : trashRoots()) {
+        totalSizeBefore += FileUtil::getFileSize(trashPath);
 #ifdef Q_OS_MACOS
-    emptyDir(trashPath);
+        emptyDir(trashPath);
 #else
-    emptyDir(trashPath + "/files");
-    emptyDir(trashPath + "/info");
+        emptyDir(trashPath + "/files");
+        emptyDir(trashPath + "/info");
 #endif
+    }
 
-    return sizeBefore;
+    return totalSizeBefore;
 }
 
 quint64 CleanerService::cleanFiles(const QStringList &paths, int minFileAgeSecs,

--- a/shared/nexis/Managers/cleaner_service.h
+++ b/shared/nexis/Managers/cleaner_service.h
@@ -134,9 +134,12 @@ protected:
     // beginning with `-` from being interpreted as an rm option.
     virtual void removeElevated(const QStringList &paths);
 
-    // WI-08: test seam for cleanTrash(). Production returns the platform's
-    // user Trash directory; tests override to point at a QTemporaryDir.
-    virtual QString trashRoot() const;
+    // WI-08 / GH#182: test seam for cleanTrash() and scan(). Production
+    // returns all trash directories the current user has items in: the home
+    // trash plus, on Linux, any per-volume .Trash-$UID and .Trash/$UID
+    // directories found on mounted filesystems (FreeDesktop Trash spec §1.2).
+    // Tests override to return a controlled list of QTemporaryDir paths.
+    virtual QStringList trashRoots() const;
 
     // SSO-3399 / SSO-3704: test seam for the user-vs-root ownership split in
     // cleanFiles(). Production compares ownerId() to geteuid(); tests override

--- a/tests/managers/test_cleaner_access_needed.cpp
+++ b/tests/managers/test_cleaner_access_needed.cpp
@@ -58,7 +58,7 @@ protected:
         return true;
     }
 
-    QString trashRoot() const override { return QString(); }
+    QStringList trashRoots() const override { return {}; }
 };
 
 class TestCleanerAccessNeeded : public QObject

--- a/tests/managers/test_cleaner_service.cpp
+++ b/tests/managers/test_cleaner_service.cpp
@@ -45,9 +45,11 @@ protected:
         }
     }
 
-    QString trashRoot() const override
+    QStringList trashRoots() const override
     {
-        return mockTrashRoot;
+        if (!mockTrashRoot.isEmpty())
+            return { mockTrashRoot };
+        return CleanerService::trashRoots();
     }
 };
 
@@ -104,6 +106,7 @@ private slots:
     void cleanFiles_elevatedBranch_routesThroughSeam();
     void cleanFiles_elevatedBranch_argvHasEndOfOptionsGuard();
     void cleanTrash_removesContents_viaSeam();
+    void cleanTrash_multipleRoots_allCleaned();   // GH#182
 };
 
 void TestCleanerService::initTestCase()
@@ -334,6 +337,38 @@ void TestCleanerService::cleanTrash_removesContents_viaSeam()
 #else
     QCOMPARE(QDir(tmp.path() + "/files").entryList(QDir::AllEntries | QDir::Hidden | QDir::NoDotAndDotDot).size(), 0);
     QCOMPARE(QDir(tmp.path() + "/info").entryList(QDir::AllEntries | QDir::Hidden | QDir::NoDotAndDotDot).size(), 0);
+#endif
+}
+
+void TestCleanerService::cleanTrash_multipleRoots_allCleaned()
+{
+#ifdef Q_OS_MACOS
+    QSKIP("macOS .Trash has a flat layout; mounted-FS trash test is Linux-only");
+#else
+    // Simulate a home trash root plus a mounted-filesystem .Trash-$uid root.
+    // Both must be emptied in a single cleanTrash() call (GH#182).
+    QTemporaryDir home;
+    QTemporaryDir mount;
+    QVERIFY(home.isValid() && mount.isValid());
+
+    writeFile(home.path()  + "/files/a.txt",      "AAA");
+    writeFile(home.path()  + "/info/a.trashinfo",  "INFO");
+    writeFile(mount.path() + "/files/b.txt",       "BBB");
+    writeFile(mount.path() + "/info/b.trashinfo",  "INFO");
+
+    struct MultiRootCS : public TestableCleanerService {
+        QStringList roots;
+        QStringList trashRoots() const override { return roots; }
+    } cs;
+    cs.roots = { home.path(), mount.path() };
+
+    const quint64 before = cs.cleanTrash();
+    QVERIFY(before > 0);
+
+    QCOMPARE(QDir(home.path()  + "/files").entryList(QDir::AllEntries | QDir::Hidden | QDir::NoDotAndDotDot).size(), 0);
+    QCOMPARE(QDir(home.path()  + "/info" ).entryList(QDir::AllEntries | QDir::Hidden | QDir::NoDotAndDotDot).size(), 0);
+    QCOMPARE(QDir(mount.path() + "/files").entryList(QDir::AllEntries | QDir::Hidden | QDir::NoDotAndDotDot).size(), 0);
+    QCOMPARE(QDir(mount.path() + "/info" ).entryList(QDir::AllEntries | QDir::Hidden | QDir::NoDotAndDotDot).size(), 0);
 #endif
 }
 


### PR DESCRIPTION
## Summary

Implements FreeDesktop Trash Specification § 1.2 for mounted filesystems (closes GH#182 / NEX-7303).

- **`CleanerService::trashRoots()`** (new virtual, replaces `trashRoot()`) enumerates all applicable trash directories: home trash (`~/.local/share/Trash/`) plus `.Trash-$uid/` and `.Trash/$uid/` on every non-root, non-virtual mounted volume found via `QStorageInfo::mountedVolumes()`. Pseudo-mounts (`/proc`, `/sys`, `/dev`, `/run`, `/snap`, `/dev/loop*`) are skipped.
- **`cleanTrash()`** and **`scan(TRASH)`** now iterate all roots returned by `trashRoots()`, so USB drives and secondary partitions are cleaned and scanned alongside the home trash.
- **Tests:** `TestableCleanerService` seam updated to override `trashRoots()` (returns `{mockTrashRoot}` when set). New `cleanTrash_multipleRoots_allCleaned` slot verifies the multi-root clean path end-to-end with two `QTemporaryDir`-backed roots. 13/13 tests pass.

## Files changed

- `shared/nexis/Managers/cleaner_service.h` — `trashRoot()` → `trashRoots()` virtual seam
- `shared/nexis/Managers/cleaner_service.cpp` — `QStorageInfo` include; new `trashRoots()` impl; updated `cleanTrash()` and `scan(TRASH)`
- `tests/managers/test_cleaner_service.cpp` — seam override update + new multi-root test
- `tests/managers/test_cleaner_access_needed.cpp` — seam override update
- `CHANGELOG.md` — `[Unreleased]` entry

## Test plan

- [x] Build clean with `cmake --build` — passes
- [x] `ctest -R CleanerService|CleanerAccess` — 13/13 pass (1 macOS skip expected)
- [ ] QA: plug in a USB drive with a `.Trash-$UID/` directory and verify Nexis Cleaner now reports and empties it

Closes GH#182