### PR TITLE
chore(ci): bump github/codeql-action/analyze to v4.37.0 (SSO-13349)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,7 +70,7 @@ jobs:
             libqt6svg6-dev
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -82,6 +82,6 @@ jobs:
           cmake --build build -j"$(nproc)"
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- `github/codeql-action/init` was bumped to v4.37.0 by Dependabot PR #230, but the sibling `github/codeql-action/analyze` step was left pinned at v4.36.3, causing `Analyze (c-cpp)` to fail with:
  ```
  Loaded a configuration file for version '4.37.0', but running version '4.36.3'
  Not all workflow steps that use `github/codeql-action` actions use the same version.
  ```
- Bumps both `init` and `analyze` to the matching v4.37.0 SHA (`99df26d4f13ea111d4ec1a7dddef6063f76b97e9`).
- Supersedes #230, which will be closed once this merges.

Fixes SSO-13349. Unblocks SSO-13337 (merge-gate review of PR #230 → closed in favor of this PR).

## Test plan
- [ ] CI `Analyze (c-cpp)` job goes green on this PR