### PR TITLE
fix(trash): show all mounted filesystem trash directories in UI (GH#182)

### DIFF
--- a/shared/nexis/Managers/cleaner_service.cpp
+++ b/shared/nexis/Managers/cleaner_service.cpp
@@ -427,6 +427,11 @@ QStringList CleanerService::trashRoots() const
     return roots;
 }
 
+QStringList CleanerService::getTrashRoots() const
+{
+    return trashRoots();
+}
+
 quint64 CleanerService::cleanTrash()
 {
     quint64 totalSizeBefore = 0;

--- a/shared/nexis/Managers/cleaner_service.h
+++ b/shared/nexis/Managers/cleaner_service.h
@@ -106,6 +106,10 @@ public:
     void removeExclusion(const QString &path);
     static bool isExcluded(const QString &filePath, const QList<ExclusionEntry> &exclusions);
 
+    // GH#182: get all trash directories (home trash + mounted filesystem trash).
+    // Public accessor for the protected trashRoots() test seam.
+    QStringList getTrashRoots() const;
+
     // FW-12: when true, aggressive-class cleaning profiles are included in
     // APP_PROFILES scans. Defaults to false; persisted via SettingManager.
     bool isAggressiveProfilesEnabled() const;

--- a/shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp
+++ b/shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp
@@ -696,11 +696,10 @@ void SystemCleanerPage::onScanFinished()
     if (mScanBrowserPrivacy) updateCard(BROWSER_PRIVACY,        computeSize(mBrowserPrivacy));
     if (mScanSnapFlatpak)    updateCard(SNAP_FLATPAK_REVISIONS, computeSize(mSnapFlatpakRevisions));
     if (mScanTrash) {
-#ifdef Q_OS_MACOS
-        updateCard(TRASH, FileUtil::getFileSize(QDir::homePath() + "/.Trash/"));
-#else
-        updateCard(TRASH, FileUtil::getFileSize(QDir::homePath() + "/.local/share/Trash/"));
-#endif
+        quint64 trashSize = 0;
+        for (const QString &trashRoot : mCleanerService->getTrashRoots())
+            trashSize += FileUtil::getFileSize(trashRoot);
+        updateCard(TRASH, trashSize);
     }
 
     // Retain scan results for inline tree and "Clean selected"
@@ -761,11 +760,18 @@ void SystemCleanerPage::refreshInlineTree()
     addIfChecked(SNAP_FLATPAK_REVISIONS, mLblSnapFlatpakText,  mRetainedSnapFlatpak);
 
     if (catChecked(TRASH)) {
-#ifdef Q_OS_MACOS
-        addTreeRoot(TRASH, mLblTrashText, { QFileInfo(QDir::homePath() + "/.Trash/") }, true);
-#else
-        addTreeRoot(TRASH, mLblTrashText, { QFileInfo(QDir::homePath() + "/.local/share/Trash/") }, true);
-#endif
+        // GH#182: display each trash root (home + mounted FSes) separately
+        int trashCount = 0;
+        for (const QString &trashRoot : mCleanerService->getTrashRoots()) {
+            QString displayName = mLblTrashText;
+            if (trashCount > 0) {
+                // For mounted FS trash, show the mount point path
+                QFileInfo fi(trashRoot);
+                displayName = QString("%1 (%2)").arg(mLblTrashText, fi.absolutePath());
+            }
+            addTreeRoot(TRASH, displayName, { QFileInfo(trashRoot) }, true);
+            trashCount++;
+        }
         anyAdded = true;
     }
 


### PR DESCRIPTION
## Summary
Fixed trash view to display trash from all mounted filesystems, not just home trash.

The UI was hardcoded to only show `~/.local/share/Trash` even though the backend `CleanerService` properly handles per-volume `.Trash-$UID` directories per the FreeDesktop Trash Specification.

## Root Cause
`SystemCleanerPage` was hardcoded to only display the home trash directory. When the trash view was refactored to support mounted filesystem trash (GH#182 implementation), the UI layer wasn't updated to use the new `CleanerService::trashRoots()` discovery.

Additionally, the `addTreeRoot()` function was only displaying the first trash root when `noChild=true`, so even if multiple roots were passed, only the first would show.

## Changes
- Add public `getTrashRoots()` accessor to `CleanerService` (safely exposes protected `trashRoots()` test seam)
- Update trash size calculation to sum all trash roots instead of hardcoded home trash
- Update trash tree display to show each trash root as a separate item with mount point labels
- Now displays: "Trash" for home trash, "Trash (/mnt/Data)" for mounted filesystem trash, etc.

## Testing
- Created test trash directories on `/mnt/Data`, `/mnt/Data-02`, `/mnt/Data-03`  
- Verified all trash locations now appear in the UI after scanning
- Verified total trash size includes all mounted filesystem trash
- Verified individual trash directories can be managed independently

Fixes GH#182

🤖 Generated with Claude Code