### PR TITLE
chore(ci): bump github/codeql-action init+analyze to v4.37.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,7 +70,7 @@ jobs:
             libqt6svg6-dev
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -82,6 +82,6 @@ jobs:
           cmake --build build -j"$(nproc)"
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Dependabot split the codeql-action v4.36.3 -> v4.37.0 bump into two PRs: #230 (`init` only) and #231 (`analyze` only). Each fails its own `Analyze (c-cpp)` CI check because CodeQL rejects mismatched `init`/`analyze` versions.
- This PR bumps both steps atomically to v4.37.0, same remediation pattern used for the prior 4.36.2→4.36.3 split (SSO-12118, PR #227).
- Supersedes #230 and #231, which are being closed in favor of this PR.

## Test plan
- [x] CI `Analyze (c-cpp)` required check passes on this branch (no version mismatch)
- [x] Other CI jobs (Linux/macOS builds) unaffected — no code changes, workflow-only

Tracking: SSO-13338 (merge-gate handoff for PR #231)