### PR TITLE
docs: bump version headers to 2.7.0

### DIFF
--- a/docs/APPLICATION_OVERVIEW.md
+++ b/docs/APPLICATION_OVERVIEW.md
@@ -1,7 +1,7 @@
 # Nexis — Application Overview
 
 > A comprehensive reference for what Nexis does and how it is built.
-> Last updated: 2026-06-24 | Version 2.6.2 (Unreleased)
+> Last updated: 2026-06-25 | Version 2.7.0
 
 ---
 
@@ -61,7 +61,7 @@ Nexis is a **cross-platform (Linux + macOS) system optimizer and monitoring tool
 
 | Metric | Value | Source of truth |
 |--------|-------|-----------------|
-| Version | 2.3.14 | `project(... VERSION ...)` in `CMakeLists.txt` |
+| Version | 2.7.0 | `project(... VERSION ...)` in `CMakeLists.txt` |
 | Source LOC (C++) | ~48,700 | `shared/`, `linux/`, `macos/` (`*.cpp`/`*.h`/`*.mm`) |
 | Source files (C++) | 338 | same |
 | Test LOC | ~6,050 | `tests/` |

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -1,7 +1,7 @@
 # Nexis — Architecture Review
 
 > A deep and comprehensive review of the Nexis architecture: how logic and UI work together, what's working well, what should change, and where the application should go next.
-> Last updated: 2026-06-24 (SSO-3497, SSO-3383, SSO-3391 / WI-29, SSO-3396 / WI-33, SSO-3738 / FW-10, SSO-3739 / FW-11, SSO-3740 / FW-12, SSO-3743 / FW-15, GH#191) | Version 2.6.2 (Unreleased)
+> Last updated: 2026-06-25 (SSO-3497, SSO-3383, SSO-3391 / WI-29, SSO-3396 / WI-33, SSO-3738 / FW-10, SSO-3739 / FW-11, SSO-3740 / FW-12, SSO-3743 / FW-15, GH#191) | Version 2.7.0
 
 > **Packaging note (SSO-3376, 2026-06):** The Flatpak (Flathub) distribution channel was retired. There is no `flatpak-spawn`/sandbox-detection layer in the codebase — the privileged-host operations Nexis depends on (`pkexec`, `systemctl`, `smartctl`, `fstrim`, `nvidia-smi`, `/proc` and `/sys` reads) are architecturally unsuited to a bubblewrap sandbox, and adding one would require routing `CommandUtil` through `flatpak-spawn --host` plus holding the `org.freedesktop.Flatpak` portal — i.e. eliminating the sandbox benefit. Linux ships via `.deb` (PPA + GitHub releases), AppImage, and AUR.
 


### PR DESCRIPTION
Bumps the `Version X.Y.Z` headers in `docs/APPLICATION_OVERVIEW.md` and `docs/ARCHITECTURE_REVIEW.md` to 2.7.0, fixing the `build.yml` **Doc version header check** that went red after #203 bumped CMake to 2.7.0 without the matching doc headers. Also corrects a stale `Version | 2.3.14` stat in the overview table.

Docs-only — the in-flight v2.7.0 release artifacts are unaffected (the check isn't part of `release.yml`). `scripts/check_doc_versions.sh` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)