### PR TITLE
fix(network): BUG-47 cleanup on Network Usage page (SSO-13812)

### DIFF
--- a/shared/nexis/Pages/Network/network_usage_page.cpp
+++ b/shared/nexis/Pages/Network/network_usage_page.cpp
@@ -121,10 +121,12 @@ protected:
 
 private:
     QList<DailyBucket> mBuckets;
-    QColor mRxColor = QColor("#5294e2");
-    QColor mTxColor = QColor("#5294e2").lighter(140);
-    QColor mBgColor = QColor("#2A2C32");
-    QColor mGridColor = QColor("#3A3D4A");
+    // BUG-47: no hardcoded hex — real values are set by setColor()/setChrome()
+    // via refreshThemeColors(), called before this widget's first paint.
+    QColor mRxColor;
+    QColor mTxColor;
+    QColor mBgColor;
+    QColor mGridColor;
 };
 
 #include "network_usage_page.moc"


### PR DESCRIPTION
## Summary
- Re-verified the 7 gaps from the [SSO-13742](https://github.com/s4solutionsllc/Nexis) post-merge design review against current `native` (commit `6ba3802a`, PR #251). Items 1-6 (drop shadows, `@cardBgElevated` token, DS §3 page/section accent-bar headers, static chart chrome, cap card visibility) are **already compliant** — the review's descriptions match the pre-modernization version of this file (`a3460e43`), not the merged `6ba3802a` it cites. No source change needed for those.
- Item 7 (BUG-47: hardcoded hex color literals) was real, if minor: `BarChartWidget`'s color members default-initialized from `QColor("#5294e2")` etc. Removed the hex literals — real values always come from `refreshThemeColors()` → `setColor()`/`setChrome()`, called in the page constructor before the widget's first paint, so behavior is unchanged.

## Test plan
- [ ] Merge-gate CI (build + CodeQL) — no local cmake/build toolchain available in this environment, deferring to CI per repo convention.
- [ ] Visual check: Network Usage page renders identically pre/post (no functional change — only removed unused hex defaults).

Ref: [SSO-13812](/SSO/issues/SSO-13812)