### PR TITLE
ci: fix AppImage dry-run — drop invalid 'qtsvg' aqt module (GH#195)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,10 +314,10 @@ jobs:
           host: linux
           target: desktop
           arch: linux_gcc_64
-          # qtcharts + qtsvg are separate modules; LinguistTools (lrelease) ships
-          # in the base install. Adjust this list if `cmake` configure fails on a
-          # missing Qt component during the dry-run.
-          modules: 'qtcharts qtsvg'
+          # Only Qt Charts is an add-on module. Qt Svg and the Linguist tools
+          # (lrelease) ship in the base desktop install — aqt has no 'qtsvg'
+          # module, so listing it fails (GH#195 dry-run run 28185605536).
+          modules: 'qtcharts'
           cache: true
 
       - name: Configure


### PR DESCRIPTION
First dry-run (run 28185605536) failed at `Install Qt 6.8`: aqt has no `qtsvg` module (Qt Svg + Linguist tools are in the base desktop install). Drops `qtsvg` from the module list so only `qtcharts` (a real add-on) is requested. Same fix pushed to the #198 hotfix branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)