### PR TITLE
chore(ci)(deps): bump github/codeql-action from v4.36.2 to v4.36.3 (SSO-12118)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,7 +70,7 @@ jobs:
             libqt6svg6-dev
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -82,6 +82,6 @@ jobs:
           cmake --build build -j"$(nproc)"
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Consolidates two separate Dependabot PRs (#218 and #219) into a single atomic bump.

**Root cause of test failures:** Dependabot opened separate PRs for `codeql-action/init` (#219) and `codeql-action/analyze` (#218). Each PR only updated one of the two actions, leaving `init` and `analyze` on mismatched versions. CodeQL requires both steps to be on the same version — this mismatch caused the `Analyze (c-cpp)` check to fail on both PRs.

**Fix:** Update both `init` and `analyze` to `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a` (v4.36.3) in a single commit, making the workflow self-consistent.

After merging this PR, close the two Dependabot PRs:
- Close #218 (`codeql-action/analyze` bump — superseded)
- Close #219 (`codeql-action/init` bump — superseded)

Closes SSO-12118

🤖 Generated with [Claude Code](https://claude.com/claude-code)