### PR TITLE
fix(main): wire runScheduledReport() into --report argv dispatch (SSO-5778)

### DIFF
--- a/shared/nexis-core/Utils/headless_util.cpp
+++ b/shared/nexis-core/Utils/headless_util.cpp
@@ -11,7 +11,8 @@ bool HeadlessUtil::isHeadlessArgv(int argc, char *const argv[])
         const char *a = argv[i];
         if (a == nullptr) continue;
         if (std::strcmp(a, "--clean") == 0 ||
-            std::strcmp(a, "--check-threshold") == 0) {
+            std::strcmp(a, "--check-threshold") == 0 ||
+            std::strcmp(a, "--report") == 0) {
             return true;
         }
     }

--- a/shared/nexis-core/Utils/headless_util.h
+++ b/shared/nexis-core/Utils/headless_util.h
@@ -13,8 +13,9 @@ class NEXISCORESHARED_EXPORT HeadlessUtil
 {
 public:
     // True if argv contains a CLI flag that triggers a non-interactive run
-    // (`--clean` or `--check-threshold`). Pure scan of argv; performs no
-    // env access or Qt calls so it is safe to call before QApplication.
+    // (`--clean`, `--check-threshold`, or `--report`). Pure scan of argv;
+    // performs no env access or Qt calls so it is safe to call before
+    // QApplication.
     static bool isHeadlessArgv(int argc, char *const argv[]);
 
     // True if main() should `qputenv("QT_QPA_PLATFORM", "offscreen")` before

--- a/shared/nexis/main.cpp
+++ b/shared/nexis/main.cpp
@@ -21,6 +21,7 @@
 #include <Managers/setting_manager.h>
 #include <Managers/cleaner_service.h>
 #include <Managers/schedule_manager.h>
+#include <Managers/health_report_manager.h>
 #include <Utils/format_util.h>
 #include <Utils/headless_util.h>
 
@@ -201,12 +202,13 @@ int main(int argc, char *argv[])
     qApp->setDesktopFileName("nexis");
 
     // ── Headless mode detection (before QLockFile) ──────────────────────
-    // Parse --clean <schedule-id> and --check-threshold before the
-    // single-instance lock so that OS-scheduled headless invocations
-    // don't conflict with a running GUI instance.
+    // Parse --clean <schedule-id>, --check-threshold, and --report
+    // <schedule-id> before the single-instance lock so that OS-scheduled
+    // headless invocations don't conflict with a running GUI instance.
 
     QString cleanScheduleId;
     bool checkThreshold = false;
+    QString reportScheduleId;
 
     for (int i = 1; i < argc; ++i) {
         QString arg(argv[i]);
@@ -214,10 +216,12 @@ int main(int argc, char *argv[])
             cleanScheduleId = QString(argv[++i]);
         } else if (arg == "--check-threshold") {
             checkThreshold = true;
+        } else if (arg == "--report" && i + 1 < argc) {
+            reportScheduleId = QString(argv[++i]);
         }
     }
 
-    bool headless = !cleanScheduleId.isEmpty() || checkThreshold;
+    bool headless = !cleanScheduleId.isEmpty() || checkThreshold || !reportScheduleId.isEmpty();
 
     // ── Headless --clean ────────────────────────────────────────────────
     if (!cleanScheduleId.isEmpty()) {
@@ -255,6 +259,17 @@ int main(int argc, char *argv[])
                 .arg(FormatUtil::formatBytes(result.totalSize));
             showNotificationAndExit(app, "Nexis", msg);
         }
+
+        return 0;
+    }
+
+    // ── Headless --report ────────────────────────────────────────────────
+    // Fired by the launchd/systemd/cron entries syncReportSchedulesToOS()
+    // installs (SSO-5778, follow-up to FW-14 / SSO-3742).
+    if (!reportScheduleId.isEmpty()) {
+        qInstallMessageHandler(messageHandler);
+
+        HealthReportManager::ins()->runScheduledReport(reportScheduleId);
 
         return 0;
     }

--- a/tests/utils/test_headless_util.cpp
+++ b/tests/utils/test_headless_util.cpp
@@ -22,6 +22,7 @@ private slots:
     void isHeadlessArgv_cleanLast_true();
     void isHeadlessArgv_cleanWithoutId_stillTrue();
     void isHeadlessArgv_checkThreshold_true();
+    void isHeadlessArgv_report_true();
     void isHeadlessArgv_mixedWithHide_true();
     void isHeadlessArgv_prefixOnly_false();
     void isHeadlessArgv_nullArgv_false();
@@ -84,6 +85,11 @@ void TestHeadlessUtil::isHeadlessArgv_cleanWithoutId_stillTrue()
 void TestHeadlessUtil::isHeadlessArgv_checkThreshold_true()
 {
     QCOMPARE(callIsHeadless({"nexis", "--check-threshold"}), 1);
+}
+
+void TestHeadlessUtil::isHeadlessArgv_report_true()
+{
+    QCOMPARE(callIsHeadless({"nexis", "--report", "schedule-abc"}), 1);
 }
 
 void TestHeadlessUtil::isHeadlessArgv_mixedWithHide_true()


### PR DESCRIPTION
## Summary
- Disclosed non-blocking follow-up gap from PR #176 (FW-14 health-report export, SSO-3742): `HealthReportManager::runScheduledReport()` existed but `main.cpp` never parsed/dispatched `--report <scheduleId>`, so OS-scheduled reports (`syncReportSchedulesToOS()`'s launchd plist / crontab entries) silently never fired.
- Added `--report <scheduleId>` argv parsing in `main()`, mirroring the existing `--clean <scheduleId>` headless branch: installs the message handler, calls `HealthReportManager::ins()->runScheduledReport(id)`, and exits without constructing the GUI.
- Extended `HeadlessUtil::isHeadlessArgv()` to recognize `--report` so the offscreen QPA platform override (audit WI-06 / SSO-3368) also applies to scheduled report runs, not just `--clean`/`--check-threshold`.
- Added a `HeadlessUtil` unit test (`isHeadlessArgv_report_true`) covering the new flag.

On-demand export via the GUI path already worked and is unchanged.

## Test plan
- [x] `tests/utils/test_headless_util.cpp`: new `isHeadlessArgv_report_true` case added, mirroring existing `--clean` coverage.
- [ ] CI (`build.yml`) build + `ctest` — no Qt6/cmake toolchain available in this sandbox to build locally; relying on CI to confirm compile + test pass.
- [ ] Manual: `nexis --report <scheduleId>` against a schedule created via the GUI writes the Markdown report headlessly (recommend DevOps/QA smoke-test on a real launchd/cron install per SSO-5778 acceptance criteria).

Closes SSO-5778.