### PR TITLE
chore(ci): remove temporary SSO-14443 post-fix repeat-test step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,22 +81,6 @@ jobs:
       - name: Unit Tests
         run: xvfb-run -a ctest --test-dir build --output-on-failure -E ScreenshotTests
 
-      # TEMPORARY (SSO-14443): post-fix repeat run to confirm the flake no longer
-      # reproduces. Remove after CTO review/merge.
-      - name: SSO-14443 post-fix - repeat DuplicateFinderTests 20x
-        if: matrix.arch == 'x64'
-        run: |
-          cd build
-          pass=0; fail=0
-          for i in $(seq 1 20); do
-            if xvfb-run -a ctest -R '^DuplicateFinderTests$' --output-on-failure; then
-              pass=$((pass+1))
-            else
-              fail=$((fail+1))
-            fi
-          done
-          echo "SSO-14443 post-fix (30000ms + pool warmup): PASS=$pass FAIL=$fail out of 20"
-
       # ScreenshotTests are intentionally NOT run on the Linux per-PR jobs:
       # there are no committed Linux baselines (so the comparison always QSKIPs —
       # no regression value), and the test hangs indefinitely under xvfb while


### PR DESCRIPTION
## Summary

PR #273 (SSO-14443 DuplicateFinderTests flake fix) merged directly without removing the temporary 20x repeat-run CI step it added for post-fix evidence. That step ran once and confirmed **PASS=20 FAIL=0 out of 20** (Linux x64, run https://github.com/s4solutionsllc/Nexis/actions/runs/29622416327). Evidence captured; the step now just adds ~20x redundant `DuplicateFinderTests` invocations to every future PR build.

## Change

Removes the "SSO-14443 post-fix - repeat DuplicateFinderTests 20x" step from `.github/workflows/build.yml`. No other change.

Test-only CI workflow change, no production code, no security surface.