### PR TITLE
feat(processes): add process-name column on Linux (GH#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Processes: dedicated process-name column (GH#194, Linux).** The Processes table now shows a short process name (e.g. `systemd`) next to PID, sourced from `/proc/<pid>/comm` and distinct from the full command line — matching `ps`/`top`/`htop` and making the table easier to scan and sort. The column is Linux-only; macOS omits it entirely (no empty column).
+
 ## [2.7.0] - 2026-06-25
 
 ### Added

--- a/docs/APPLICATION_OVERVIEW.md
+++ b/docs/APPLICATION_OVERVIEW.md
@@ -349,7 +349,8 @@ Manage system services (daemons).
 
 View and manage running processes.
 
-- Process table with 19 data columns + 1 fixed kill column: PID, name, user, CPU%, memory%, command line, Disk Read/s, Disk Write/s, Net Down/s, Net Up/s, GPU %, GPU VRAM, and more
+- Process table (20 data columns on Linux / 19 on macOS) + 1 fixed kill column: PID, Name, user, CPU%, memory%, command line, Disk Read/s, Disk Write/s, Net Down/s, Net Up/s, GPU %, GPU VRAM, and more
+- **Process Name column (GH#194, Linux only):** A short process name (e.g. `systemd`) sourced from `/proc/<pid>/comm`, shown right after PID and distinct from the full command line. Omitted entirely on macOS (no permanently-empty column). Column membership is driven by a platform-conditional `Col` enum in `processes_page.h`, so every column index stays correct on both platforms.
 - **Per-row kill icon (GH#174):** A fixed ✕ column at the far right lets users kill a process with a single click without selecting the row first. Rendered by `KillButtonDelegate` using `@destructiveColor` theme token; excluded from the header show/hide menu.
 - Disk Read/s and Disk Write/s columns show per-process disk I/O rates via `proc_pid_rusage()` (macOS) or `/proc/<pid>/io` (Linux), using delta-based calculation with `QElapsedTimer`
 - Net Down/s and Net Up/s columns show per-process network bandwidth via `nettop` parsing (macOS only; Linux shows N/A)

--- a/linux/nexis-core/Info/process_info.cpp
+++ b/linux/nexis-core/Info/process_info.cpp
@@ -215,6 +215,10 @@ QList<Process> ProcessInfoLinux::collectProcesses()
 
         proc.setCmd(ProcInfoParser::formatCmdline(cmdlineBytes, sf.comm));
 
+        // GH#194: the short process name (e.g. "systemd") is already parsed
+        // from /proc/<pid>/stat into sf.comm — no extra /proc read needed.
+        proc.setName(sf.comm);
+
         // FR-115: walk /proc/<pid>/fdinfo/* and fold DRM stats into proc.
         if (mCollectGpu) {
             collectGpuForPid(pid, proc, gpuElapsedSec);

--- a/shared/nexis-core/Info/process.cpp
+++ b/shared/nexis-core/Info/process.cpp
@@ -70,6 +70,16 @@ void Process::setCmd(const QString &value)
     cmd = value;
 }
 
+QString Process::getName() const
+{
+    return name;
+}
+
+void Process::setName(const QString &value)
+{
+    name = value;
+}
+
 QString Process::getStartTime() const
 {
     return startTime;

--- a/shared/nexis-core/Info/process.h
+++ b/shared/nexis-core/Info/process.h
@@ -67,6 +67,11 @@ public:
     QString getCmd() const;
     void setCmd(const QString &value);
 
+    // GH#194: short process name (Linux: /proc/<pid>/comm), distinct from the
+    // full command line in getCmd(). Empty on platforms that don't collect it.
+    QString getName() const;
+    void setName(const QString &value);
+
 private:
     pid_t pid;
     quint64 rss;
@@ -87,6 +92,7 @@ private:
     double gpuPercent = -1.0;
     qint64 gpuVramBytes = -1;
     QString cmd;
+    QString name;
 };
 
 

--- a/shared/nexis/Pages/Processes/processes_page.cpp
+++ b/shared/nexis/Pages/Processes/processes_page.cpp
@@ -38,13 +38,19 @@ ProcessesPage::ProcessesPage(QWidget *parent, InfoManager *infoManager,
 
 void ProcessesPage::init()
 {
+    // Order MUST mirror the Col enum in the header. GH#194: the Name column is
+    // Linux-only (omitted on macOS), matching the conditional Col_Name entry.
     mHeaders = QStringList {
-        "PID", tr("Resident Memory"), tr("%Memory"), tr("Virtual Memory"),
+        "PID",
+#ifdef Q_OS_LINUX
+        tr("Name"),                              // GH#194: Col_Name (Linux only)
+#endif
+        tr("Resident Memory"), tr("%Memory"), tr("Virtual Memory"),
         tr("User"), "%CPU", tr("Start Time"), tr("State"), tr("Group"),
         tr("Nice"), tr("CPU Time"), tr("Session"),
         tr("Disk Read/s"), tr("Disk Write/s"), tr("Net Down/s"), tr("Net Up/s"),
-        tr("GPU %"), tr("GPU VRAM"),            // FR-115 (indices 16, 17)
-        tr("Process")                            // index 18; Kill icon is 19 (kKillCol, not in mHeaders)
+        tr("GPU %"), tr("GPU VRAM"),             // FR-115
+        tr("Process")                            // Col_Cmd (last data column)
     };
 
     // slider settings
@@ -68,13 +74,13 @@ void ProcessesPage::init()
     mSortFilterModel->setSortRole(SortRole);
     mSortFilterModel->setDynamicSortFilter(true);
     mSortFilterModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
-    mSortFilterModel->sort(5, Qt::SortOrder::DescendingOrder);
+    mSortFilterModel->sort(Col_Pcpu, Qt::SortOrder::DescendingOrder);
 
     ui->tableProcess->horizontalHeader()->setSectionsMovable(true);
     ui->tableProcess->horizontalHeader()->setFixedHeight(Dpi::scale(36));
     ui->tableProcess->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     ui->tableProcess->horizontalHeader()->setCursor(Qt::PointingHandCursor);
-    ui->tableProcess->horizontalHeader()->resizeSection(0, 70);
+    ui->tableProcess->horizontalHeader()->resizeSection(Col_Pid, 70);
 
     // GH#174: Kill column — fixed narrow width, not shown in header context menu
     // (not in mHeaders so loadHeaderMenu() ignores it), not sortable.
@@ -118,11 +124,9 @@ void ProcessesPage::init()
 void ProcessesPage::updateProcessIoCollection()
 {
     const auto *header = ui->tableProcess->horizontalHeader();
-    // Columns: 12=Disk Read/s, 13=Disk Write/s, 14=Net Down/s, 15=Net Up/s,
-    //          16=GPU %, 17=GPU VRAM.
-    const bool diskVisible = !header->isSectionHidden(12) || !header->isSectionHidden(13);
-    const bool netVisible  = !header->isSectionHidden(14) || !header->isSectionHidden(15);
-    const bool gpuVisible  = !header->isSectionHidden(16) || !header->isSectionHidden(17);
+    const bool diskVisible = !header->isSectionHidden(Col_DiskRead) || !header->isSectionHidden(Col_DiskWrite);
+    const bool netVisible  = !header->isSectionHidden(Col_NetDown) || !header->isSectionHidden(Col_NetUp);
+    const bool gpuVisible  = !header->isSectionHidden(Col_GpuPct) || !header->isSectionHidden(Col_GpuVram);
     im->setCollectProcessDiskIO(diskVisible);
     im->setCollectProcessNetIO(netVisible);
     im->setCollectProcessGpu(gpuVisible);
@@ -142,8 +146,14 @@ void ProcessesPage::loadHeaderMenu()
 
     }
     mHeaderMenu.addActions(actionList);
-    // exclude headers — GPU %/VRAM (16,17) hidden by default, same pattern as disk/net I/O.
-    QList<int> hiddenHeaders = { 3, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+    // Columns hidden by default (GPU %/VRAM, disk/net I/O, and the verbose
+    // columns). The Name column (GH#194) is intentionally NOT hidden — it is a
+    // primary identity column shown by default on Linux.
+    QList<int> hiddenHeaders = {
+        Col_Vsize, Col_StartTime, Col_State, Col_Group, Col_Nice,
+        Col_CpuTime, Col_Session, Col_DiskRead, Col_DiskWrite,
+        Col_NetDown, Col_NetUp, Col_GpuPct, Col_GpuVram
+    };
 
     QList<QAction*> actions = mHeaderMenu.actions();
     for (const int i : hiddenHeaders) {
@@ -234,6 +244,13 @@ QList<QStandardItem*> ProcessesPage::createRow(const Process &proc)
     // FR-116: pin role used by PinSortFilterProxyModel::lessThan.
     pid_i->setData(ProcessPrefsManager::ins()->isPinned(proc.getCmd()),
                    PinSortFilterProxyModel::PinnedRole);
+
+#ifdef Q_OS_LINUX
+    // GH#194: short process name (Linux only).
+    QStandardItem *name_i = new QStandardItem(proc.getName());
+    name_i->setData(proc.getName(), data);
+    name_i->setData(proc.getName(), Qt::ToolTipRole);
+#endif
 
     QStandardItem *rss_i = new QStandardItem(FormatUtil::formatBytes(proc.getRss()));
     rss_i->setData(proc.getRss(), data);
@@ -338,7 +355,11 @@ QList<QStandardItem*> ProcessesPage::createRow(const Process &proc)
     kill_i->setFlags(Qt::ItemIsEnabled);
     kill_i->setData(tr("Kill process"), Qt::ToolTipRole);
 
-    row << pid_i << rss_i << pmem_i << vsize_i << uname_i << pcpu_i
+    row << pid_i;
+#ifdef Q_OS_LINUX
+    row << name_i;   // GH#194: Col_Name, right after PID
+#endif
+    row << rss_i << pmem_i << vsize_i << uname_i << pcpu_i
         << starttime_i << state_i << group_i << nice_i << cpuTime_i
         << session_i << diskRead_i << diskWrite_i << netDown_i << netUp_i
         << gpuPct_i << gpuVram_i
@@ -359,61 +380,64 @@ void ProcessesPage::updateRow(int row, const Process &proc)
         }
     };
 
-    setCell(0,  QString::number(proc.getPid()), proc.getPid(), proc.getPid());
+    setCell(Col_Pid, QString::number(proc.getPid()), proc.getPid(), proc.getPid());
     // FR-116: refresh pinned role on the updated row.
-    if (auto *pidItem = mItemModel->item(row, 0))
+    if (auto *pidItem = mItemModel->item(row, Col_Pid))
         pidItem->setData(ProcessPrefsManager::ins()->isPinned(proc.getCmd()),
                          PinSortFilterProxyModel::PinnedRole);
-    setCell(1,  FormatUtil::formatBytes(proc.getRss()), proc.getRss(), FormatUtil::formatBytes(proc.getRss()));
-    setCell(2,  QString::number(proc.getPmem()), proc.getPmem(), proc.getPmem());
-    setCell(3,  FormatUtil::formatBytes(proc.getVsize()), proc.getVsize(), FormatUtil::formatBytes(proc.getVsize()));
-    setCell(4,  proc.getUname(), proc.getUname(), proc.getUname());
-    setCell(5,  QString::number(proc.getPcpu()), proc.getPcpu(), proc.getPcpu());
-    setCell(6,  proc.getStartTime(), proc.getStartTime(), proc.getStartTime());
-    setCell(7,  proc.getState(), proc.getState(), proc.getState());
-    setCell(8,  proc.getGroup(), proc.getGroup(), proc.getGroup());
-    setCell(9,  QString::number(proc.getNice()), proc.getNice(), proc.getNice());
-    setCell(10, proc.getCpuTime(), proc.getCpuTime(), proc.getCpuTime());
-    setCell(11, proc.getSession(), proc.getSession(), proc.getSession());
+#ifdef Q_OS_LINUX
+    setCell(Col_Name, proc.getName(), proc.getName(), proc.getName());   // GH#194
+#endif
+    setCell(Col_Rss,     FormatUtil::formatBytes(proc.getRss()), proc.getRss(), FormatUtil::formatBytes(proc.getRss()));
+    setCell(Col_Pmem,    QString::number(proc.getPmem()), proc.getPmem(), proc.getPmem());
+    setCell(Col_Vsize,   FormatUtil::formatBytes(proc.getVsize()), proc.getVsize(), FormatUtil::formatBytes(proc.getVsize()));
+    setCell(Col_User,    proc.getUname(), proc.getUname(), proc.getUname());
+    setCell(Col_Pcpu,    QString::number(proc.getPcpu()), proc.getPcpu(), proc.getPcpu());
+    setCell(Col_StartTime, proc.getStartTime(), proc.getStartTime(), proc.getStartTime());
+    setCell(Col_State,   proc.getState(), proc.getState(), proc.getState());
+    setCell(Col_Group,   proc.getGroup(), proc.getGroup(), proc.getGroup());
+    setCell(Col_Nice,    QString::number(proc.getNice()), proc.getNice(), proc.getNice());
+    setCell(Col_CpuTime, proc.getCpuTime(), proc.getCpuTime(), proc.getCpuTime());
+    setCell(Col_Session, proc.getSession(), proc.getSession(), proc.getSession());
 
     QString diskReadText = proc.getDiskReadRate() < 0
         ? QString::fromUtf8("\u2014")
         : FormatUtil::formatBytes(static_cast<quint64>(proc.getDiskReadRate())) + "/s";
-    setCell(12, diskReadText, proc.getDiskReadRate(), diskReadText);
+    setCell(Col_DiskRead, diskReadText, proc.getDiskReadRate(), diskReadText);
 
     QString diskWriteText = proc.getDiskWriteRate() < 0
         ? QString::fromUtf8("\u2014")
         : FormatUtil::formatBytes(static_cast<quint64>(proc.getDiskWriteRate())) + "/s";
-    setCell(13, diskWriteText, proc.getDiskWriteRate(), diskWriteText);
+    setCell(Col_DiskWrite, diskWriteText, proc.getDiskWriteRate(), diskWriteText);
 
     QString netDownText = proc.getNetDownRate() < 0
         ? QString::fromUtf8("\u2014")
         : FormatUtil::formatBytes(static_cast<quint64>(proc.getNetDownRate())) + "/s";
-    setCell(14, netDownText, proc.getNetDownRate(), netDownText);
+    setCell(Col_NetDown, netDownText, proc.getNetDownRate(), netDownText);
 
     QString netUpText = proc.getNetUpRate() < 0
         ? QString::fromUtf8("\u2014")
         : FormatUtil::formatBytes(static_cast<quint64>(proc.getNetUpRate())) + "/s";
-    setCell(15, netUpText, proc.getNetUpRate(), netUpText);
+    setCell(Col_NetUp, netUpText, proc.getNetUpRate(), netUpText);
 
     QString gpuPctText = proc.getGpuPercent() < 0
         ? QString::fromUtf8("\u2014")
         : QString::number(proc.getGpuPercent(), 'f', 0) + "%";
-    setCell(16, gpuPctText, proc.getGpuPercent(), gpuPctText);
+    setCell(Col_GpuPct, gpuPctText, proc.getGpuPercent(), gpuPctText);
 
     QString gpuVramText = proc.getGpuVramBytes() < 0
         ? QString::fromUtf8("\u2014")
         : FormatUtil::formatBytes(static_cast<quint64>(proc.getGpuVramBytes()));
-    setCell(17, gpuVramText, proc.getGpuVramBytes(), gpuVramText);
+    setCell(Col_GpuVram, gpuVramText, proc.getGpuVramBytes(), gpuVramText);
 
-    setCell(18, proc.getCmd(), proc.getCmd(), QString("<p>%1</p>").arg(proc.getCmd()));
-    if (auto *item = mItemModel->item(row, 18))
+    setCell(Col_Cmd, proc.getCmd(), proc.getCmd(), QString("<p>%1</p>").arg(proc.getCmd()));
+    if (auto *item = mItemModel->item(row, Col_Cmd))
         item->setFont(QFont(QStringLiteral("JetBrains Mono")));
 }
 
 void ProcessesPage::on_txtProcessSearch_textChanged(const QString &val)
 {
-    mSortFilterModel->setFilterKeyColumn(mHeaders.count() - 1);
+    mSortFilterModel->setFilterKeyColumn(Col_Cmd);
     mSortFilterModel->setFilterFixedString(val);
 }
 
@@ -428,7 +452,7 @@ void ProcessesPage::on_btnEndProcess_clicked()
     pid_t pid = mSelectedRowModel.data(SortRole).toInt();
 
     if (pid) {
-        QString selectedUname = mSortFilterModel->index(mSelectedRowModel.row(), 4).data(SortRole).toString();
+        QString selectedUname = mSortFilterModel->index(mSelectedRowModel.row(), Col_User).data(SortRole).toString();
         mProcessService->killProcess(pid, selectedUname, im->getUserName());
     }
 }
@@ -449,7 +473,7 @@ void ProcessesPage::onKillColumnClicked(const QModelIndex &proxyIndex)
     if (!pid)
         return;
 
-    QStandardItem *unameItem = mItemModel->item(src.row(), 4);
+    QStandardItem *unameItem = mItemModel->item(src.row(), Col_User);
     const QString uname = unameItem ? unameItem->data(SortRole).toString() : QString();
     mProcessService->killProcess(pid, uname, im->getUserName());
 }

--- a/shared/nexis/Pages/Processes/processes_page.h
+++ b/shared/nexis/Pages/Processes/processes_page.h
@@ -66,7 +66,41 @@ private:
     // (name, metric) hysteresis.
     void evaluateThresholdAlerts(const QList<Process> &processes);
 
-    static constexpr int kKillCol = 19; // GH#174: per-row kill icon column
+    // Logical column indices for the process table. GH#194: the Name column
+    // (Linux /proc/<pid>/comm — a short process name distinct from the full
+    // command line) exists only on Linux; on macOS it is omitted entirely so
+    // there is no permanently-empty column. Defining it conditionally keeps
+    // every downstream index correct on both platforms — on macOS the enum
+    // collapses to the historical 0..18 layout. The Name column sits right
+    // after PID; Command stays last (it is the wide, variable-width column and
+    // the search filter target).
+    enum Col {
+        Col_Pid = 0,
+#ifdef Q_OS_LINUX
+        Col_Name,
+#endif
+        Col_Rss,
+        Col_Pmem,
+        Col_Vsize,
+        Col_User,
+        Col_Pcpu,
+        Col_StartTime,
+        Col_State,
+        Col_Group,
+        Col_Nice,
+        Col_CpuTime,
+        Col_Session,
+        Col_DiskRead,
+        Col_DiskWrite,
+        Col_NetDown,
+        Col_NetUp,
+        Col_GpuPct,
+        Col_GpuVram,
+        Col_Cmd,
+        Col_Count   // number of data columns (kill icon follows)
+    };
+
+    static constexpr int kKillCol = Col_Count; // GH#174: per-row kill icon column
 
 private:
     Ui::ProcessesPage *ui;

--- a/tests/core/test_process_info.cpp
+++ b/tests/core/test_process_info.cpp
@@ -88,7 +88,25 @@ private slots:
 
     // ── concurrency stress ────────────────────────────────────────────────
     void stress_concurrentSetAndGetProcessList();
+
+    // ── GH#194: Process name vs command line ──────────────────────────────
+    void process_nameAndCmdAreIndependent();
 };
+
+void TestProcessInfo::process_nameAndCmdAreIndependent()
+{
+    // GH#194: getName() (short process name, e.g. "systemd") is a distinct
+    // field from getCmd() (full command line, e.g. "/sbin/init splash").
+    // Setting one must not affect the other, and an unset name defaults empty.
+    Process p;
+    QVERIFY(p.getName().isEmpty());
+
+    p.setCmd(QStringLiteral("/sbin/init splash"));
+    p.setName(QStringLiteral("systemd"));
+
+    QCOMPARE(p.getName(), QStringLiteral("systemd"));
+    QCOMPARE(p.getCmd(), QStringLiteral("/sbin/init splash"));
+}
 
 void TestProcessInfo::publish_collectIsLocalAndDoesNotMutateCache()
 {


### PR DESCRIPTION
Closes #194.

Adds a short **process name** (e.g. `systemd`) to the Processes table, sourced from `/proc/<pid>/comm` and distinct from the full command line — matching `ps`/`top`/`htop`. **Linux only**: on macOS the column is omitted entirely (no permanently-empty column), per maintainer direction.

## Changes
**Data layer (cross-platform, trivial)**
- `Process`: new `name` field + `getName()`/`setName()`.
- Linux collector ([process_info.cpp](linux/nexis-core/Info/process_info.cpp)): `proc.setName(sf.comm)` — `sf.comm` is already parsed from `/proc/<pid>/stat`, so **no extra per-PID `/proc` read** (the collector is deliberately frugal about file opens).

**UI ([processes_page](shared/nexis/Pages/Processes/processes_page.cpp))**
- Introduced a platform-conditional `Col` enum and replaced every hardcoded column index with it. `Col_Name` is defined only under `#ifdef Q_OS_LINUX`, placed right after `Col_Pid`; Command stays last. On macOS the enum collapses to the historical `0..18` layout, so there is **no Name column and no empty column**.
- The Name column is visible by default (not in the header hide-menu defaults) and the table is sortable by it.
- **Bonus fix:** the refactor surfaced two pre-existing magic-index reads of the **User** column (`item(.., 4)`) that would have pointed at the wrong column once Name shifts the Linux layout — now `Col_User`.

**Tests / docs**
- Added a test asserting `name` and `cmd` are independent and round-trip.
- CHANGELOG `[Unreleased]` + `APPLICATION_OVERVIEW.md` Processes section.

## Verification
- ✅ macOS build clean; **all 56 tests pass** (incl. the new one), `ScreenshotTests` excluded as elsewhere.
- ⚠️ The `#ifdef Q_OS_LINUX` blocks (the actual Name column) compile only in the **Linux CI job** — I can't compile the Linux path on this Mac, so I read those blocks back carefully and rely on `build.yml`'s Linux build to confirm. macOS verifies the column is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
