### PR TITLE
fix(appimage): stamp x86_64 AppImage with the real version (GH#222)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,23 @@ jobs:
             echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           fi
 
+      # GH#222: keep the bundled AppStream metainfo's newest <release> in step
+      # with the tag (mirrors the "Sync debian changelog version from tag" step
+      # below). Installed into the AppDir and the .deb, this metainfo is what
+      # appimagetool reads for the AppImage version when VERSION is unset.
+      - name: Sync metainfo release version from tag
+        run: |
+          TAG_VERSION="${{ steps.version.outputs.VERSION }}"
+          META="linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml"
+          TOP_VERSION=$(grep -oP '<release version="\K[^"]+' "$META" | head -1)
+          if [ "$TOP_VERSION" != "$TAG_VERSION" ]; then
+            echo "Inserting metainfo <release> $TAG_VERSION (top was ${TOP_VERSION:-none})"
+            DATE=$(date -u +%Y-%m-%d)
+            sed -i "s|<releases>|<releases>\n    <release version=\"${TAG_VERSION}\" date=\"${DATE}\"/>|" "$META"
+          else
+            echo "metainfo already at $TAG_VERSION — no sync needed"
+          fi
+
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DAPP_VERSION_OVERRIDE=${{ steps.version.outputs.VERSION }}
 
@@ -298,6 +315,24 @@ jobs:
             echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           fi
 
+      # GH#222: keep the bundled AppStream metainfo's newest <release> in step
+      # with the tag, mirroring the "Sync debian changelog version from tag"
+      # step in build-linux. This metainfo is installed into the AppDir and is
+      # what appimagetool reads for the AppImage version when VERSION is unset —
+      # a stale top entry (2.3.8) is what stamped old versions onto new builds.
+      - name: Sync metainfo release version from tag
+        run: |
+          TAG_VERSION="${{ steps.version.outputs.VERSION }}"
+          META="linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml"
+          TOP_VERSION=$(grep -oP '<release version="\K[^"]+' "$META" | head -1)
+          if [ "$TOP_VERSION" != "$TAG_VERSION" ]; then
+            echo "Inserting metainfo <release> $TAG_VERSION (top was ${TOP_VERSION:-none})"
+            DATE=$(date -u +%Y-%m-%d)
+            sed -i "s|<releases>|<releases>\n    <release version=\"${TAG_VERSION}\" date=\"${DATE}\"/>|" "$META"
+          else
+            echo "metainfo already at $TAG_VERSION — no sync needed"
+          fi
+
       - name: Install build prerequisites
         run: |
           sudo apt-get update -qq
@@ -353,6 +388,11 @@ jobs:
         env:
           # install-qt-action exports QT_ROOT_DIR for the selected Qt.
           QMAKE: ${{ env.QT_ROOT_DIR }}/bin/qmake6
+          # GH#222: without VERSION, appimagetool falls back to the newest
+          # <release> in the bundled AppStream metainfo (stale at 2.3.8), so the
+          # AppImage was stamped 2.3.8 while the binary reported the real tag.
+          # The arm64 leg in build-linux already sets this; keep the two in sync.
+          VERSION: ${{ steps.version.outputs.VERSION }}
           APPIMAGE_EXTRACT_AND_RUN: "1"
         run: |
           APPDIR="${{ github.workspace }}/AppDir"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Installation stats: releases now publish two extra assets so per-channel download counting works — a brew-specific DMG copy (`Nexis-X.Y.Z-macOS-arm64.brew.dmg`, splitting Homebrew installs from direct `.dmg` downloads on GitHub's per-asset counters) and a counted source tarball (`nexis-X.Y.Z-source.tar.gz`) that the AUR package now builds from, making AUR installs visible for the first time.
 - Installation stats: a nightly collector workflow aggregates download counts from GitHub Releases, the Launchpad PPA, and the AUR into a daily snapshot history, rendered on a new website stats page (total downloads, per-channel breakdown, and a latest-version "active installs" view).
 
+## [2.8.3] - 2026-07-07
+
+### Fixed
+- Linux AppImage (x86_64) now reports the correct release version. The x86_64 AppImage build did not pass `VERSION` to `appimagetool`, so it fell back to the newest `<release>` in the bundled AppStream metainfo — which was stale at 2.3.8 — stamping every new AppImage as 2.3.8 even though the app itself reported the right version. Third-party AppImage update managers relying on that version string now correctly detect new releases (GH#222).
+- Release pipeline: the AppStream metainfo `<release>` history is now synced from the release tag at build time (mirroring the existing `debian/changelog` sync), so the version bundled in the AppImage and `.deb` can no longer drift behind the tag (GH#222).
+
 ## [2.8.2] - 2026-07-04
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0" CACHE STRING "Minimum macOS deployment version")
 endif()
 
-project(Nexis VERSION 2.8.2)
+project(Nexis VERSION 2.8.3)
 
 # Adding features(build cache + faster linkers) and reasonable defaults(Debug build by default)
 include("${CMAKE_CURRENT_SOURCE_DIR}/shared/cmake/cxxbasics/CXXBasics.cmake")

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -95,7 +95,14 @@ CVE / security patches: see §6.
 #    auto-rewrites the top entry's version to match the tag if they differ,
 #    so a stale top version is recoverable — but for a clean PPA upload, add
 #    a real entry with notes.
-git add CHANGELOG.md CMakeLists.txt linux/aur/PKGBUILD linux/debian/changelog
+# 5. Add a new <release version="X.Y.Z" date="YYYY-MM-DD"> entry at the top of
+#    linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml (this AppStream
+#    file is bundled into the AppImage and .deb, and appimagetool reads it for
+#    the AppImage version). Note: release.yml's "Sync metainfo release version
+#    from tag" step auto-inserts a matching top entry if it differs from the
+#    tag — recoverable like debian/changelog — but add a real entry with notes.
+git add CHANGELOG.md CMakeLists.txt linux/aur/PKGBUILD linux/debian/changelog \
+        linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml
 git commit -m "chore(release): X.Y.Z"
 git push origin native
 

--- a/docs/APPLICATION_OVERVIEW.md
+++ b/docs/APPLICATION_OVERVIEW.md
@@ -1,7 +1,7 @@
 # Nexis — Application Overview
 
 > A comprehensive reference for what Nexis does and how it is built.
-> Last updated: 2026-07-04 | Version 2.8.2
+> Last updated: 2026-07-07 | Version 2.8.3
 
 ---
 

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -1,7 +1,7 @@
 # Nexis — Architecture Review
 
 > A deep and comprehensive review of the Nexis architecture: how logic and UI work together, what's working well, what should change, and where the application should go next.
-> Last updated: 2026-07-04 (SSO-3497, SSO-3383, SSO-3391 / WI-29, SSO-3396 / WI-33, SSO-3738 / FW-10, SSO-3739 / FW-11, SSO-3740 / FW-12, SSO-3743 / FW-15, GH#191, GH#182, GH#214) | Version 2.8.2
+> Last updated: 2026-07-07 (SSO-3497, SSO-3383, SSO-3391 / WI-29, SSO-3396 / WI-33, SSO-3738 / FW-10, SSO-3739 / FW-11, SSO-3740 / FW-12, SSO-3743 / FW-15, GH#191, GH#182, GH#214) | Version 2.8.3
 
 > **Packaging note (SSO-3376, 2026-06):** The Flatpak (Flathub) distribution channel was retired. There is no `flatpak-spawn`/sandbox-detection layer in the codebase — the privileged-host operations Nexis depends on (`pkexec`, `systemctl`, `smartctl`, `fstrim`, `nvidia-smi`, `/proc` and `/sys` reads) are architecturally unsuited to a bubblewrap sandbox, and adding one would require routing `CommandUtil` through `flatpak-spawn --host` plus holding the `org.freedesktop.Flatpak` portal — i.e. eliminating the sandbox benefit. Linux ships via `.deb` (PPA + GitHub releases), AppImage, and AUR.
 

--- a/linux/aur/PKGBUILD
+++ b/linux/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Luke Simpson <luke@s4solutions.ai>
 pkgname=nexis
-pkgver=2.8.2
+pkgver=2.8.3
 pkgrel=1
 pkgdesc="Linux system optimizer and monitoring tool"
 arch=('x86_64' 'aarch64')

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,12 @@
+nexis (2.8.3-0) unstable; urgency=medium
+
+  * Linux AppImage (x86_64) now reports the correct release version — the build
+    did not pass VERSION to appimagetool, so it fell back to the stale AppStream
+    metainfo version and stamped every AppImage as 2.3.8. The metainfo release
+    version is now also synced from the tag at build time (GH#222).
+
+ -- Luke Simpson <luke@s4solutions.ai>  Tue, 07 Jul 2026 12:00:00 -0400
+
 nexis (2.8.2-0) unstable; urgency=medium
 
   * Dashboard: the primary value centered in gauge, hybrid, ring, and donut

--- a/linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml
+++ b/linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml
@@ -74,6 +74,14 @@
   </screenshots>
 
   <releases>
+    <release version="2.8.3" date="2026-07-07">
+      <description>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>Linux AppImage now reports its correct version. Previously the x86_64 AppImage was stamped with an old version, so third-party AppImage update managers kept seeing an outdated release and never offered the update.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.3.8" date="2026-05-29">
       <description>
         <p>New features and bug fixes:</p>


### PR DESCRIPTION
## Summary

The x86_64 AppImage was published stamped as **2.3.8** even though the binary reported the correct version (e.g. 2.8.2). Third-party AppImage update managers read that stale version string and never detected new releases. This fixes the versioning and cuts **2.8.3**.

## Linked issues

- Fixes #222

## Changes

**Root cause:** the `build-appimage-x86_64` job's *Build AppImage* step did not pass `VERSION` to `appimagetool`, so it fell back to the newest `<release>` in the bundled AppStream metainfo — which was stale at 2.3.8. (The arm64 leg in `build-linux` already set `VERSION`, so only x86_64 was affected.)

- **`.github/workflows/release.yml`** — pass `VERSION: ${{ steps.version.outputs.VERSION }}` to the x86_64 *Build AppImage* step (matches the arm64 leg). This alone fixes the reported symptom.
- **`.github/workflows/release.yml`** — add a *Sync metainfo release version from tag* step to **both** the `build-appimage-x86_64` and `build-linux` jobs, mirroring the existing *Sync debian changelog version from tag* step. If the newest metainfo `<release>` differs from the tag it inserts a matching entry, so the AppStream version bundled in the AppImage/`.deb` can never drift behind the tag again (defense-in-depth if `VERSION` is ever dropped).
- **`linux/metainfo/…Nexis.metainfo.xml`** — add the current `2.8.3` `<release>` entry (the block was stale at 2.3.8).
- **Version bump to 2.8.3** per `RELEASE.md` §1: `CMakeLists.txt` project version, `CHANGELOG.md`, `linux/aur/PKGBUILD` (`pkgver`), `linux/debian/changelog`.
- **`RELEASE.md`** — document the metainfo entry as step 5 of the release checklist.

Only the packaging/versioning path changed — no application source, UI, or runtime behavior is touched. The AppImage's glibc floor, bundled Qt, and distro coverage are unchanged.

## Testing

- [ ] Built on Linux
- [ ] Built on macOS
- [ ] Unit tests pass
- [x] Manually exercised the affected code path

Notes:
- `release.yml` validated as parseable YAML; `metainfo.xml` validated as well-formed XML.
- Dry-ran the *Sync metainfo release version from tag* logic: **no-op** when the top `<release>` already matches the tag (the committed 2.8.3 entry), and a clean, well-formed insert for a newer tag (e.g. 2.8.4).
- No local AppImage build here. **Recommend a release dry-run** (`workflow_dispatch` with an rc version) before tagging — the `build-appimage-x86_64` job's own comment notes it has not been validated end-to-end; this is the moment to confirm the produced `Nexis-*.AppImage` carries the right version.

## Docs

- [x] `CHANGELOG.md` updated under `## [2.8.3]`
- [x] `docs/APPLICATION_OVERVIEW.md` — N/A (no feature/UI/platform change)
- [x] `docs/ARCHITECTURE_REVIEW.md` — N/A (no signals/singletons/timers/wiring change)

## Release

This PR bumps to **2.8.3**. Release is tag-driven (`push` of `v*`): after merge to `native`, tagging **`v2.8.3`** triggers `release.yml`, which builds all artifacts and publishes the GitHub Release.

```bash
git checkout native && git pull
git tag v2.8.3
git push origin v2.8.3
```

Note (`hotfixFromBranch` policy): the `## [2.8.3]` changelog section is scoped to this packaging fix only, so the generated release notes stay focused; the unrelated items under `## [Unreleased]` are intentionally left for a later version.

## Reviewer checklist

- [x] Conventional-commit subject line (`type(scope): summary`)
- [x] No new hardcoded hex colors in C++ (N/A — no C++ changed)
- [x] No new `setFocusPolicy(Qt::NoFocus)` (N/A)
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV3s4Rdk71rJ72cQSLzgKy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FV3s4Rdk71rJ72cQSLzgKy)_