### PR TITLE
feat: installation tracking + graphify setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,27 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_FILE_PATH\" | grep -q 'CMakeLists.txt'; then echo '⚠️  CMakeLists.txt modified — clean rebuild recommended: /build-verify clean'; fi"
+            "command": "if echo \"$CLAUDE_FILE_PATH\" | grep -q 'CMakeLists.txt'; then echo '\u26a0\ufe0f  CMakeLists.txt modified \u2014 clean rebuild recommended: /build-verify clean'; fi"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/graph.json ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"MANDATORY: graphify-out/graph.json exists. You MUST run `graphify query \\\"<question>\\\"` before grepping raw files. Only grep after graphify has oriented you, or to modify/debug specific lines.\"}}'   || true ;; esac"
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "HIT=$(python3 -c \"import json,sys;d=json.load(sys.stdin);t=d.get('tool_input',d);exts=('.py','.js','.ts','.tsx','.jsx','.astro','.vue','.svelte','.go','.rs','.java','.rb','.c','.h','.cpp','.hpp','.cc','.cs','.kt','.swift','.php','.scala','.lua','.sh','.md','.rst','.txt','.mdx');vals=[str(t.get('file_path') or ''),str(t.get('pattern') or ''),str(t.get('path') or '')];j=' '.join(vals).lower().replace(chr(92),'/');tails=[('.'+x.rsplit('.',1)[-1]) for v in vals if v for x in [v.lower().replace(chr(92),'/').rsplit('/',1)[-1]] if '.' in x];sys.stdout.write('1' if 'graphify-out/' not in j and any(tl in exts for tl in tails) else '')\" 2>/dev/null || true); if [ \"$HIT\" = 1 ] && [ -f graphify-out/graph.json ]; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"MANDATORY: graphify-out/graph.json exists. You MUST run graphify before reading source files. Use: `graphify query \\\"<question>\\\"` (scoped subgraph), `graphify explain \\\"<concept>\\\"`, or `graphify path \\\"<A>\\\" \\\"<B>\\\"`. Only read raw files after graphify has oriented you, or to modify/debug specific lines. This rule applies to subagents too \u2014 include it in every subagent prompt involving code exploration.\"}}'; fi || true"
           }
         ]
       }

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -57,7 +57,14 @@ jobs:
         if: steps.gate.outputs.SHOULD_BUMP == 'true'
         run: |
           VERSION="${{ steps.version.outputs.VERSION }}"
-          URL="https://github.com/s4solutionsllc/Nexis/releases/download/v${VERSION}/Nexis-${VERSION}-macOS-arm64.dmg"
+          # Install tracking (Phase 1): fetch the brew-specific asset name —
+          # the same bytes as the direct .dmg, uploaded twice by release.yml so
+          # GitHub's per-asset download counter can split brew installs from
+          # direct downloads. The tap cask's `url` stanza must reference the
+          # same .brew.dmg name (one-time manual change in
+          # s4solutionsllc/homebrew-nexis — the sed below only rewrites
+          # version/sha256).
+          URL="https://github.com/s4solutionsllc/Nexis/releases/download/v${VERSION}/Nexis-${VERSION}-macOS-arm64.brew.dmg"
           echo "Downloading ${URL}"
           # --fail makes curl exit non-zero on HTTP errors instead of writing
           # the error body to disk (a 404 page would otherwise be hashed and

--- a/.github/workflows/install-stats.yml
+++ b/.github/workflows/install-stats.yml
@@ -1,0 +1,65 @@
+# Install tracking (docs/plans/2026-07-05-installation-tracking-findings-and-plan.md
+# Phase 3): nightly collector that snapshots per-channel download counts from
+# the GitHub Releases API, the Launchpad PPA, and the AUR RPC into
+# website/src/data/install-stats.json (one entry per day), then triggers a
+# website rebuild. GitHub only exposes *cumulative* counts, so the time series
+# starts the day this first runs — dispatch it once at merge to seed day one.
+name: Install Stats
+
+on:
+  schedule:
+    # Daily, off the top of the hour to avoid the GitHub cron thundering herd.
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  collect:
+    name: Collect installation stats
+    runs-on: ubuntu-latest
+    # contents:write to commit the snapshot back to `native`; actions:write to
+    # dispatch the pages.yml rebuild (same pattern as release.yml). Scoped to
+    # this job only — the top-level default stays read-only.
+    permissions:
+      contents: write
+      actions: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Pin to the branch we write back to so the push below is a
+          # fast-forward (same reasoning as aur.yml's mirror-back step).
+          ref: native
+
+      - name: Collect stats
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 scripts/collect_install_stats.py
+
+      - name: Commit snapshot
+        id: commit
+        run: |
+          if git diff --quiet -- website/src/data/install-stats.json; then
+            echo "No stat changes today — nothing to commit"
+            echo "PUSHED=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add website/src/data/install-stats.json
+          git commit -m "chore(stats): daily install-stats snapshot"
+          # GITHUB_TOKEN-authored pushes do not fire other workflows (same
+          # pattern as aur.yml's mirror-back step), so this cannot loop.
+          git push origin HEAD:native
+          echo "PUSHED=true" >> "$GITHUB_OUTPUT"
+
+      # The GITHUB_TOKEN push above will NOT trigger pages.yml on its own, so
+      # rebuild the website explicitly — otherwise the stats page goes stale.
+      - name: Trigger website rebuild
+        if: steps.commit.outputs.PUSHED == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run pages.yml --ref native

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -632,10 +632,40 @@ jobs:
           echo "APPIMAGE_ARM64_NAME=$(basename $APPIMAGE_ARM64)" >> "$GITHUB_OUTPUT"
           echo "BINARY_ARM64_PATH=$BINARY_ARM64" >> "$GITHUB_OUTPUT"
 
-          # macOS
-          DMG=$(find artifacts/macos -name '*.dmg' | head -1)
+          # macOS (exclude the brew-named copy in case it ever lands in the
+          # artifact dir — DMG_PATH must always be the direct-download DMG)
+          DMG=$(find artifacts/macos -name '*.dmg' ! -name '*.brew.dmg' | head -1)
           echo "DMG_PATH=$DMG" >> "$GITHUB_OUTPUT"
           echo "DMG_NAME=$(basename $DMG)" >> "$GITHUB_OUTPUT"
+
+      # Install tracking (docs/plans/2026-07-05-installation-tracking-findings-and-plan.md
+      # Phase 1): upload a byte-identical second copy of the DMG under a
+      # brew-specific asset name. GitHub counts downloads per asset, so this
+      # splits `brew install` traffic (homebrew.yml + the tap cask fetch the
+      # .brew.dmg) from direct .dmg downloads on the same counter-free bytes.
+      - name: Create brew-named DMG copy
+        id: brewdmg
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          DMG="${{ steps.files.outputs.DMG_PATH }}"
+          BREW_DMG="$(dirname "$DMG")/Nexis-${VERSION}-macOS-arm64.brew.dmg"
+          cp "$DMG" "$BREW_DMG"
+          echo "BREW_DMG_PATH=$BREW_DMG" >> "$GITHUB_OUTPUT"
+
+      # Install tracking (Phase 2): GitHub does NOT count downloads of the
+      # auto-generated tag tarball (archive/refs/tags/...), so AUR installs
+      # were invisible. Publish an equivalent source tarball as a real release
+      # asset — the AUR PKGBUILD sources it, making every makepkg/yay/paru
+      # build a counted download. The --prefix matches the auto-generated
+      # tarball's top-level dir (Nexis-X.Y.Z/) so the PKGBUILD build dir is
+      # unchanged.
+      - name: Create source tarball
+        id: source
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          TARBALL="${{ runner.temp }}/nexis-${VERSION}-source.tar.gz"
+          git archive --format=tar.gz --prefix="Nexis-${VERSION}/" -o "$TARBALL" HEAD
+          echo "SOURCE_PATH=$TARBALL" >> "$GITHUB_OUTPUT"
 
       - name: Delete pre-rebrand release for this tag (if any)
         env:
@@ -771,7 +801,9 @@ jobs:
             "${{ steps.files.outputs.DEB_ARM64_PATH }}" \
             "${{ steps.files.outputs.APPIMAGE_ARM64_PATH }}" \
             "${{ steps.files.outputs.BINARY_ARM64_PATH }}" \
-            "${{ steps.files.outputs.DMG_PATH }}"
+            "${{ steps.files.outputs.DMG_PATH }}" \
+            "${{ steps.brewdmg.outputs.BREW_DMG_PATH }}" \
+            "${{ steps.source.outputs.SOURCE_PATH }}"
           do
             if [ -n "$f" ] && [ -f "$f" ]; then
               (cd "$(dirname "$f")" && sha256sum "$(basename "$f")") >> "$SUMS_FILE"
@@ -798,6 +830,8 @@ jobs:
             ${{ steps.files.outputs.APPIMAGE_ARM64_PATH }}
             ${{ steps.files.outputs.BINARY_ARM64_PATH }}
             ${{ steps.files.outputs.DMG_PATH }}
+            ${{ steps.brewdmg.outputs.BREW_DMG_PATH }}
+            ${{ steps.source.outputs.SOURCE_PATH }}
             ${{ steps.checksums.outputs.SUMS_PATH }}
 
       - name: Trigger website rebuild

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ test_screenshots/
 # Binary source files (kept locally)
 shared/nexis/static/nexis.icns
 shared/nexis/static/header.xcf
+
+# graphify generated knowledge graph (regenerate with `graphify update .`)
+graphify-out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Installation stats: releases now publish two extra assets so per-channel download counting works — a brew-specific DMG copy (`Nexis-X.Y.Z-macOS-arm64.brew.dmg`, splitting Homebrew installs from direct `.dmg` downloads on GitHub's per-asset counters) and a counted source tarball (`nexis-X.Y.Z-source.tar.gz`) that the AUR package now builds from, making AUR installs visible for the first time.
+- Installation stats: a nightly collector workflow aggregates download counts from GitHub Releases, the Launchpad PPA, and the AUR into a daily snapshot history, rendered on a new website stats page (total downloads, per-channel breakdown, and a latest-version "active installs" view).
+
 ## [2.8.2] - 2026-07-04
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,3 +150,13 @@ This extends the global Phase 3 workflow.
 ## Notable Forks
 
 - **QuentiumYT/Stacer** — Most active upstream fork (78 stars). Reference for fixes and features.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -122,6 +122,29 @@ Defined in `.github/workflows/release.yml`. As of v2.6.x (SSO-4093):
 | `build-macos` | `macos-14` (Apple Silicon) | `nexis.app`, `.dmg` | macdeployqt + notarized |
 | `release` | `ubuntu-latest` | GitHub Release, attaches all artifacts | extracts notes from `CHANGELOG.md` |
 
+> **Install-tracking assets (2026-07-05 plan).** The `release` job publishes two
+> extra assets so per-channel download counting works
+> (see `docs/plans/2026-07-05-installation-tracking-findings-and-plan.md`):
+>
+> - `Nexis-X.Y.Z-macOS-arm64.brew.dmg` — byte-identical copy of the `.dmg`
+>   under a brew-specific name. `homebrew.yml` and the tap cask fetch this
+>   copy, so GitHub's per-asset counter splits brew installs from direct
+>   `.dmg` downloads.
+> - `nexis-X.Y.Z-source.tar.gz` — `git archive` of the tag (same content and
+>   `Nexis-X.Y.Z/` prefix as the auto-generated tag tarball, which GitHub does
+>   **not** count). The AUR PKGBUILD sources this asset, making every
+>   `makepkg`/`yay`/`paru` build a counted download.
+>
+> **AUR source-URL ordering:** the PKGBUILD's `releases/download/...` source
+> URL only resolves for releases that ship the source asset (v2.8.3+). Never
+> re-point the AUR package at a tag older than the first release carrying
+> `-source.tar.gz` without also flipping its `source=` back to the
+> `archive/refs/tags/` URL.
+>
+> The nightly `install-stats.yml` workflow (cron + `workflow_dispatch`)
+> aggregates GitHub Releases, Launchpad PPA, and AUR RPC counts into
+> `website/src/data/install-stats.json`, rendered at `/Nexis/stats`.
+
 > **Why a Resolute container (SSO-4093 / SSO-7306).** FW-06 (SSO-3733) raised
 > the Qt floor to 6.8 LTS. Noble (Ubuntu 24.04) ships Qt 6.4 via `qt6-base-dev`,
 > so the previous bare-runner `build-linux` job no longer satisfies the floor.
@@ -218,11 +241,18 @@ Linux artifacts are not code-signed. Provenance comes from:
 Automatic. `homebrew.yml` triggers on successful completion of the `Release`
 workflow when the head branch starts with `v`:
 
-1. Downloads the published macOS DMG from the GitHub Release.
+1. Downloads the published brew-specific DMG copy (`.brew.dmg` — same bytes
+   as the direct `.dmg`, separate download counter) from the GitHub Release.
 2. Computes `sha256sum`.
 3. Clones `s4solutionsllc/homebrew-nexis` (token: `secrets.HOMEBREW_TAP_TOKEN`).
 4. `sed -i` updates `version` and `sha256` in `Casks/nexis.rb`.
 5. Commits and pushes to the tap's default branch.
+
+> **One-time tap change (install tracking):** the sed only rewrites
+> `version`/`sha256`, so the cask's `url` stanza must be manually re-pointed
+> at the `.brew.dmg` asset name **once**, at the same time as the first
+> release that ships it (v2.8.3+). Until both land, brew installs keep
+> counting against the direct `.dmg`.
 
 ### Manual fallback
 
@@ -232,7 +262,7 @@ If the auto-bump fails (token expired, tap permissions changed, DMG URL drift):
 git clone git@github.com:s4solutionsllc/homebrew-nexis.git
 cd homebrew-nexis
 VERSION=2.3.4
-URL="https://github.com/s4solutionsllc/Nexis/releases/download/v${VERSION}/Nexis-${VERSION}-macOS-arm64.dmg"
+URL="https://github.com/s4solutionsllc/Nexis/releases/download/v${VERSION}/Nexis-${VERSION}-macOS-arm64.brew.dmg"
 # -f makes curl exit non-zero on 4xx/5xx instead of writing the error body
 # to disk; --retry 3 handles transient GitHub CDN blips. Without these, a
 # 404 page would be hashed and committed to the tap, breaking
@@ -452,9 +482,11 @@ VERSION=2.3.4
 
 # 1. Release page exists with all expected artifacts.
 gh release view "v${VERSION}" --repo s4solutionsllc/Nexis | grep -E '(deb|AppImage|dmg|nexis-|SHA256)'
-# Expect (single Resolute .deb per arch since SSO-4093; Noble/Plucky .debs gone):
+# Expect (single Resolute .deb per arch since SSO-4093; Noble/Plucky .debs gone;
+# install-tracking assets since the 2026-07-05 plan):
 #   2 deb (`_ubuntu2604.deb` x86_64/arm64) + 2 AppImage (x86_64/arm64) +
-#   2 raw binaries (nexis-x86_64/nexis-arm64) + 1 dmg + 1 SHA256SUMS = 8 artifacts.
+#   2 raw binaries (nexis-x86_64/nexis-arm64) + 1 dmg + 1 brew.dmg +
+#   1 source tarball (nexis-X.Y.Z-source.tar.gz) + 1 SHA256SUMS = 10 artifacts.
 
 # 2. Homebrew Cask was bumped.
 curl -fsSL https://raw.githubusercontent.com/s4solutionsllc/homebrew-nexis/main/Casks/nexis.rb \

--- a/docs/plans/2026-07-05-installation-tracking-findings-and-plan.md
+++ b/docs/plans/2026-07-05-installation-tracking-findings-and-plan.md
@@ -1,7 +1,7 @@
 # Installation Tracking — Findings & Implementation Plan
 
 **Date:** 2026-07-05
-**Status:** Proposed
+**Status:** Implemented (pending first post-merge release-cycle verification and the one-time tap `url` change)
 **Goal:** Report how many installations Nexis has — a total, plus a breakdown by
 installation type (direct `.deb`, AppImage, direct `.dmg`, apt/PPA, brew, AUR).
 
@@ -75,10 +75,10 @@ countable; Phase 3 is the collector that produces the numbers.
 
 ### Phase 1 — Disambiguate brew from direct `.dmg` (release plumbing)
 
-- [ ] `release.yml`: after building the DMG, upload a **second copy** of the
+- [x] `release.yml`: after building the DMG, upload a **second copy** of the
       same file under a brew-specific asset name, e.g.
       `Nexis-${VERSION}-macOS-arm64.brew.dmg`. Same bytes, distinct counter.
-- [ ] `homebrew.yml`: point the checksum download and the cask `url` template
+- [x] `homebrew.yml`: point the checksum download and the cask `url` template
       at the `.brew.dmg` asset name (checksum is identical, but the workflow
       should fetch the asset it references for the audit-B2 sanity checks).
 - [ ] `s4solutionsllc/homebrew-nexis` `Casks/nexis.rb`: update the `url` stanza
@@ -91,10 +91,10 @@ release onward.
 
 ### Phase 2 — Make AUR visible (release plumbing)
 
-- [ ] `release.yml`: create the source tarball (same content as the tag
+- [x] `release.yml`: create the source tarball (same content as the tag
       archive; `git archive --format=tar.gz --prefix=Nexis-${VERSION}/ v${VERSION}`)
       and upload it as a release asset, e.g. `nexis-${VERSION}-source.tar.gz`.
-- [ ] `linux/aur/PKGBUILD`: change `source=` from
+- [x] `linux/aur/PKGBUILD`: change `source=` from
       `archive/refs/tags/v$pkgver.tar.gz` to
       `releases/download/v$pkgver/nexis-$pkgver-source.tar.gz`, and adjust the
       extract dir prefix if it differs. `aur.yml`'s `updpkgsums: true` already
@@ -112,7 +112,7 @@ PKGBUILD (or land both and cut the release before the next AUR publish fires).
 
 ### Phase 3 — Nightly stats collector + dashboard
 
-- [ ] New workflow `.github/workflows/install-stats.yml`:
+- [x] New workflow `.github/workflows/install-stats.yml`:
       - `schedule: cron` (daily) + `workflow_dispatch`.
       - **Source 1 — GitHub Releases API:** all releases → per-asset
         `download_count`. Classify by filename: `_ubuntu2604.deb` → `deb-direct`,
@@ -128,17 +128,19 @@ PKGBUILD (or land both and cut the release before the next AUR publish fires).
         (running history, one entry per day) and commit with
         `[skip ci]`-safe semantics (GITHUB_TOKEN pushes don't retrigger
         workflows — same pattern as `aur.yml`'s mirror-back step).
-- [ ] Snapshot schema (per day):
+- [x] Snapshot schema (per day):
       `{ date, totals: { all, byChannel: { "deb-direct", appimage, "dmg-direct", brew, apt, aur } }, latestVersion: { version, byChannel: {...} }, aur: { votes, popularity } }`
       — `totals` = cumulative downloads; `latestVersion` = the active-install
       proxy.
-- [ ] Website: a simple stats page/section reading `install-stats.json` —
+- [x] Website: a simple stats page/section reading `install-stats.json` —
       headline total, per-channel breakdown, and a latest-version
       ("active installs") view. Follows the existing Astro site structure
       under `website/`.
-- [ ] Backfill note: GitHub only exposes *cumulative* counts, so the time
-      series starts the day the collector first runs; run `workflow_dispatch`
-      once at merge to seed day one.
+- [x] Backfill note: GitHub only exposes *cumulative* counts, so the time
+      series starts the day the collector first runs; day one (2026-07-05)
+      was seeded at implementation time by running the collector locally
+      against the live APIs, so `install-stats.json` ships with a real first
+      snapshot.
 
 ### Acceptance criteria
 

--- a/linux/aur/PKGBUILD
+++ b/linux/aur/PKGBUILD
@@ -14,7 +14,13 @@ makedepends=('cmake' 'gcc' 'make' 'qt6-tools')
 # real-object reference into an LTO object). Disabling LTO keeps the packaged
 # build using plain objects that any linker handles.
 options=('!lto')
-source=("$pkgname-$pkgver.tar.gz::https://github.com/s4solutionsllc/Nexis/archive/refs/tags/v$pkgver.tar.gz")
+# Install tracking (Phase 2): source the uploaded release asset instead of the
+# auto-generated tag tarball — GitHub only counts downloads of uploaded assets,
+# so this makes AUR builds visible in per-asset download stats. Same content
+# and Nexis-$pkgver/ prefix as the old archive URL. Effective from the first
+# release that ships the asset (> 2.8.2); aur.yml's updpkgsums regenerates
+# sha256sums at publish time.
+source=("$pkgname-$pkgver.tar.gz::https://github.com/s4solutionsllc/Nexis/releases/download/v$pkgver/nexis-$pkgver-source.tar.gz")
 sha256sums=('688a58f90a609f277eed460bc69ce82ce28241822f213c378bc80410b68b5d7b')
 
 build() {

--- a/scripts/collect_install_stats.py
+++ b/scripts/collect_install_stats.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Nightly installation-stats collector (install-stats.yml).
+
+Aggregates three sources into one dated snapshot appended to
+website/src/data/install-stats.json:
+
+  1. GitHub Releases API  — cumulative per-asset download_count, classified
+     into channels by filename (see classify()).
+  2. Launchpad API        — per-binary download counts for the
+     ppa:s4solutionsllc/nexis archive → the `apt` channel.
+  3. AUR RPC              — NumVotes / Popularity (supplementary signal only;
+     actual AUR install counts come from the -source.tar.gz release asset).
+
+`totals` are cumulative downloads across all releases; `latestVersion` counts
+only the latest release's assets — the best available proxy for the *active*
+install base (strongest for apt, weakest for AppImage; see
+docs/plans/2026-07-05-installation-tracking-findings-and-plan.md §1.3).
+
+Stdlib only — runs on a bare ubuntu-latest runner. Fails loudly on any source
+error rather than recording a partial (misleadingly low) snapshot.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "s4solutionsllc/Nexis")
+TOKEN = os.environ.get("GITHUB_TOKEN", "")
+DATA_FILE = Path(__file__).resolve().parent.parent / "website/src/data/install-stats.json"
+
+CHANNELS = ["deb-direct", "appimage", "dmg-direct", "brew", "apt", "aur"]
+LAUNCHPAD_ARCHIVE = "https://api.launchpad.net/devel/~s4solutionsllc/+archive/ubuntu/nexis"
+AUR_RPC = "https://aur.archlinux.org/rpc/v5/info?arg[]=nexis"
+
+
+def fetch_json(url, github=False):
+    req = urllib.request.Request(url, headers={"User-Agent": "nexis-install-stats"})
+    if github and TOKEN:
+        req.add_header("Authorization", f"Bearer {TOKEN}")
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.load(resp)
+
+
+def classify(asset_name):
+    """Map a release-asset filename to a channel, or None if uncounted.
+
+    Order matters: .brew.dmg before .dmg. Raw binaries (nexis-x86_64 /
+    nexis-arm64) and SHA256SUMS files are deliberately uncounted — they are
+    not an installation channel.
+    """
+    if asset_name.endswith(".brew.dmg"):
+        return "brew"
+    if asset_name.endswith(".dmg"):
+        return "dmg-direct"
+    if asset_name.endswith(".deb"):
+        return "deb-direct"
+    if asset_name.endswith(".AppImage"):
+        return "appimage"
+    if asset_name.endswith("-source.tar.gz"):
+        return "aur"
+    return None
+
+
+def asset_arch(asset_name):
+    lowered = asset_name.lower()
+    if "aarch64" in lowered or "arm64" in lowered:
+        return "arm64"
+    return "x86_64"
+
+
+def github_release_counts():
+    """Return (totals_by_channel, latest_version, latest_by_channel, appimage_by_arch)."""
+    totals = {c: 0 for c in CHANNELS}
+    appimage_by_arch = {"x86_64": 0, "arm64": 0}
+
+    latest = fetch_json(f"https://api.github.com/repos/{REPO}/releases/latest", github=True)
+    latest_version = latest["tag_name"].lstrip("v")
+    latest_by_channel = {c: 0 for c in CHANNELS}
+    for asset in latest.get("assets", []):
+        channel = classify(asset["name"])
+        if channel:
+            latest_by_channel[channel] += asset["download_count"]
+
+    page = 1
+    while True:
+        releases = fetch_json(
+            f"https://api.github.com/repos/{REPO}/releases?per_page=100&page={page}",
+            github=True,
+        )
+        if not releases:
+            break
+        for release in releases:
+            if release.get("draft"):
+                continue
+            for asset in release.get("assets", []):
+                channel = classify(asset["name"])
+                if not channel:
+                    continue
+                totals[channel] += asset["download_count"]
+                if channel == "appimage":
+                    appimage_by_arch[asset_arch(asset["name"])] += asset["download_count"]
+        page += 1
+
+    return totals, latest_version, latest_by_channel, appimage_by_arch
+
+
+def launchpad_counts(latest_version):
+    """Return (total_downloads, latest_version_downloads, by_series)."""
+    total = 0
+    latest = 0
+    by_series = {}
+    url = f"{LAUNCHPAD_ARCHIVE}?ws.op=getPublishedBinaries&ws.size=75"
+    while url:
+        page = fetch_json(url)
+        for entry in page.get("entries", []):
+            count = fetch_json(entry["self_link"] + "?ws.op=getDownloadCount")
+            if not isinstance(count, int):
+                count = 0
+            total += count
+            # distro_arch_series_link: .../devel/ubuntu/<series>/<arch>
+            series_parts = entry.get("distro_arch_series_link", "").rstrip("/").split("/")
+            if len(series_parts) >= 2:
+                series = series_parts[-2]
+                by_series[series] = by_series.get(series, 0) + count
+            # Deb versions look like `2.8.2-1~questing1` — prefix-match the tag.
+            if entry.get("binary_package_version", "").startswith(latest_version):
+                latest += count
+        url = page.get("next_collection_link")
+    return total, latest, by_series
+
+
+def aur_info():
+    data = fetch_json(AUR_RPC)
+    results = data.get("results") or []
+    if not results:
+        return {"votes": 0, "popularity": 0.0}
+    return {
+        "votes": results[0].get("NumVotes", 0),
+        "popularity": results[0].get("Popularity", 0.0),
+    }
+
+
+def main():
+    totals, latest_version, latest_by_channel, appimage_by_arch = github_release_counts()
+    apt_total, apt_latest, apt_by_series = launchpad_counts(latest_version)
+    totals["apt"] = apt_total
+    latest_by_channel["apt"] = apt_latest
+
+    snapshot = {
+        "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "totals": {
+            "all": sum(totals.values()),
+            "byChannel": totals,
+        },
+        "latestVersion": {
+            "version": latest_version,
+            "byChannel": latest_by_channel,
+        },
+        "aur": aur_info(),
+        "detail": {
+            "appimageByArch": appimage_by_arch,
+            "aptBySeries": apt_by_series,
+        },
+    }
+
+    history = []
+    if DATA_FILE.exists():
+        history = json.loads(DATA_FILE.read_text() or "[]")
+    # Re-running on the same day replaces that day's snapshot (idempotent).
+    history = [s for s in history if s.get("date") != snapshot["date"]]
+    history.append(snapshot)
+    history.sort(key=lambda s: s["date"])
+
+    DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+    DATA_FILE.write_text(json.dumps(history, indent=2) + "\n")
+
+    print(f"Snapshot for {snapshot['date']}: total={snapshot['totals']['all']}")
+    print(json.dumps(snapshot, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/website/src/data/install-stats.json
+++ b/website/src/data/install-stats.json
@@ -1,0 +1,43 @@
+[
+  {
+    "date": "2026-07-05",
+    "totals": {
+      "all": 3262,
+      "byChannel": {
+        "deb-direct": 1170,
+        "appimage": 1600,
+        "dmg-direct": 281,
+        "brew": 0,
+        "apt": 211,
+        "aur": 0
+      }
+    },
+    "latestVersion": {
+      "version": "2.8.2",
+      "byChannel": {
+        "deb-direct": 8,
+        "appimage": 23,
+        "dmg-direct": 4,
+        "brew": 0,
+        "apt": 0,
+        "aur": 0
+      }
+    },
+    "aur": {
+      "votes": 2,
+      "popularity": 0.695757
+    },
+    "detail": {
+      "appimageByArch": {
+        "x86_64": 1421,
+        "arm64": 179
+      },
+      "aptBySeries": {
+        "resolute": 0,
+        "questing": 35,
+        "noble": 163,
+        "jammy": 13
+      }
+    }
+  }
+]

--- a/website/src/pages/stats.astro
+++ b/website/src/pages/stats.astro
@@ -1,0 +1,130 @@
+---
+import Base from '../layouts/Base.astro';
+import Nav from '../components/Nav.astro';
+import Footer from '../components/Footer.astro';
+import snapshots from '../data/install-stats.json';
+
+const latest = snapshots.length ? snapshots[snapshots.length - 1] : null;
+
+const channelLabels: Record<string, string> = {
+  'deb-direct': 'Direct .deb',
+  appimage: 'AppImage',
+  'dmg-direct': 'Direct .dmg (macOS)',
+  brew: 'Homebrew',
+  apt: 'apt (PPA)',
+  aur: 'AUR',
+};
+
+function channelRows(byChannel: Record<string, number>) {
+  const max = Math.max(1, ...Object.values(byChannel));
+  return Object.entries(channelLabels).map(([key, label]) => ({
+    key,
+    label,
+    count: byChannel[key] ?? 0,
+    percent: Math.round(((byChannel[key] ?? 0) / max) * 100),
+  }));
+}
+
+const totalRows = latest ? channelRows(latest.totals.byChannel) : [];
+const latestRows = latest ? channelRows(latest.latestVersion.byChannel) : [];
+---
+
+<Base
+  title="Nexis — Installation Stats"
+  description="How many installations Nexis has: total downloads and a per-channel breakdown across .deb, AppImage, .dmg, Homebrew, apt (PPA), and AUR."
+>
+  <Nav />
+  <main class="mx-auto max-w-3xl px-6 py-24 md:py-32">
+    <h1 class="text-4xl font-bold tracking-tight text-white md:text-5xl">
+      Installation <span class="text-nexis-orange">Stats</span>
+    </h1>
+
+    {
+      !latest ? (
+        <p class="mt-6 text-lg text-nexis-muted leading-relaxed">
+          Collecting data — the nightly stats collector hasn't produced its
+          first snapshot yet. Check back soon.
+        </p>
+      ) : (
+        <>
+          <p class="mt-6 text-lg text-nexis-muted leading-relaxed">
+            Nexis is free and has no telemetry, so these numbers come from
+            public download counters (GitHub Releases, the Launchpad PPA, and
+            the AUR) — downloads, not phone-home pings. Last updated{' '}
+            <span class="text-white">{latest.date}</span>.
+          </p>
+
+          <div class="mt-12 rounded-xl border border-nexis-border bg-nexis-dark-card p-8 text-center">
+            <div class="text-5xl font-bold text-nexis-orange">
+              {latest.totals.all.toLocaleString('en-US')}
+            </div>
+            <div class="mt-2 text-nexis-muted">total downloads, all versions and channels</div>
+          </div>
+
+          <h2 class="mt-16 text-2xl font-bold text-white">Downloads by channel</h2>
+          <p class="mt-2 text-sm text-nexis-muted">Cumulative across all releases.</p>
+          <div class="mt-6 space-y-3">
+            {totalRows.map((row) => (
+              <div>
+                <div class="flex justify-between text-sm">
+                  <span class="text-nexis-light">{row.label}</span>
+                  <span class="text-nexis-muted">{row.count.toLocaleString('en-US')}</span>
+                </div>
+                <div class="mt-1 h-2 rounded-full bg-nexis-border/40">
+                  <div
+                    class="h-2 rounded-full bg-nexis-orange"
+                    style={`width: ${row.percent}%`}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <h2 class="mt-16 text-2xl font-bold text-white">
+            Active installs (latest version, v{latest.latestVersion.version})
+          </h2>
+          <p class="mt-2 text-sm text-nexis-muted">
+            Downloads of the latest version only. Because every installed
+            machine downloads each new version roughly once when it updates,
+            this is the best available proxy for the active install base —
+            strongest for apt (which re-downloads on every upgrade), weakest
+            for AppImage (users may keep old versions).
+          </p>
+          <div class="mt-6 space-y-3">
+            {latestRows.map((row) => (
+              <div>
+                <div class="flex justify-between text-sm">
+                  <span class="text-nexis-light">{row.label}</span>
+                  <span class="text-nexis-muted">{row.count.toLocaleString('en-US')}</span>
+                </div>
+                <div class="mt-1 h-2 rounded-full bg-nexis-border/40">
+                  <div
+                    class="h-2 rounded-full bg-nexis-orange"
+                    style={`width: ${row.percent}%`}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <h2 class="mt-16 text-2xl font-bold text-white">AUR community signal</h2>
+          <p class="mt-4 text-nexis-muted">
+            The AUR doesn't count installs, but it does track community
+            engagement:
+            <span class="text-white">{latest.aur.votes}</span> votes,
+            popularity score{' '}
+            <span class="text-white">{latest.aur.popularity.toFixed(2)}</span>.
+          </p>
+
+          <p class="mt-12 text-sm text-nexis-muted">
+            Caveats: these are downloads per version, not unique machines — CI,
+            mirrors, and bots add a little noise, and one download can serve
+            several installs. Snapshots are collected nightly; history begins
+            {' '}{snapshots[0].date}.
+          </p>
+        </>
+      )
+    }
+  </main>
+  <Footer />
+</Base>


### PR DESCRIPTION
## Summary

Adds end-to-end installation/usage tracking for Nexis, plus graphify knowledge-graph tooling for this repo.

### Installation tracking
- **Release publishing** — publish a brew-tracked DMG copy and a counted AUR source tarball so Homebrew and AUR installs are measurable.
- **Nightly collector** — nightly install-stats collector and a website stats page to surface the numbers.
- **Docs** — changelog, release runbook, and plan status updated for the install-tracking work.

### graphify setup
- PreToolUse hooks that nudge toward `graphify query` before raw grep/read.
- `## graphify` section in `CLAUDE.md` documenting the knowledge graph.
- `.gitignore` entry for the generated `graphify-out/` directory (regenerable via `graphify update .`).

## Commits
- `50422413` feat(release): publish brew-tracked DMG copy and counted AUR source tarball
- `48c1b963` feat(stats): nightly install-stats collector and website stats page
- `2c1ec0bf` docs(stats): changelog, release runbook, and plan status for install tracking
- `3d1cb973` chore(graphify): add graphify hooks, docs, and gitignore output

🤖 Generated with [Claude Code](https://claude.com/claude-code)