### PR TITLE
feat(hardware-info): DS §2/§3/§4 elevated cards + typography (SSO-13735)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Notes
 - Screenshot-baseline waiver (RELEASE.md §0.5): the non-blocking ScreenshotTests step is expected to flag the Resources page baselines (macOS + Linux, both themes) — the elevated-card redesign above is an intended visual change. Baselines will be regenerated via `screenshot-baselines.yml` once this lands.
 
+### Changed
+- Hardware Info page (UX modernization, NEX F1/F2/F4 consumer): the System, Processor, Graphics, and Memory sections now render as their own DS §2 elevated cards (`[cardRole="elevated"]`, 90/26 drop shadow) with a DS §3 accent-bar section-title header above each card — Graphics uses `@gpuColor`, Processor `@cpuColor`, Memory `@memoryColor`, System the neutral `@accentColor`. Key/value rows get DS §4 typography (labels 9pt/600 `@color06`, values 9pt `@color05`, `@borderColor` row divider). Battery gets the same accent-bar header (`@batteryColor`) but intentionally no card — the approved design capture cuts off before any Battery rows, so no card chrome or fabricated rows were added for it; its live battery data (when present) is unaffected. Fans and Storage, which fall outside the approved capture, keep their original `QGroupBox` chrome unchanged. Section order, all key/value content, and the full-width "Copy GPU Diagnostics" button are unchanged (SSO-13735).
+
+### Notes
+- Screenshot-baseline waiver (RELEASE.md §0.5): the non-blocking ScreenshotTests step is expected to flag the Hardware Info page baselines (macOS + Linux, both themes) — the elevated-card redesign above is an intended visual change. Baselines will be regenerated via `screenshot-baselines.yml` once this lands.
+
 ## [2.8.3] - 2026-07-07
 
 ### Added

--- a/docs/APPLICATION_OVERVIEW.md
+++ b/docs/APPLICATION_OVERVIEW.md
@@ -196,6 +196,8 @@ Comprehensive static hardware inventory displayed in tabular sections. Two expor
 - **Export System Report** — plain text file with aligned columns. Default: `nexis-report-YYYY-MM-DD.txt`.
 - **Export as HTML (FR-126)** — self-contained HTML file (inline CSS, no external dependencies) containing a system snapshot (CPU %, memory, GPU, battery), all hardware tables, top-10 processes by CPU at export time, and pending update count. Default: `nexis-report-YYYY-MM-DD.html`.
 
+**Elevated-card chrome (SSO-13735, UX modernization):** System, Processor, Graphics, and Memory each render as a DS §2 elevated card with a DS §3 accent-bar section header (Graphics uses `@gpuColor`; System/Processor/Memory use their type-appropriate tokens). Battery gets the same accent-bar header (`@batteryColor`) but no card — the approved design capture cut off before any Battery rows. Fans and Storage, outside that capture, keep their original chrome.
+
 **9 sections:**
 - **System** — Hostname, OS, distribution, kernel, architecture, desktop environment
 - **Processor** — Model name, physical/logical core count, base clock, L1/L2/L3 cache sizes

--- a/shared/nexis/Pages/HardwareInfo/hardware_info_page.cpp
+++ b/shared/nexis/Pages/HardwareInfo/hardware_info_page.cpp
@@ -28,6 +28,7 @@
 #include "dpi.h"
 #include "Managers/app_manager.h"
 #include "signal_mapper.h"
+#include "utilities.h"
 
 #ifdef Q_OS_LINUX
 class SmartPermissionDialog : public QDialog
@@ -82,6 +83,17 @@ HardwareInfoPage::HardwareInfoPage(QWidget *parent, InfoManager *infoManager) :
 {
     ui->setupUi(this);
 
+    // DS §2 (NEX F1): elevated-card chrome for the System/Processor/Graphics/
+    // Memory sections — structural, so it's fine to set up before the
+    // deferred populate*() pass. DS §3 accent-bar headers are pure QSS via
+    // objectName (see style.qss), no C++ wiring needed. Battery
+    // intentionally gets no card (hardware_info_page.ui, SSO-13735
+    // acceptance criteria).
+    for (QWidget *card : {ui->grpSystem, ui->grpProcessor, ui->grpGraphics, ui->grpMemory})
+        card->setAttribute(Qt::WA_StyledBackground, true);
+    Utilities::addDropShadow(
+        QList<QWidget *>{ui->grpSystem, ui->grpProcessor, ui->grpGraphics, ui->grpMemory}, 90, 26);
+
     connect(SignalMapper::ins(), &SignalMapper::sigChangedAppTheme, this, &HardwareInfoPage::refreshThemeColors);
     // FR-98: defer populate*() work to first showEvent so sysctl, SMART,
     // battery, and fan I/O only run when the user actually visits this page.
@@ -112,10 +124,17 @@ void HardwareInfoPage::addRow(QTableWidget *table, const QString &label, const Q
     int row = table->rowCount();
     table->insertRow(row);
 
+    // DS §4 (SSO-13735): labels are 9pt/600 @color06; values keep the
+    // #HardwareInfoPage QTableWidget::item QSS default (9pt @color05).
     QTableWidgetItem *labelItem = new QTableWidgetItem(label);
-    QFont bold = labelItem->font();
-    bold.setBold(true);
-    labelItem->setFont(bold);
+    QFont labelFont = labelItem->font();
+    labelFont.setPointSize(9);
+    labelFont.setWeight(QFont::DemiBold);
+    labelItem->setFont(labelFont);
+    QSettings *labelSv = AppManager::ins()->getStyleValues();
+    if (labelSv)
+        labelItem->setForeground(QColor(labelSv->value("@color06").toString()));
+    mLabelItems.append(labelItem);
     table->setItem(row, 0, labelItem);
 
     QTableWidgetItem *valueItem = new QTableWidgetItem(value);
@@ -251,6 +270,7 @@ void HardwareInfoPage::populateGraphics()
     t->horizontalHeader()->setStretchLastSection(true);
 
     if (!im->hasGpu()) {
+        ui->sectionHeaderRowGraphics->hide();
         ui->grpGraphics->hide();
         return;
     }
@@ -366,6 +386,7 @@ void HardwareInfoPage::populateBattery()
     t->horizontalHeader()->setStretchLastSection(true);
 
     if (!im->hasBattery()) {
+        ui->sectionHeaderRowBattery->hide();
         ui->grpBattery->hide();
         return;
     }
@@ -711,6 +732,10 @@ void HardwareInfoPage::onUnlockAllDrives()
 
 void HardwareInfoPage::repopulateStorage()
 {
+    // setRowCount(0) deletes tblStorage's current items; drop their mLabelItems
+    // entries first so refreshThemeColors() never touches a freed pointer.
+    for (int row = 0; row < ui->tblStorage->rowCount(); ++row)
+        mLabelItems.removeAll(ui->tblStorage->item(row, 0));
     ui->tblStorage->setRowCount(0);
     populateStorage();
     fitTableHeight(ui->tblStorage);
@@ -730,6 +755,12 @@ void HardwareInfoPage::refreshThemeColors()
         else if (entry.verdict == "Critical")
             entry.item->setForeground(QColor(sv->value("@destructiveColor").toString()));
     }
+
+    // DS §4 (SSO-13735): label cells carry an explicit @color06 foreground
+    // (Qt QSS has no per-column ::item selector), so re-resolve it here.
+    const QColor labelColor(sv->value("@color06").toString());
+    for (QTableWidgetItem *labelItem : mLabelItems)
+        labelItem->setForeground(labelColor);
 }
 
 static QString tableToText(QTableWidget *table, const QString &sectionTitle)

--- a/shared/nexis/Pages/HardwareInfo/hardware_info_page.h
+++ b/shared/nexis/Pages/HardwareInfo/hardware_info_page.h
@@ -57,6 +57,10 @@ private:
     Ui::HardwareInfoPage *ui;
     InfoManager *im;
     QList<HealthItem> mHealthItems;
+    // DS §4 (SSO-13735): key/value label cells get an explicit @color06
+    // foreground (Qt QSS has no per-column ::item selector) — tracked here so
+    // refreshThemeColors() can re-resolve it on theme switch.
+    QList<QTableWidgetItem *> mLabelItems;
     QList<DriveHealth> mStorageDrives;
     // FR-98: populate work (SMART / sysctl / battery / fan I/O) runs on
     // first showEvent rather than at construction time.

--- a/shared/nexis/Pages/HardwareInfo/hardware_info_page.ui
+++ b/shared/nexis/Pages/HardwareInfo/hardware_info_page.ui
@@ -34,12 +34,45 @@
        <property name="rightMargin"><number>15</number></property>
        <property name="bottomMargin"><number>10</number></property>
 
-       <!-- System section -->
+       <!-- System section: DS §3 header (NEX F2) + DS §2 elevated card (NEX F1) -->
        <item>
-        <widget class="QGroupBox" name="grpSystem">
-         <property name="title">
-          <string>System</string>
-         </property>
+        <widget class="QWidget" name="sectionHeaderRowSystem" native="true">
+         <layout class="QHBoxLayout" name="sectionHeaderRowSystemLayout">
+          <property name="leftMargin"><number>2</number></property>
+          <property name="topMargin"><number>0</number></property>
+          <property name="rightMargin"><number>2</number></property>
+          <property name="bottomMargin"><number>0</number></property>
+          <property name="spacing"><number>8</number></property>
+          <item>
+           <widget class="QFrame" name="sectionHeaderAccentSystem">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize"><size><width>3</width><height>18</height></size></property>
+            <property name="maximumSize"><size><width>3</width><height>16777215</height></size></property>
+            <property name="frameShape"><enum>QFrame::NoFrame</enum></property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="sectionHeaderTitleSystem">
+            <property name="text"><string>System</string></property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="sectionHeaderSpacerSystem">
+            <property name="orientation"><enum>Qt::Horizontal</enum></property>
+            <property name="sizeHint" stdset="0"><size><width>40</width><height>16</height></size></property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="grpSystem" native="true">
+         <property name="cardRole" stdset="0"><string notr="true">elevated</string></property>
          <layout class="QVBoxLayout" name="grpSystemLayout">
           <property name="leftMargin"><number>12</number></property>
           <property name="topMargin"><number>12</number></property>
@@ -63,10 +96,43 @@
 
        <!-- Processor section -->
        <item>
-        <widget class="QGroupBox" name="grpProcessor">
-         <property name="title">
-          <string>Processor</string>
-         </property>
+        <widget class="QWidget" name="sectionHeaderRowProcessor" native="true">
+         <layout class="QHBoxLayout" name="sectionHeaderRowProcessorLayout">
+          <property name="leftMargin"><number>2</number></property>
+          <property name="topMargin"><number>0</number></property>
+          <property name="rightMargin"><number>2</number></property>
+          <property name="bottomMargin"><number>0</number></property>
+          <property name="spacing"><number>8</number></property>
+          <item>
+           <widget class="QFrame" name="sectionHeaderAccentProcessor">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize"><size><width>3</width><height>18</height></size></property>
+            <property name="maximumSize"><size><width>3</width><height>16777215</height></size></property>
+            <property name="frameShape"><enum>QFrame::NoFrame</enum></property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="sectionHeaderTitleProcessor">
+            <property name="text"><string>Processor</string></property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="sectionHeaderSpacerProcessor">
+            <property name="orientation"><enum>Qt::Horizontal</enum></property>
+            <property name="sizeHint" stdset="0"><size><width>40</width><height>16</height></size></property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="grpProcessor" native="true">
+         <property name="cardRole" stdset="0"><string notr="true">elevated</string></property>
          <layout class="QVBoxLayout" name="grpProcessorLayout">
           <property name="leftMargin"><number>12</number></property>
           <property name="topMargin"><number>12</number></property>
@@ -90,10 +156,43 @@
 
        <!-- Graphics section -->
        <item>
-        <widget class="QGroupBox" name="grpGraphics">
-         <property name="title">
-          <string>Graphics</string>
-         </property>
+        <widget class="QWidget" name="sectionHeaderRowGraphics" native="true">
+         <layout class="QHBoxLayout" name="sectionHeaderRowGraphicsLayout">
+          <property name="leftMargin"><number>2</number></property>
+          <property name="topMargin"><number>0</number></property>
+          <property name="rightMargin"><number>2</number></property>
+          <property name="bottomMargin"><number>0</number></property>
+          <property name="spacing"><number>8</number></property>
+          <item>
+           <widget class="QFrame" name="sectionHeaderAccentGraphics">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize"><size><width>3</width><height>18</height></size></property>
+            <property name="maximumSize"><size><width>3</width><height>16777215</height></size></property>
+            <property name="frameShape"><enum>QFrame::NoFrame</enum></property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="sectionHeaderTitleGraphics">
+            <property name="text"><string>Graphics</string></property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="sectionHeaderSpacerGraphics">
+            <property name="orientation"><enum>Qt::Horizontal</enum></property>
+            <property name="sizeHint" stdset="0"><size><width>40</width><height>16</height></size></property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="grpGraphics" native="true">
+         <property name="cardRole" stdset="0"><string notr="true">elevated</string></property>
          <layout class="QVBoxLayout" name="grpGraphicsLayout">
           <property name="leftMargin"><number>12</number></property>
           <property name="topMargin"><number>12</number></property>
@@ -117,10 +216,43 @@
 
        <!-- Memory section -->
        <item>
-        <widget class="QGroupBox" name="grpMemory">
-         <property name="title">
-          <string>Memory</string>
-         </property>
+        <widget class="QWidget" name="sectionHeaderRowMemory" native="true">
+         <layout class="QHBoxLayout" name="sectionHeaderRowMemoryLayout">
+          <property name="leftMargin"><number>2</number></property>
+          <property name="topMargin"><number>0</number></property>
+          <property name="rightMargin"><number>2</number></property>
+          <property name="bottomMargin"><number>0</number></property>
+          <property name="spacing"><number>8</number></property>
+          <item>
+           <widget class="QFrame" name="sectionHeaderAccentMemory">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize"><size><width>3</width><height>18</height></size></property>
+            <property name="maximumSize"><size><width>3</width><height>16777215</height></size></property>
+            <property name="frameShape"><enum>QFrame::NoFrame</enum></property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="sectionHeaderTitleMemory">
+            <property name="text"><string>Memory</string></property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="sectionHeaderSpacerMemory">
+            <property name="orientation"><enum>Qt::Horizontal</enum></property>
+            <property name="sizeHint" stdset="0"><size><width>40</width><height>16</height></size></property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="grpMemory" native="true">
+         <property name="cardRole" stdset="0"><string notr="true">elevated</string></property>
          <layout class="QVBoxLayout" name="grpMemoryLayout">
           <property name="leftMargin"><number>12</number></property>
           <property name="topMargin"><number>12</number></property>
@@ -142,15 +274,50 @@
         </widget>
        </item>
 
-       <!-- Battery section -->
+       <!-- Battery section: title-only header, no card — capture cuts off
+            before any Battery rows (SSO-13735 acceptance criteria); tblBattery
+            keeps rendering real battery data when present, just without the
+            DS §2 card chrome. -->
        <item>
-        <widget class="QGroupBox" name="grpBattery">
-         <property name="title">
-          <string>Battery</string>
-         </property>
+        <widget class="QWidget" name="sectionHeaderRowBattery" native="true">
+         <layout class="QHBoxLayout" name="sectionHeaderRowBatteryLayout">
+          <property name="leftMargin"><number>2</number></property>
+          <property name="topMargin"><number>0</number></property>
+          <property name="rightMargin"><number>2</number></property>
+          <property name="bottomMargin"><number>0</number></property>
+          <property name="spacing"><number>8</number></property>
+          <item>
+           <widget class="QFrame" name="sectionHeaderAccentBattery">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize"><size><width>3</width><height>18</height></size></property>
+            <property name="maximumSize"><size><width>3</width><height>16777215</height></size></property>
+            <property name="frameShape"><enum>QFrame::NoFrame</enum></property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="sectionHeaderTitleBattery">
+            <property name="text"><string>Battery</string></property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="sectionHeaderSpacerBattery">
+            <property name="orientation"><enum>Qt::Horizontal</enum></property>
+            <property name="sizeHint" stdset="0"><size><width>40</width><height>16</height></size></property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="grpBattery" native="true">
          <layout class="QVBoxLayout" name="grpBatteryLayout">
           <property name="leftMargin"><number>12</number></property>
-          <property name="topMargin"><number>12</number></property>
+          <property name="topMargin"><number>6</number></property>
           <property name="rightMargin"><number>12</number></property>
           <property name="bottomMargin"><number>6</number></property>
           <item>

--- a/shared/nexis/static/themes/default/style/style.qss
+++ b/shared/nexis/static/themes/default/style/style.qss
@@ -1278,6 +1278,42 @@ QLabel[accessibleName="dialog-title"] {
     background-color: transparent;
 }
 
+/* DS §3 section-title headers (SSO-13735): System/Processor/Graphics/Memory/
+   Battery each get their own accent-bar + label header (NEX F2 groundwork).
+   uic requires unique objectNames within one .ui, so — unlike the
+   single-instance #sectionHeaderAccent/#sectionHeaderTitle pages — these five
+   bars/labels are named per section and styled by name rather than through
+   the shared [accentToken] property selectors. */
+#HardwareInfoPage #sectionHeaderAccentSystem,
+#HardwareInfoPage #sectionHeaderAccentProcessor,
+#HardwareInfoPage #sectionHeaderAccentGraphics,
+#HardwareInfoPage #sectionHeaderAccentMemory,
+#HardwareInfoPage #sectionHeaderAccentBattery {
+    border-radius: 1;
+    min-height: 18;
+}
+
+#HardwareInfoPage #sectionHeaderAccentSystem    { background-color: @accentColor; }
+#HardwareInfoPage #sectionHeaderAccentProcessor { background-color: @cpuColor; }
+#HardwareInfoPage #sectionHeaderAccentGraphics  { background-color: @gpuColor; }
+#HardwareInfoPage #sectionHeaderAccentMemory    { background-color: @memoryColor; }
+#HardwareInfoPage #sectionHeaderAccentBattery   { background-color: @batteryColor; }
+
+#HardwareInfoPage #sectionHeaderTitleSystem,
+#HardwareInfoPage #sectionHeaderTitleProcessor,
+#HardwareInfoPage #sectionHeaderTitleGraphics,
+#HardwareInfoPage #sectionHeaderTitleMemory,
+#HardwareInfoPage #sectionHeaderTitleBattery {
+    color: @color06;
+    font-size: 9pt;
+    font-weight: 600;
+}
+
+/* SSO-13735: System/Processor/Graphics/Memory moved to the shared
+   [cardRole="elevated"] + per-section header recipe above (DS §2/§3, NEX
+   F1/F2); these QGroupBox rules now only style the remaining native-title
+   sections (Fans, Storage) that are out of this item's approved-capture
+   scope. */
 #HardwareInfoPage QGroupBox {
     border: 1px solid @borderColor;
     border-radius: 12;
@@ -1299,11 +1335,16 @@ QLabel[accessibleName="dialog-title"] {
     border: 0;
 }
 
+/* DS §4 key/value typography (SSO-13735): 9pt base for both columns, with an
+   @borderColor divider between rows. Label-column overrides (9pt/600
+   @color06) are applied per-item in C++ (addRow()) since Qt QSS has no
+   per-column ::item selector — see hardware_info_page.cpp. */
 #HardwareInfoPage QTableWidget::item {
-    font-size: 10pt;
+    font-size: 9pt;
     color: @color05;
     padding: @dp8 @dp6;
     background-color: @color01;
+    border-top: 1px solid @borderColor;
 }
 
 /**************************


### PR DESCRIPTION
## Summary
- System/Processor/Graphics/Memory sections on the Hardware Info page become DS §2 elevated cards (`[cardRole="elevated"]`, 90/26 drop shadow) with a DS §3 accent-bar section-title header (Graphics `@gpuColor`, Processor `@cpuColor`, Memory `@memoryColor`, System `@accentColor`), consuming the F1/F2 shared QSS groundwork.
- Battery gets the same header treatment (`@batteryColor`) but no card — the approved design capture (`docs/design/ux-modernization/mockups/{notes,renders}/hardware_info*`) cuts off before any Battery rows, so no card chrome or fabricated rows were added. Real battery data (when present) is unaffected.
- Fans/Storage are outside the approved capture and keep their original `QGroupBox` chrome, unchanged.
- Key/value rows get DS §4 typography: labels 9pt/600 `@color06`, values 9pt `@color05`, `@borderColor` row divider.
- Shadow count: 4 (System, Processor, Graphics, Memory), matching the issue's acceptance criteria.

## Test plan
- [x] Reviewed generated `.ui` XML for well-formedness and object-name uniqueness (uic requires unique names within one `.ui`; verified no collisions).
- [x] Manually traced `addRow()` / `refreshThemeColors()` / `repopulateStorage()` for the new `mLabelItems` tracking, including the pre-existing `setRowCount(0)` item-deletion path (mirrors the existing `mHealthItems` pattern).
- [ ] **Local cmake/Qt6 toolchain is unavailable in this environment** — could not run a local build or `ctest`. Relying on CI (`build.yml`) for compilation; please confirm the build is green before merge.
- [ ] UAT per the issue: navigate to Hardware Info, verify System/Processor/Graphics/Memory are separate elevated cards, Graphics' accent bar differs in color from the others, "Copy GPU Diagnostics" still works, Battery shows a title with no fabricated rows, and all four cards stay legible in Light theme.

Screenshot-baseline note: like the merged Resources/System-Cleaner Phase-2 PRs, this is expected to flag the Hardware Info screenshot baselines (macOS + Linux, both themes) in the non-blocking `ScreenshotTests` step — the card redesign is an intended visual change; baselines regenerate via `screenshot-baselines.yml`.

Closes [SSO-13735](/SSO/issues/SSO-13735).

🤖 Generated with [Claude Code](https://claude.com/claude-code)