### PR TITLE
fix(dashboard): allow resizing tiles beyond 2x2 (GH#191)

### DIFF
--- a/shared/nexis/Pages/Dashboard/dashboard_tile_wrapper.cpp
+++ b/shared/nexis/Pages/Dashboard/dashboard_tile_wrapper.cpp
@@ -1,4 +1,5 @@
 #include "dashboard_tile_wrapper.h"
+#include "dashboard_layout_util.h"
 
 #include <QVBoxLayout>
 #include <QPainter>
@@ -347,8 +348,13 @@ void DashboardTileWrapper::mouseMoveEvent(QMouseEvent *event)
         int cellWidth = width() / mGridColSpan;
         int cellHeight = height() / mGridRowSpan;
         if (cellWidth > 0 && cellHeight > 0) {
-            int newColSpan = qBound(1, (event->pos().x() + cellWidth / 2) / cellWidth, 2);
-            int newRowSpan = qBound(1, (event->pos().y() + cellHeight / 2) / cellHeight, 2);
+            // GH#191: the grid is responsive (up to kMaxCols wide) and rows grow
+            // as needed, so don't hard-cap the span at 2x2 — that was a leftover
+            // from the old fixed 4x4 grid. DashboardPage::onTileResizeRequested()
+            // gates the actual resize via regionIsFree() (real column count +
+            // occupancy), so anything that doesn't fit is simply rejected.
+            int newColSpan = qBound(1, (event->pos().x() + cellWidth / 2) / cellWidth, DashboardLayout::kMaxCols);
+            int newRowSpan = qBound(1, (event->pos().y() + cellHeight / 2) / cellHeight, DashboardLayout::kMaxCols);
             if (newColSpan != mGridColSpan || newRowSpan != mGridRowSpan)
                 emit resizeRequested(this, newColSpan, newRowSpan);
         }


### PR DESCRIPTION
Found during Mint 21 testing of the dashboard: a tile can't be resized larger than 2×2.

**Cause:** the resize handle in `dashboard_tile_wrapper.cpp` clamped both spans to a max of 2:
```cpp
int newColSpan = qBound(1, (event->pos().x() + cellWidth / 2) / cellWidth, 2);
int newRowSpan = qBound(1, (event->pos().y() + cellHeight / 2) / cellHeight, 2);
```
That `2` is a leftover from the original fixed 4×4 proportional grid. On the responsive fixed-cell grid (up to `kMaxCols` columns, rows grow on demand) there's no reason to cap at 2×2.

**Fix:** raise the cap to `DashboardLayout::kMaxCols`. The real "does it fit" check is unchanged — `DashboardPage::onTileResizeRequested()` calls `regionIsFree()` against the live column count + occupancy, so an oversized drag that doesn't fit is simply rejected. Builds clean.

Targets `native` (next dashboard release); not part of the v2.6.3 AppImage hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)