### PR TITLE
feat(resources): DS §2/§3 elevated cards for CPU/GPU/Disk R/W charts (SSO-13731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - System Cleaner: clicking "Select All" after the loading scan completes no longer crashes on Linux. The `toggled` signal fired by each checkbox was invoking `refreshInlineTree()` once per category card — up to 9 calls that each cleared and rebuilt the full tree widget (including `getFileSize()` on every retained file). On systems with large `~/.cache/` trees this caused an OOM kill. The fix batches the bulk checkbox update with a `mBulkCategoryUpdate` guard flag so `refreshInlineTree()` is called exactly once after all checkboxes are set (GH#226).
 
+### Changed
+- Resources page (UX modernization, NEX F1/F2 consumer): the CPU, CPU Load Averages, GPU, and Disk Read Write history charts now render as DS §2 elevated cards with a DS §3 accent-bar header (`HistoryChart::setElevated()` — `[cardRole="elevated"]` fill + border, 3px `#sectionHeaderAccent` bar colored via `@cpuColor`/`@gpuColor`/`@diskColor`, 90/26 drop shadow) and their plot surface now uses the `@chartBackgroundColor` token instead of the flatter `@historyChartBackgroundColor`. The chart header's "expand" (fullscreen) button moves to the true top-right of the row (previously it sat immediately after the title). Memory, Network, Disk Temperature, PSI, OOM Kills, and the Disk Usage Launcher are unchanged and keep the page's original flat shadow.
+
+### Notes
+- Screenshot-baseline waiver (RELEASE.md §0.5): the non-blocking ScreenshotTests step is expected to flag the Resources page baselines (macOS + Linux, both themes) — the elevated-card redesign above is an intended visual change. Baselines will be regenerated via `screenshot-baselines.yml` once this lands.
+
 ## [2.8.3] - 2026-07-07
 
 ### Added

--- a/docs/APPLICATION_OVERVIEW.md
+++ b/docs/APPLICATION_OVERVIEW.md
@@ -395,6 +395,8 @@ Historical time-series charts for system resource usage.
 - Disk temperature per-drive (30s refresh, if SMART supported)
 - **CPU Pressure Stall (FR-124, Linux only)** — 3-series chart (avg10, avg60, avg300) sourced from `/proc/pressure/cpu`. Shows the percentage of time at least one task was stalled waiting for CPU. Only created when the PSI file is present (kernel 4.20+, `CONFIG_PSI=y`). Zero cost when hidden (uses DataRefreshService subscription gating).
 
+**Elevated-card chrome (NEX-Resources, UX modernization):** the CPU, CPU Load Averages, GPU, and Disk Read Write bands render as DS §2 elevated cards (`HistoryChart::setElevated()`) with a DS §3 accent bar in that metric's color token (`@cpuColor`/`@gpuColor`/`@diskColor`) and a plot surface on `@chartBackgroundColor`. The remaining charts (Memory, Network, Disk Temperature, PSI) and the OOM Kills / Disk Usage Launcher cards keep the page's original flat chrome — a later item covers them.
+
 **OOM Kills panel (FW-11 / SSO-3739, Linux only):** systemd-oomd / cgroup v2 observability card appended after the PSI chart. Shows the oomd service state (active / inactive / masked / not installed), oomd-attributed totals (`OOMKills`, `ManagedOOMKills`), the kernel-side `oom_kill` counter from `/sys/fs/cgroup/memory.events`, and the most recent kill events (timestamp, unit, cgroup path, reason) parsed from `journalctl -u systemd-oomd.service`. Hides itself entirely when no oomd or cgroup-v2 signal is available, and shows a defensive warning on the rare host that doesn't expose the v2 unified hierarchy (systemd 259 / Ubuntu 26.04 is v2-only — v1 hosts will not boot the new systemd). Subscribes to `DataRefreshService::Signal::Oomd` on the 5 s medium tick.
 
 **Disk Usage Launcher:**

--- a/shared/nexis/Pages/Resources/history_chart.cpp
+++ b/shared/nexis/Pages/Resources/history_chart.cpp
@@ -3,6 +3,8 @@
 #include "dpi.h"
 #include "Managers/app_manager.h"
 #include "signal_mapper.h"
+#include "utilities.h"
+#include <QStyle>
 
 HistoryChart::~HistoryChart()
 {
@@ -42,6 +44,9 @@ HistoryChart::HistoryChart(const QString &title, const int &seriesCount,
 void HistoryChart::init()
 {
     ui->lblHistoryTitle->setText(mTitle);
+    // Width is not stylable via QSS (mirrors #metricTileAccent /
+    // #sectionHeaderAccent convention, style.qss DS §3 doc comment).
+    ui->sectionHeaderAccent->setFixedWidth(3);
 
     // add series to chart
     for (int i = 0; i < mSeriesCount; i++) {
@@ -68,14 +73,14 @@ void HistoryChart::init()
 
     mChart->setContentsMargins(-Dpi::scale(11), -Dpi::scale(11), -Dpi::scale(11), -Dpi::scale(11));
     mChart->setMargins(QMargins(Dpi::scale(20), 0, Dpi::scale(10), Dpi::scale(10)));
-    ui->layoutHistoryChart->addWidget(mChartView, 1, 0, 1, 3);
+    ui->layoutHistoryChart->addWidget(mChartView, 1, 0, 1, 4);
 
     connect(mSignalMapper, &SignalMapper::sigChangedAppTheme, [=] {
         QSettings *sv = mAppManager->getStyleValues();
         if (!sv) return;
         QString chartLabelColor = sv->value("@chartLabelColor").toString();
         QString chartGridColor = sv->value("@chartGridColor").toString();
-        QString historyChartBackground = sv->value("@historyChartBackgroundColor").toString();
+        QString historyChartBackground = sv->value(mBackgroundToken).toString();
 
         mChart->axes(Qt::Horizontal).first()->setLabelsColor(chartLabelColor);
         mChart->axes(Qt::Horizontal).first()->setGridLineColor(chartGridColor);
@@ -133,11 +138,48 @@ void HistoryChart::setSeriesList(const QVector<QSplineSeries *> &seriesList)
 
 void HistoryChart::on_checkHistoryTitle_clicked(bool checked)
 {
-    QLayout *charts = topLevelWidget()->findChild<QWidget*>("charts")->layout();
+    QWidget *chartsContainer = topLevelWidget()->findChild<QWidget*>("charts");
+    if (!chartsContainer)
+        return;
+
+    QLayout *charts = chartsContainer->layout();
+
+    // An elevated chart (setElevated()) still IS the direct charts-layout
+    // item — no wrapper widget is introduced — so `this` already matches
+    // whatever itemAt(i)->widget() returns; walk up defensively in case a
+    // future wrapper is added around a chart.
+    QWidget *topLevelItem = this;
+    while (topLevelItem->parentWidget() && topLevelItem->parentWidget() != chartsContainer)
+        topLevelItem = topLevelItem->parentWidget();
 
     for (int i = 0; i < charts->count(); ++i) {
-        charts->itemAt(i)->widget()->setVisible(! checked);
+        if (QWidget *w = charts->itemAt(i)->widget())
+            w->setVisible(!checked || w == topLevelItem);
     }
+}
 
-    show();
+void HistoryChart::setElevated(const QString &accentToken)
+{
+    // DS §2 elevated container + DS §3 accent-bar header (style.qss
+    // [cardRole="elevated"] / #sectionHeaderAccent[accentToken=...] — NEX
+    // F1/F2 groundwork). Scoped to this instance only: ui->layoutHistoryChart
+    // and ui->sectionHeaderAccent belong to this HistoryChart's own ui, so
+    // charts that never call this (Memory, Network, ...) are unaffected.
+    setAttribute(Qt::WA_StyledBackground, true);
+    setProperty("cardRole", "elevated");
+
+    ui->sectionHeaderAccent->setProperty("compact", true);
+    ui->sectionHeaderAccent->setProperty("accentToken", accentToken);
+    ui->sectionHeaderAccent->setVisible(true);
+    style()->unpolish(ui->sectionHeaderAccent);
+    style()->polish(ui->sectionHeaderAccent);
+
+    ui->layoutHistoryChart->setContentsMargins(16, 12, 16, 14);
+
+    mBackgroundToken = QStringLiteral("@chartBackgroundColor");
+    QSettings *sv = mAppManager->getStyleValues();
+    if (sv)
+        mChart->setBackgroundBrush(QColor(sv->value(mBackgroundToken).toString()));
+
+    Utilities::addDropShadow(this, 90, 26);
 }

--- a/shared/nexis/Pages/Resources/history_chart.h
+++ b/shared/nexis/Pages/Resources/history_chart.h
@@ -31,6 +31,14 @@ public:
     void setSeriesList(const QVector<QSplineSeries *> &seriesList);
     void setCategoryAxisYLabels();
 
+    // DS §2/§3 (NEX-Resources): opt a chart into the elevated-card header
+    // treatment — reveals + colors the accent bar (accentToken is one of the
+    // #sectionHeaderAccent[accentToken=...] values in style.qss, e.g. "cpu",
+    // "gpu", "disk"), pads the header/body, switches the plot surface to the
+    // @chartBackgroundColor token, and applies the DS §2 drop shadow. Charts
+    // that don't call this keep today's flat, unshadowed-by-default chrome.
+    void setElevated(const QString &accentToken);
+
 private slots:
     void on_checkHistoryTitle_clicked(bool checked);
 
@@ -50,6 +58,8 @@ private:
     QVector<QSplineSeries *> mSeriesList;
 
     QCategoryAxis *mAxisY;
+
+    QString mBackgroundToken = QStringLiteral("@historyChartBackgroundColor");
 };
 
 #endif // HISTORYCHART_H

--- a/shared/nexis/Pages/Resources/history_chart.ui
+++ b/shared/nexis/Pages/Resources/history_chart.ui
@@ -44,29 +44,26 @@
    <property name="verticalSpacing">
     <number>0</number>
    </property>
-   <item row="0" column="1">
-    <widget class="QCheckBox" name="checkHistoryTitle">
-     <property name="cursor">
-      <cursorShape>PointingHandCursor</cursorShape>
+   <item row="0" column="0" alignment="Qt::AlignLeft|Qt::AlignVCenter">
+    <widget class="QFrame" name="sectionHeaderAccent">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="focusPolicy">
-      <enum>Qt::NoFocus</enum>
+     <property name="visible">
+      <bool>false</bool>
      </property>
-     <property name="layoutDirection">
-      <enum>Qt::LeftToRight</enum>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string notr="true"/>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
     </widget>
    </item>
-   <item row="0" column="0" alignment="Qt::AlignLeft|Qt::AlignTop">
+   <item row="0" column="1" alignment="Qt::AlignLeft|Qt::AlignTop">
     <widget class="QLabel" name="lblHistoryTitle">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -91,6 +88,25 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="0" column="3">
+    <widget class="QCheckBox" name="checkHistoryTitle">
+     <property name="cursor">
+      <cursorShape>PointingHandCursor</cursorShape>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string notr="true"/>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/shared/nexis/Pages/Resources/resources_page.cpp
+++ b/shared/nexis/Pages/Resources/resources_page.cpp
@@ -81,7 +81,24 @@ void ResourcesPage::init()
         ui->chartsLayout->addWidget(widget);
     }
 
-    Utilities::addDropShadow(widgets, 40);
+    // DS §2/§3 (NEX-Resources): elevated container + accent-bar header for
+    // the four history-chart bands named in the approved design (CPU, CPU
+    // Load Averages, GPU, Disk Read Write). Memory/Network/Disk Health/PSI/
+    // OOM are out of this item's scope and keep the flat shadow below.
+    mChartCpu->setElevated(QStringLiteral("cpu"));
+    mChartCpuLoadAvg->setElevated(QStringLiteral("cpu"));
+    if (mChartGpu)
+        mChartGpu->setElevated(QStringLiteral("gpu"));
+    mChartDiskReadWrite->setElevated(QStringLiteral("disk"));
+
+    QList<QWidget*> flatShadowWidgets = widgets;
+    flatShadowWidgets.removeOne(mChartCpu);
+    flatShadowWidgets.removeOne(mChartCpuLoadAvg);
+    flatShadowWidgets.removeOne(mChartDiskReadWrite);
+    if (mChartGpu)
+        flatShadowWidgets.removeOne(mChartGpu);
+
+    Utilities::addDropShadow(flatShadowWidgets, 40);
 
     // Subscribe to DataRefreshService signals
     connect(mRefresh, &DataRefreshService::cpuUpdated,


### PR DESCRIPTION
## Summary
- Wraps the CPU, CPU Load Averages, GPU, and Disk Read Write history-chart bands in the shared DS §2 elevated-card + DS §3 accent-bar header recipe (`[cardRole="elevated"]`, `#sectionHeaderAccent[accentToken=...]`), consuming the NEX F1/F2 QSS groundwork already on `native`. Matches the approved `docs/design/ux-modernization/mockups/renders/resources_{dark,light}.png` mockups and `notes/resources.md`.
- `HistoryChart::setElevated(accentToken)` applies the treatment per-instance (background/border/shadow, accent bar color+visibility, header padding, plot surface swapped to `@chartBackgroundColor`), so `Memory`, `Network`, `Disk Temperature`, `PSI`, and `OOM Kills` — out of this item's scope — are untouched and keep the page's existing flat shadow.
- Reordered the shared `history_chart.ui` header row (accent bar → title → stretch → expand button) so the "expand" (fullscreen) button sits at the header's true top-right on every chart, not just the 4 restyled ones. This is a shared, low-risk layout fix (button repositioning only, same icon/behavior).
- Fixed `HistoryChart::on_checkHistoryTitle_clicked` (the fullscreen toggle): it previously assumed each chart was always a direct child of the `charts` layout, which is still true here (no wrapper widget was introduced), but the handler now resolves the actual layout-owned ancestor defensively instead of hard-coding `this`, and drops the now-redundant trailing `show()` call.
- Sidebar "Resources" highlight: confirmed via code read (`App::createSidebarButton`, exclusive `QButtonGroup`, `#sidebar QPushButton:checked`) that real navigation already highlights the correct item — the stale "Dashboard" highlight in the captured docs/design screenshots is a screenshot-harness artifact (`QStackedWidget::setCurrentWidget()` bypassing the button click path), not a production bug. No code change needed for that acceptance-criteria bullet.

## Scope notes
- Only the 6 files listed in the issue were touched: `history_chart.{cpp,h,ui}`, `resources_page.cpp`, plus `CHANGELOG.md`/`docs/APPLICATION_OVERVIEW.md` per the repo's pre-commit doc checklist.
- `style.qss`/`values.ini` were **not** touched — all needed tokens/selectors (`@cpuColor`, `@gpuColor`, `@diskColor`, `@chartBackgroundColor`, `@cardBgElevated`, `@borderColor`, `[cardRole="elevated"]`, `#sectionHeaderAccent[accentToken=...]`) already exist from the NEX F1/F2/F4 blocker work.
- Shadow count: exactly 4 new DS §2 elevated containers added (CPU, CPU Load Averages, GPU, Disk Read Write) — everything else on the page is unchanged.

## Test plan
- [ ] No local C++ toolchain available in the authoring sandbox (no `cmake`/`g++`) — please confirm `cmake --build build` and `ctest --test-dir build --output-on-failure -E ScreenshotTests` are green in CI.
- [ ] `tests/screenshots` `ScreenshotTests` (non-blocking on this repo's CI) will very likely flag the `resources` baseline images (macOS + Linux, both themes) — this is the intended visual change described in the CHANGELOG's new "Notes" entry; regenerate via `screenshot-baselines.yml` after merge.
- [ ] Manual UAT once built: navigate to Resources, verify each of the 4 named charts has its own card + correctly-colored accent bar, confirm the sidebar still highlights "Resources", click each chart's expand button to confirm the fullscreen toggle still works, and check Light theme legibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)