### PR TITLE
fix(ci): AppImage GLIBC_2.43 regression — build x86_64 AppImage on glibc 2.35 (GH#195)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,14 @@ jobs:
           echo "DEB_PATH=$DEST" >> "$GITHUB_OUTPUT"
           echo "DEB_NAME=$DEST" >> "$GITHUB_OUTPUT"
 
-      # --- AppImage ---
+      # --- AppImage (arm64 only) ---
+      # GH#195: the x86_64 AppImage is built by the `build-appimage-x86_64` job
+      # on the ubuntu-22.04 runner (glibc 2.35) so it runs on older distros.
+      # Building it here (ubuntu:26.04, glibc 2.43) made 2.6.2 fail to launch on
+      # Linux Mint 21 / Ubuntu 22.04. arm64 stays here for now because aqt has no
+      # official Qt 6.8 Linux-arm64 desktop binary (see RELEASE.md / GH#195).
       - name: Install to AppDir
+        if: matrix.arch == 'arm64'
         run: DESTDIR=${{ github.workspace }}/AppDir cmake --install build
 
       # WI-13 / SSO-3375: pin linuxdeploy to a tagged release and verify the
@@ -136,6 +142,7 @@ jobs:
       #   https://github.com/linuxdeploy/linuxdeploy/releases
       #   https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases
       - name: Download linuxdeploy and Qt plugin (pinned + verified)
+        if: matrix.arch == 'arm64'
         env:
           LINUXDEPLOY_TAG: "1-alpha-20251107-1"
           LINUXDEPLOY_PLUGIN_QT_TAG: "1-alpha-20250213-1"
@@ -178,6 +185,7 @@ jobs:
       # SSO-6445: debug step confirms AppDir layout and qmake path before
       # linuxdeploy runs, so future failures have a clear evidence trail.
       - name: Debug AppDir layout and qmake
+        if: matrix.arch == 'arm64'
         run: |
           echo "=== AppDir/usr/bin ==="
           ls -la AppDir/usr/bin/ || echo "WARN: AppDir/usr/bin not found"
@@ -189,6 +197,7 @@ jobs:
           ldd AppDir/usr/bin/nexis 2>&1 | grep -i qt || echo "(no Qt lines in ldd output)"
 
       - name: Build AppImage
+        if: matrix.arch == 'arm64'
         env:
           QMAKE: /usr/bin/qmake6
           VERSION: ${{ steps.version.outputs.VERSION }}
@@ -215,6 +224,7 @@ jobs:
             --output appimage
 
       - name: Find AppImage file
+        if: matrix.arch == 'arm64'
         id: appimage
         run: |
           APPIMAGE=$(ls Nexis-*.AppImage | head -1)
@@ -232,6 +242,112 @@ jobs:
             ${{ steps.deb.outputs.DEB_PATH }}
             ${{ steps.appimage.outputs.APPIMAGE_PATH }}
             build/output/nexis-${{ matrix.arch }}
+
+  # ============================================================================
+  # AppImage (x86_64) — built on the ubuntu-22.04 runner (glibc 2.35) so the
+  # AppImage launches on Ubuntu 22.04+ / Linux Mint 21+ (GH#195). The `.deb`
+  # leg above builds on ubuntu:26.04 because it links that distro's system Qt
+  # 6.8; an AppImage bundles Qt but NOT glibc, so building it on 26.04 (glibc
+  # 2.43) made the 2.6.2 AppImage fail with `GLIBC_2.43 not found` on every
+  # stable distro. Here Qt 6.8 comes from aqtinstall (decoupled from the host
+  # apt, which on 22.04 only ships Qt 6.2), so the AppImage's glibc floor is the
+  # runner's 2.35. (arm64 AppImage still builds in build-linux on 26.04 — aqt
+  # has no official Qt 6.8 Linux-arm64 desktop binary; tracked as a follow-up.)
+  #
+  # NOTE: this job has not been validated end-to-end — it must be exercised via
+  # a release dry-run (rc tag) before the real v2.6.3 tag. Likely tuning points:
+  # the install-qt-action commit pin, the aqt `arch`/`modules` list (Svg/tools),
+  # and the QMAKE path env. See the PR for the validation checklist.
+  # ============================================================================
+  build-appimage-x86_64:
+    name: AppImage Build (x86_64 · glibc 2.35)
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install build prerequisites
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq build-essential cmake file libgl1-mesa-dev
+
+      # Qt 6.8 from aqtinstall — NOT 22.04 apt (which only has Qt 6.2). The
+      # official Qt binaries are built for broad glibc compatibility, so the
+      # resulting AppImage's glibc floor is the ubuntu-22.04 runner's (2.35).
+      # TODO(GH#195): pin to a commit SHA per the repo's action-pinning policy.
+      - name: Install Qt 6.8
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.8.*'
+          host: linux
+          target: desktop
+          arch: linux_gcc_64
+          # qtcharts + qtsvg are separate modules; LinguistTools (lrelease) ships
+          # in the base install. Adjust this list if `cmake` configure fails on a
+          # missing Qt component during the dry-run.
+          modules: 'qtcharts qtsvg'
+          cache: true
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DAPP_VERSION_OVERRIDE=${{ steps.version.outputs.VERSION }}
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+      - name: Install to AppDir
+        run: DESTDIR=${{ github.workspace }}/AppDir cmake --install build
+
+      # Pinned + SHA-verified linuxdeploy (x86_64) — same provenance discipline
+      # as the build-linux leg (WI-13 / SSO-3375).
+      - name: Download linuxdeploy and Qt plugin (pinned + verified)
+        env:
+          LINUXDEPLOY_TAG: "1-alpha-20251107-1"
+          LINUXDEPLOY_PLUGIN_QT_TAG: "1-alpha-20250213-1"
+          LINUXDEPLOY_SHA256_X86_64: "c20cd71e3a4e3b80c3483cef793cda3f4e990aca14014d23c544ca3ce1270b4d"
+          LINUXDEPLOY_PLUGIN_QT_SHA256_X86_64: "15106be885c1c48a021198e7e1e9a48ce9d02a86dd0a1848f00bdbf3c1c92724"
+        run: |
+          set -euo pipefail
+          ld_file="linuxdeploy-x86_64.AppImage"
+          ldq_file="linuxdeploy-plugin-qt-x86_64.AppImage"
+          wget -q --tries=3 \
+            "https://github.com/linuxdeploy/linuxdeploy/releases/download/${LINUXDEPLOY_TAG}/${ld_file}"
+          wget -q --tries=3 \
+            "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/${LINUXDEPLOY_PLUGIN_QT_TAG}/${ldq_file}"
+          echo "${LINUXDEPLOY_SHA256_X86_64}  ${ld_file}"   | sha256sum -c -
+          echo "${LINUXDEPLOY_PLUGIN_QT_SHA256_X86_64}  ${ldq_file}" | sha256sum -c -
+          chmod +x "${ld_file}" "${ldq_file}"
+
+      - name: Build AppImage
+        env:
+          # install-qt-action exports QT_ROOT_DIR for the selected Qt.
+          QMAKE: ${{ env.QT_ROOT_DIR }}/bin/qmake6
+          APPIMAGE_EXTRACT_AND_RUN: "1"
+        run: |
+          APPDIR="${{ github.workspace }}/AppDir"
+          ./linuxdeploy-x86_64.AppImage \
+            --appdir "$APPDIR" \
+            --executable "$APPDIR/usr/bin/nexis" \
+            --desktop-file "$APPDIR/usr/share/applications/nexis.desktop" \
+            --icon-file "$APPDIR/usr/share/icons/hicolor/256x256/apps/nexis.png" \
+            --plugin qt \
+            --output appimage
+
+      - name: Find AppImage file
+        id: appimage
+        run: |
+          APPIMAGE=$(ls Nexis-*.AppImage | head -1)
+          echo "APPIMAGE_PATH=$APPIMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Upload x86_64 AppImage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: linux-appimage-x86_64
+          path: ${{ steps.appimage.outputs.APPIMAGE_PATH }}
 
   # ============================================================================
   # macOS build: .app bundle + .dmg
@@ -416,7 +532,7 @@ jobs:
   # ============================================================================
   release:
     name: Create Release
-    needs: [build-linux, build-macos]
+    needs: [build-linux, build-appimage-x86_64, build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -430,6 +546,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: linux-artifacts-x86_64
+          path: artifacts/linux-x86_64
+
+      # GH#195: the x86_64 AppImage now comes from the dedicated glibc-2.35 job;
+      # land it in the same dir so the `*.AppImage` glob below picks it up.
+      - name: Download Linux x86_64 AppImage (glibc 2.35)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: linux-appimage-x86_64
           path: artifacts/linux-x86_64
 
       - name: Download Linux ARM64 artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,10 +314,10 @@ jobs:
           host: linux
           target: desktop
           arch: linux_gcc_64
-          # qtcharts + qtsvg are separate modules; LinguistTools (lrelease) ships
-          # in the base install. Adjust this list if `cmake` configure fails on a
-          # missing Qt component during the dry-run.
-          modules: 'qtcharts qtsvg'
+          # Only Qt Charts is an add-on module. Qt Svg and the Linguist tools
+          # (lrelease) ship in the base desktop install — aqt has no 'qtsvg'
+          # module, so listing it fails (GH#195 dry-run run 28185605536).
+          modules: 'qtcharts'
           cache: true
 
       - name: Configure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,19 @@ on:
   push:
     tags:
       - 'v*'
+  # GH#195: manual dry-run. Builds every artifact (.deb, AppImage, .dmg) as
+  # downloadable workflow artifacts WITHOUT publishing anything. The `release`
+  # job is gated to tag pushes (see its `if:`), so a dispatch run never creates
+  # a GitHub Release — and because no tag is pushed and no release is published,
+  # the PPA (tag-triggered), Homebrew, and AUR (release-triggered) workflows
+  # never fire. Use this to validate the release builds (esp. the AppImage's
+  # glibc floor) on a branch before tagging the real release.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version for the dry-run build (e.g. 2.6.3-rc1)'
+        required: false
+        default: '0.0.0-dryrun'
 
 # SSO-3399: default job permissions are read-only. Only the `release` job
 # actually needs `contents: write` (to publish the GitHub Release) and
@@ -77,9 +90,16 @@ jobs:
             fakeroot \
             xvfb
 
-      - name: Extract version from tag
+      - name: Extract version
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          # On a tag push, derive from the tag (vX.Y.Z -> X.Y.Z). On a manual
+          # workflow_dispatch dry-run there is no tag, so use the input. (GH#195)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DAPP_VERSION_OVERRIDE=${{ steps.version.outputs.VERSION }}
@@ -100,7 +120,7 @@ jobs:
 
       - name: Sync debian changelog version from tag
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${{ steps.version.outputs.VERSION }}"
           CURRENT_DEB_VERSION=$(head -1 debian/changelog | grep -oP '\(\K[^)]+' | cut -d- -f1)
           if [ "$CURRENT_DEB_VERSION" != "$TAG_VERSION" ]; then
             echo "Updating debian/changelog from $CURRENT_DEB_VERSION to $TAG_VERSION"
@@ -267,9 +287,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Extract version from tag
+      - name: Extract version
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          # On a tag push, derive from the tag (vX.Y.Z -> X.Y.Z). On a manual
+          # workflow_dispatch dry-run there is no tag, so use the input. (GH#195)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install build prerequisites
         run: |
@@ -368,9 +395,16 @@ jobs:
             sleep 15
           done
 
-      - name: Extract version from tag
+      - name: Extract version
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          # On a tag push, derive from the tag (vX.Y.Z -> X.Y.Z). On a manual
+          # workflow_dispatch dry-run there is no tag, so use the input. (GH#195)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Check for signing secrets
         id: signing
@@ -532,6 +566,10 @@ jobs:
   # ============================================================================
   release:
     name: Create Release
+    # GH#195: publish ONLY on a real tag push. A manual workflow_dispatch run is
+    # a build-only dry-run — skipping this job means no GitHub Release is created
+    # (so Homebrew/AUR never fire) and no tag exists (so the PPA never fires).
+    if: github.event_name == 'push'
     needs: [build-linux, build-appimage-x86_64, build-macos]
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.3] - 2026-06-25
+
+### Fixed
+- **AppImage failed to launch on most Linux distros — `GLIBC_2.43 not found` (GH#195):** the 2.6.2 x86_64 AppImage was built inside the `ubuntu:26.04` release container (glibc 2.43), and since an AppImage bundles Qt but not glibc, it required glibc 2.43 at runtime — so it failed immediately on Ubuntu 22.04 / Linux Mint 21.x (glibc 2.35) and every other stable distro, with `version 'GLIBC_2.43' not found (required by ...libQt6Gui.so.6 / libc.so.6)`. The x86_64 AppImage is now built on the `ubuntu-22.04` runner (glibc 2.35, matching the documented "glibc ≥ 2.35" floor) with Qt 6.8 supplied by aqtinstall instead of the build distro's apt; the `.deb` continues to build on Resolute (26.04) for its system-Qt 6.8 dependency. (Known follow-up: the arm64 AppImage still builds on 26.04 — there is no official Qt 6.8 Linux-arm64 desktop binary to bundle from an older base; arm64 users on glibc < 2.43 should use the `.deb` on 26.04+ until that is addressed.)
+
 ## [2.6.2] - 2026-06-24
 
 ### CI / Internal


### PR DESCRIPTION
Fixes #195.

## Problem
The **2.6.2 x86_64 AppImage fails to launch on every stable Linux distro** (Linux Mint 21.x, Ubuntu 22.04, etc.) with:
```
version `GLIBC_2.43' not found (required by .../libQt6Gui.so.6 / libc.so.6 / libgnutls.so.30)
```
`release.yml` builds the whole Linux matrix inside `container: ubuntu:26.04` (glibc 2.43; introduced by the SSO-7306 25.04→26.04 move for the `.deb`'s Qt 6.8 dependency). An **AppImage bundles Qt but not glibc**, so building it there raised its runtime glibc floor to 2.43. Worse: `RELEASE.md` explicitly routes Mint 21 / Ubuntu 22.04 users (who can't use the Qt-6.8 `.deb`) to the AppImage — so that population currently has **no working install**.

## Fix
- **x86_64 AppImage** now builds in a new `build-appimage-x86_64` job on the **`ubuntu-22.04` runner (glibc 2.35)** — matching the documented "glibc ≥ 2.35" floor — with **Qt 6.8 from `install-qt-action`/aqtinstall** (22.04 apt only has Qt 6.2). The `build-linux` job's AppImage steps are gated to `arm64` only; the release job pulls the x86_64 AppImage from the new job.
- **`.deb`** is unchanged — still built on Resolute (26.04) for its system-Qt 6.8 dependency. It declares its deps and targets 26.04+, so its glibc floor is correct.

## ⚠️ Not yet validated end-to-end — needs a release dry-run before tagging
GitHub Actions changes can't be run locally. The YAML parses and the job graph is wired, but the new job must be exercised via an **rc dry-run** (e.g. tag `v2.6.3-rc1` or a `workflow_dispatch`) before the real `v2.6.3`. Likely tuning points, all commented in the job:
- **Pin `jurplel/install-qt-action@v4` to a commit SHA** (repo action-pinning policy).
- **aqt `arch`/`modules`** — using `linux_gcc_64` + `qtcharts qtsvg`; confirm `cmake` configure finds Charts/Svg/LinguistTools (add `qttools` if lrelease is missing).
- **`QMAKE`** is set from `install-qt-action`'s `QT_ROOT_DIR`.
- `build-linux`'s x86_64 upload now lists an empty AppImage path → a non-fatal `upload-artifact` warning (deb + raw binary still upload).

## Release mechanics (per RELEASE_POLICY: hotfixFromBranch)
This branch is cut **off the `v2.6.2` tag**, so it contains only the CI fix — **tag `v2.6.3` on this branch's commit** to ship the patch without dragging in the unreleased dashboard feature on `native`. Merging into `native` carries the workflow fix forward for future releases (resolve the trivial `CHANGELOG` `[Unreleased]`/`[2.6.3]` overlap on merge).

## Known follow-up (not in this hotfix)
The **arm64 AppImage** still builds on 26.04 (glibc 2.43) — there's no official Qt 6.8 Linux-arm64 desktop binary to bundle from an older base, so the clean fix needs Qt-from-source. arm64 users on glibc < 2.43 should use the `.deb` on 26.04+ meanwhile. Documented in the CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)