### PR TITLE
fix(cleaner): batch Select All to prevent OOM crash after scan (GH#226 / SSO-11446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- System Cleaner: clicking "Select All" after the loading scan completes no longer crashes on Linux. The `toggled` signal fired by each checkbox was invoking `refreshInlineTree()` once per category card — up to 9 calls that each cleared and rebuilt the full tree widget (including `getFileSize()` on every retained file). On systems with large `~/.cache/` trees this caused an OOM kill. The fix batches the bulk checkbox update with a `mBulkCategoryUpdate` guard flag so `refreshInlineTree()` is called exactly once after all checkboxes are set (GH#226).
+
 ## [2.8.3] - 2026-07-07
 
 ### Added

--- a/shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp
+++ b/shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp
@@ -286,6 +286,9 @@ void SystemCleanerPage::buildCategoryCards()
             card->setProperty("checked", on);
             card->style()->unpolish(card);
             card->style()->polish(card);
+            // GH-226: skip the expensive rebuild during onSelectAllClicked(); it
+            // will call these once after all checkboxes are set.
+            if (mBulkCategoryUpdate) return;
             if (mHasScanned) refreshInlineTree();
             updateFooterTotal();
             updateCleanerCheckBadge();
@@ -491,10 +494,21 @@ void SystemCleanerPage::onSelectAllClicked()
         if (!c.check->isChecked()) { allChecked = false; break; }
     }
     const bool target = !(total > 0 && allChecked); // false ⇒ clear, true ⇒ select
+
+    // GH-226: guard against N concurrent refreshInlineTree() calls (one per
+    // toggled signal). Each call clears and rebuilds the full tree — on systems
+    // with large ~/.cache trees this causes an OOM kill. Set the flag so the
+    // toggled lambda only updates card styling; do one shared rebuild after.
+    mBulkCategoryUpdate = true;
     for (const CategoryCard &c : mCards) {
         if (c.check && c.check->isEnabled())
             c.check->setChecked(target);
     }
+    mBulkCategoryUpdate = false;
+
+    if (mHasScanned) refreshInlineTree();
+    updateFooterTotal();
+    updateCleanerCheckBadge();
 }
 
 // ─── Scan ─────────────────────────────────────────────────────────────────────

--- a/shared/nexis/Pages/SystemCleaner/system_cleaner_page.h
+++ b/shared/nexis/Pages/SystemCleaner/system_cleaner_page.h
@@ -192,6 +192,8 @@ private:
     bool mCleanInProgress = false;
     bool mCleaningFromCard = false;   // true when clean was initiated from page-0 footer
     bool mInitialScan = false;        // true during the auto-scan fired on first show
+    // GH-226: suppress per-checkbox tree rebuilds during onSelectAllClicked()
+    bool mBulkCategoryUpdate = false;
 
     // Track background tasks so they can be awaited on shutdown (BUG-05)
     QFuture<void> mWorkerFuture;


### PR DESCRIPTION
## Summary

Fixes a hard crash (OOM kill — no stack trace, terminal shows only "killed") on Linux when clicking **Select All** in System Cleaner after the loading bar finishes.

**Root cause:** `onSelectAllClicked()` iterated over up to 9 category cards and called `setChecked()` on each one. Each `setChecked()` fired the `toggled` signal, whose lambda called `refreshInlineTree()` — which clears and rebuilds the entire `QTreeWidget`, re-computing `FileUtil::getFileSize()` for every retained file and allocating a `ByteTreeWidget` per item. On Linux with large `~/.cache/` directories this happened **up to 9 times** in rapid succession, causing memory exhaustion and an OOM kill.

**Why clicking during loading worked fine:** `mHasScanned` is `false` while the background scan runs, so the `if (mHasScanned) refreshInlineTree()` guard in the lambda prevented any tree work.

**Fix:** Added `mBulkCategoryUpdate` boolean flag. `onSelectAllClicked()` sets it before the checkbox loop, the lambda early-returns while it is set (card styling still applies), then `onSelectAllClicked()` clears the flag and calls `refreshInlineTree()`, `updateFooterTotal()`, and `updateCleanerCheckBadge()` exactly once. O(N) → O(1) tree rebuilds.

**Changed files:**
- `shared/nexis/Pages/SystemCleaner/system_cleaner_page.h` — add `mBulkCategoryUpdate` member
- `shared/nexis/Pages/SystemCleaner/system_cleaner_page.cpp` — guard in `toggled` lambda; batch loop in `onSelectAllClicked()`
- `CHANGELOG.md` — [Unreleased] entry

## Test plan

- [ ] Open System Cleaner and wait for the loading bar to finish (sizes appear on cards)
- [ ] Click **Select All** — all 9 category cards should check instantly with no crash
- [ ] Click **Clear All** — all cards deselect, footer resets to `—`
- [ ] Verify individual checkbox toggle still updates inline tree (single checkbox toggled outside bulk op)
- [ ] Verify clicking **Select All** *during* loading (before sizes appear) still works

Closes GH#226, SSO-11446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)