### PR TITLE
fix(shell): align page content top with sidebar divider line (SSO-14661)

### DIFF
--- a/shared/nexis/app.cpp
+++ b/shared/nexis/app.cpp
@@ -127,6 +127,18 @@ void App::buildSidebar()
     mLogoSeparator->setFixedHeight(1);
     mSidebarLayout->addWidget(mLogoSeparator);
 
+    // Align page content's top edge with this divider line so kiosk-mode and
+    // panel-edit buttons don't overlap content. The divider sits at:
+    //   sidebar top margin (8) + logoRow top margin (4)
+    //   + logo fixed height (Dpi::scale(28)) + logoRow bottom margin (4).
+    // Using fixed values here keeps this in sync with the constants set above;
+    // it is DPI-aware via Dpi::scale and doesn't change on sidebar collapse
+    // (only width changes, not the logo row height).
+    {
+        const int dividerY = 8 + 4 + Dpi::scale(28) + 4;
+        ui->pageContentLayout->setContentsMargins(0, dividerY, 0, 0);
+    }
+
     // Scrollable nav area — contains all section headers and buttons.
     // Logo row and footer (version + feedback) remain pinned outside the scroll area.
     mNavScrollArea = new QScrollArea(ui->sidebar);


### PR DESCRIPTION
## Problem

The dashboard content area started at y=0 (the very top of the window), while the left sidebar shows a logo block followed by a horizontal divider line before the nav icons begin. The floating kiosk-mode toggle and panel-edit buttons sat at y=10 within the page content area, so the top edge of the tile grid (y=12) was partially hidden behind those buttons. Visually, the content and sidebar felt misaligned.

## Fix

In `buildSidebar()` (app.cpp), immediately after the sidebar divider `QFrame` is added to the sidebar layout, compute the divider's vertical position and apply it as the top content-margin for `pageContentLayout`:

```cpp
const int dividerY = 8 + 4 + Dpi::scale(28) + 4;
ui->pageContentLayout->setContentsMargins(0, dividerY, 0, 0);
```

Where:
- `8` — `mSidebarLayout` top margin
- `4` — `logoRow` top margin
- `Dpi::scale(28)` — logo label fixed height (DPI-aware)
- `4` — `logoRow` bottom margin

At 1× DPI this is 44 px; at 2× DPI it grows automatically via `Dpi::scale`.

This is a **shared-shell fix**: all page-content widgets gain the same top alignment without per-page changes.

## Before / After

| Before | After |
|--------|-------|
| Content top edge = window top (y=0) | Content top edge = sidebar divider y (~44 px at 1x) |
| Tile grid starts behind kiosk/edit buttons | Clear space above tiles; buttons float in header zone |
| Content and sidebar visually misaligned | Content top aligned with sidebar divider baseline |

## Notes

- Only `shared/nexis/app.cpp` is modified — 12 lines inserted
- DPI-safe: uses existing `Dpi::scale()` helper
- Does not affect sidebar collapse (only sidebar width changes, not logo row height)

Related: SSO-14661