### PR TITLE
feat(dashboard): clean up network interface palette — routable filter + friendly names (GH#191)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,7 +685,7 @@ message(STATUS "App version: ${APP_VERSION}")
 
 target_compile_definitions(nexis-gui PUBLIC QT_DEPRECATED_WARNINGS "APP_VERSION=\"${APP_VERSION}\"")
 target_link_libraries(nexis-gui PUBLIC
-  nexis-core Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Charts Qt6::Svg Qt6::Concurrent
+  nexis-core Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Charts Qt6::Svg Qt6::Concurrent Qt6::Network
 )
 
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,11 +320,13 @@ target_include_directories(nexis-core PUBLIC
 target_compile_definitions(nexis-core PRIVATE NEXISCORE_LIBRARY QT_DEPRECATED_WARNINGS)
 target_link_libraries(nexis-core Qt6::Core Qt6::Network Qt6::Concurrent)
 
-# macOS-specific frameworks needed for system info APIs (IOKit, CoreFoundation)
+# macOS-specific frameworks needed for system info APIs (IOKit, CoreFoundation,
+# SystemConfiguration for GH#191 localized network interface names)
 if(APPLE)
   find_library(IOKIT_FRAMEWORK IOKit)
   find_library(COREFOUNDATION_FRAMEWORK CoreFoundation)
-  target_link_libraries(nexis-core ${IOKIT_FRAMEWORK} ${COREFOUNDATION_FRAMEWORK})
+  find_library(SYSTEMCONFIGURATION_FRAMEWORK SystemConfiguration)
+  target_link_libraries(nexis-core ${IOKIT_FRAMEWORK} ${COREFOUNDATION_FRAMEWORK} ${SYSTEMCONFIGURATION_FRAMEWORK})
 endif()
 
 # ============================================================================

--- a/linux/nexis-core/Info/network_info.cpp
+++ b/linux/nexis-core/Info/network_info.cpp
@@ -2,6 +2,8 @@
 
 #include <QDebug>
 #include <QFile>
+#include <QFileInfo>
+#include <QObject>
 #include <QStringList>
 
 namespace {
@@ -119,4 +121,21 @@ QList<QNetworkInterface> NetworkInfoLinux::getAllInterfaces()
 QString NetworkInfoLinux::getDefaultNetworkInterface() const
 {
     return defaultNetworkInterface;
+}
+
+QString NetworkInfoLinux::interfaceDisplayName(const QString &name) const
+{
+    const QString base = QStringLiteral("/sys/class/net/%1").arg(name);
+    if (QFileInfo::exists(base + "/wireless") || QFileInfo::exists(base + "/phy80211"))
+        return QObject::tr("Wi-Fi");
+    if (QFileInfo::exists(base + "/tun_flags"))
+        return QObject::tr("VPN");
+    if (QFileInfo::exists(base + "/bridge"))
+        return QObject::tr("Bridge");
+    QFile tf(base + "/type");
+    if (tf.open(QIODevice::ReadOnly)) {
+        const QByteArray t = tf.readAll().trimmed();
+        if (t == "1") return QObject::tr("Ethernet");  // ARPHRD_ETHER
+    }
+    return {};
 }

--- a/linux/nexis-core/Info/network_info_linux.h
+++ b/linux/nexis-core/Info/network_info_linux.h
@@ -14,6 +14,10 @@ public:
 
     void updateNetworkBytes() override;
 
+    // GH#191: synthesize a type label ("Wi-Fi", "Ethernet", "VPN", "Bridge")
+    // from /sys/class/net/<name>/ — Linux has no OS-localized iface names.
+    QString interfaceDisplayName(const QString &name) const override;
+
     // Exposed for unit tests. Parses the contents of /proc/net/route and
     // returns the iface name owning the IPv4 default route (Destination
     // column == 00000000), or an empty string if none.

--- a/macos/nexis-core/Info/network_info.cpp
+++ b/macos/nexis-core/Info/network_info.cpp
@@ -7,6 +7,8 @@
 #include <net/if_dl.h>
 #include <ifaddrs.h>
 
+#include <SystemConfiguration/SystemConfiguration.h>
+
 NetworkInfoMacOS::NetworkInfoMacOS()
 {
     refreshDefaultInterface();
@@ -97,4 +99,51 @@ QList<QNetworkInterface> NetworkInfoMacOS::getAllInterfaces()
 QString NetworkInfoMacOS::getDefaultNetworkInterface() const
 {
     return defaultNetworkInterface;
+}
+
+void NetworkInfoMacOS::rebuildDisplayNameCache() const
+{
+    // GH#191: walk every configured network interface once and map its BSD
+    // name (e.g. "en0") to the OS-localized display name (e.g. "Wi-Fi").
+    mDisplayNameCache.clear();
+
+    CFArrayRef interfaces = SCNetworkInterfaceCopyAll();
+    if (!interfaces)
+        return;
+
+    const CFIndex count = CFArrayGetCount(interfaces);
+    for (CFIndex i = 0; i < count; ++i) {
+        SCNetworkInterfaceRef iface =
+            static_cast<SCNetworkInterfaceRef>(
+                const_cast<void *>(CFArrayGetValueAtIndex(interfaces, i)));
+        if (!iface)
+            continue;
+
+        CFStringRef bsdName = SCNetworkInterfaceGetBSDName(iface);
+        CFStringRef displayName = SCNetworkInterfaceGetLocalizedDisplayName(iface);
+        if (!bsdName || !displayName)
+            continue;
+
+        mDisplayNameCache.insert(QString::fromCFString(bsdName),
+                                 QString::fromCFString(displayName));
+    }
+
+    CFRelease(interfaces);
+}
+
+QString NetworkInfoMacOS::interfaceDisplayName(const QString &name) const
+{
+    // Called on the network tile subtitle every ~1s — keep it cheap by
+    // caching. Populate lazily on first use; if the queried name is missing
+    // (interface plugged in after the cache was built), rebuild once.
+    if (mDisplayNameCache.isEmpty())
+        rebuildDisplayNameCache();
+
+    auto it = mDisplayNameCache.constFind(name);
+    if (it == mDisplayNameCache.constEnd()) {
+        rebuildDisplayNameCache();
+        it = mDisplayNameCache.constFind(name);
+    }
+
+    return it != mDisplayNameCache.constEnd() ? it.value() : QString();
 }

--- a/macos/nexis-core/Info/network_info.cpp
+++ b/macos/nexis-core/Info/network_info.cpp
@@ -108,8 +108,10 @@ void NetworkInfoMacOS::rebuildDisplayNameCache() const
     mDisplayNameCache.clear();
 
     CFArrayRef interfaces = SCNetworkInterfaceCopyAll();
-    if (!interfaces)
+    if (!interfaces) {
+        mDisplayNameCacheBuilt = true;
         return;
+    }
 
     const CFIndex count = CFArrayGetCount(interfaces);
     for (CFIndex i = 0; i < count; ++i) {
@@ -129,6 +131,7 @@ void NetworkInfoMacOS::rebuildDisplayNameCache() const
     }
 
     CFRelease(interfaces);
+    mDisplayNameCacheBuilt = true;
 }
 
 QString NetworkInfoMacOS::interfaceDisplayName(const QString &name) const
@@ -136,7 +139,7 @@ QString NetworkInfoMacOS::interfaceDisplayName(const QString &name) const
     // Called on the network tile subtitle every ~1s — keep it cheap by
     // caching. Populate lazily on first use; if the queried name is missing
     // (interface plugged in after the cache was built), rebuild once.
-    if (mDisplayNameCache.isEmpty())
+    if (!mDisplayNameCacheBuilt)
         rebuildDisplayNameCache();
 
     auto it = mDisplayNameCache.constFind(name);

--- a/macos/nexis-core/Info/network_info_macos.h
+++ b/macos/nexis-core/Info/network_info_macos.h
@@ -2,6 +2,7 @@
 #define NETWORK_INFO_MACOS_H
 
 #include <Info/network_info.h>
+#include <QHash>
 
 class NetworkInfoMacOS : public NetworkInfo
 {
@@ -13,8 +14,18 @@ public:
 
     void updateNetworkBytes() override;
 
+    // GH#191: localized interface display name via SystemConfiguration.
+    QString interfaceDisplayName(const QString &name) const override;
+
 private:
     void refreshDefaultInterface();
+
+    // GH#191: BSD name -> localized display name cache. Populated lazily on
+    // first query; rebuilt once if a queried name is missing (interfaces can
+    // be plugged/unplugged at runtime). Mutable so the const accessor can
+    // refresh it.
+    void rebuildDisplayNameCache() const;
+    mutable QHash<QString, QString> mDisplayNameCache;
 };
 
 #endif // NETWORK_INFO_MACOS_H

--- a/macos/nexis-core/Info/network_info_macos.h
+++ b/macos/nexis-core/Info/network_info_macos.h
@@ -26,6 +26,7 @@ private:
     // refresh it.
     void rebuildDisplayNameCache() const;
     mutable QHash<QString, QString> mDisplayNameCache;
+    mutable bool mDisplayNameCacheBuilt = false;
 };
 
 #endif // NETWORK_INFO_MACOS_H

--- a/shared/nexis-core/Info/network_info.h
+++ b/shared/nexis-core/Info/network_info.h
@@ -42,6 +42,11 @@ public:
     // restricted to non-loopback up+running interfaces.
     const NetInterfaceStatsMap &getInterfaceStats() const { return mInterfaceStats; }
 
+    // GH#191: human-readable name/type for an interface ("Wi-Fi", "Ethernet",
+    // "Thunderbolt Bridge", "VPN", ...). Empty when none is available; callers
+    // fall back to the raw kernel/BSD name.
+    virtual QString interfaceDisplayName(const QString &name) const { return {}; }
+
 protected:
     QString defaultNetworkInterface;
     quint64 mRxBytes = 0;

--- a/shared/nexis/Managers/info_manager.cpp
+++ b/shared/nexis/Managers/info_manager.cpp
@@ -325,6 +325,11 @@ QStringList InfoManager::getNetworkInterfaceNames() const
     return names;
 }
 
+QString InfoManager::getNetworkInterfaceDisplayName(const QString &name) const
+{
+    return ni->interfaceDisplayName(name);
+}
+
 NetInterfaceStatsMap InfoManager::getInterfaceStats() const
 {
     return ni->getInterfaceStats();

--- a/shared/nexis/Managers/info_manager.cpp
+++ b/shared/nexis/Managers/info_manager.cpp
@@ -1,5 +1,7 @@
 #include "info_manager.h"
 #include <QStandardPaths>
+#include <QNetworkInterface>
+#include <QHostAddress>
 
 #ifdef Q_OS_MACOS
 #include <Info/cpu_info_macos.h>
@@ -290,7 +292,35 @@ QString InfoManager::getDefaultNetworkInterface() const
 
 QStringList InfoManager::getNetworkInterfaceNames() const
 {
-    QStringList names = getInterfaceStats().keys();
+    // GH#191: the palette should only offer interfaces a user would actually
+    // monitor. getInterfaceStats() keeps every up/running non-loopback iface,
+    // which on macOS includes Apple-internal/virtual ones (awdl0, anpi*, llw0,
+    // ap1, bridge0, idle utunN) that carry only a link-local address. Keep an
+    // interface only if it is up + running + non-loopback AND has at least one
+    // ROUTABLE address (not link-local, not loopback) — i.e. it is actually
+    // carrying usable connectivity (Wi-Fi/Ethernet, or an active VPN tunnel).
+    QStringList names;
+    const NetInterfaceStatsMap stats = getInterfaceStats();
+    for (auto it = stats.constBegin(); it != stats.constEnd(); ++it) {
+        const QNetworkInterface iface = QNetworkInterface::interfaceFromName(it.key());
+        if (!iface.isValid())
+            continue;
+        const QNetworkInterface::InterfaceFlags flags = iface.flags();
+        if (!(flags & QNetworkInterface::IsUp) ||
+            !(flags & QNetworkInterface::IsRunning) ||
+            (flags & QNetworkInterface::IsLoopBack))
+            continue;
+        bool routable = false;
+        for (const QNetworkAddressEntry &entry : iface.addressEntries()) {
+            const QHostAddress ip = entry.ip();
+            if (!ip.isNull() && !ip.isLinkLocal() && !ip.isLoopback()) {
+                routable = true;
+                break;
+            }
+        }
+        if (routable)
+            names << it.key();
+    }
     names.sort();
     return names;
 }

--- a/shared/nexis/Managers/info_manager.h
+++ b/shared/nexis/Managers/info_manager.h
@@ -63,6 +63,7 @@ public:
     quint64 getTXbytes() const;
     QString getDefaultNetworkInterface() const;
     QStringList getNetworkInterfaceNames() const;
+    QString getNetworkInterfaceDisplayName(const QString &name) const;
     NetInterfaceStatsMap getInterfaceStats() const;
 
     QList<Disk> getDisks() const;

--- a/shared/nexis/Pages/Dashboard/dashboard_page.cpp
+++ b/shared/nexis/Pages/Dashboard/dashboard_page.cpp
@@ -11,7 +11,9 @@
 #include "signal_mapper.h"
 
 #include <QDateTime>
+#include <QHostAddress>
 #include <QNetworkAccessManager>
+#include <QNetworkInterface>
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QRegularExpression>
@@ -667,7 +669,11 @@ void DashboardPage::onNetworkUpdated(quint64 rxBytes, quint64 txBytes)
         quint64 rx = stats.value(iface).rx;
         quint64 tx = stats.value(iface).tx;
         auto last = mNetLastBytes.value(w->tileId(), {rx, tx});
-        tile->setInterfaceName(iface);
+        // GH#191: show the friendly form ("Wi-Fi (en0)") on the tile subtitle.
+        // The macOS display-name cache keeps this cheap per-tick.
+        QString friendly = im->getNetworkInterfaceDisplayName(iface);
+        tile->setInterfaceName(friendly.isEmpty() ? iface
+                                                   : QStringLiteral("%1 (%2)").arg(friendly, iface));
         tile->setValues(rx - last.first, tx - last.second, rx, tx);
         mNetLastBytes[w->tileId()] = {rx, tx};
     }
@@ -1864,7 +1870,25 @@ void DashboardPage::onAddTileClicked()
     { QList<QPair<QString, QString>> v; for (const FanSensor &f : im->getFanSensors()) v.append({f.id, f.label}); addAvail("fan", v); }
     { QList<QPair<QString, QString>> v; for (const GpuDevice &g : im->getGpuDevices()) v.append({g.name, g.name}); addAvail("gpu", v); }
     { QList<QPair<QString, QString>> v; for (const Disk &d : im->getDisks()) v.append({d.name, d.name}); addAvail("disk", v); }
-    { QList<QPair<QString, QString>> v; for (const QString &n : im->getNetworkInterfaceNames()) v.append({n, n}); addAvail("network", v); }
+    {
+        // GH#191: build a friendly LABEL (display name + iface + IP) while
+        // keeping the KEY = the raw interface name (the dialog binds on the
+        // key and addAvail filters used inputs by key, so both still work).
+        QList<QPair<QString, QString>> v;
+        for (const QString &n : im->getNetworkInterfaceNames()) {
+            QString friendly = im->getNetworkInterfaceDisplayName(n);
+            QString ip;
+            const QNetworkInterface iface = QNetworkInterface::interfaceFromName(n);
+            for (const QNetworkAddressEntry &e : iface.addressEntries()) {
+                const QHostAddress a = e.ip();
+                if (!a.isNull() && !a.isLinkLocal() && !a.isLoopback()) { ip = a.toString(); break; }
+            }
+            QString label = friendly.isEmpty() ? n : QStringLiteral("%1 (%2)").arg(friendly, n);
+            if (!ip.isEmpty()) label += QStringLiteral(" — %1").arg(ip);
+            v.append({n, label});
+        }
+        addAvail("network", v);
+    }
 
     // GH#191: a multi-instance type is offered in the type list whenever its
     // hardware EXISTS on the system (>=1 detected input), regardless of whether


### PR DESCRIPTION
## Summary

Follow-up to #196 that makes the dashboard's **Network** tile palette usable. Previously the input list showed every up/running non-loopback interface — on macOS that's ~17 entries of Apple-internal/virtual junk (`anpi*`, `ap1`, `awdl0`, `llw0`, `bridge0`, idle `utun*`), all labelled with opaque BSD names like `en0`.

Two changes:

### 1. Filter to interfaces that actually carry connectivity
`InfoManager::getNetworkInterfaceNames()` now keeps an interface only if it's **up + running + non-loopback** *and* has at least one **non-link-local, non-loopback IP** — i.e. it's actually carrying usable connectivity. Keeps Wi-Fi, connected Ethernet, and active VPN tunnels; drops the link-local-only Apple interfaces and idle tunnels. Pure cross-platform Qt (`QHostAddress::isLinkLocal/isLoopback`), no brittle name blocklists. Stays a subset of `getInterfaceStats()` so bound tiles keep their live data.

### 2. Human-friendly names
The palette and the network tile subtitle now show e.g. **`Wi-Fi (en0) — 192.168.1.5`** instead of `en0`:
- **macOS:** SystemConfiguration (`SCNetworkInterfaceGetLocalizedDisplayName`) → "Wi-Fi" / "Ethernet" / "Thunderbolt Bridge" / … (cached; SystemConfiguration framework linked).
- **Linux:** synthesized from `/sys/class/net/<iface>/` → "Wi-Fi" / "Ethernet" / "VPN" / "Bridge".
- The IP (primary routable address) is appended cross-platform. The dialog's binding **key stays the raw interface name**, so binding + already-placed filtering are unchanged.

## Notes for the reviewer
- Behavior is identical in mechanism on Linux (same Qt filter, no platform branches). The interface *landscape* differs: Linux container/VM bridges (`docker0`, `virbr0`) carry routable private IPs and so remain in the list — defensible, since they carry real traffic a user may want to monitor.
- macOS path built + tested locally; the Linux `/sys` path compiles in CI (no local Linux toolchain) — written with matching override signature, `QObject::tr` (non-QObject class), and pure filesystem reads.
- Reviewed for macOS memory safety (single `CFRelease`, borrowed `Get*` refs untouched, const-safe cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)