### PR TITLE
test(screenshots): SSO-14981 round-2 capture harness — APT Source Manager, Docker, GNOME Settings

### DIFF
--- a/.github/workflows/screenshot-baselines.yml
+++ b/.github/workflows/screenshot-baselines.yml
@@ -20,6 +20,17 @@ on:
         description: 'Which platforms to regenerate (comma-separated: linux-x64,macos)'
         default: 'linux-x64,macos'
         required: false
+      round2_pages:
+        description: >-
+          SSO-14981: also capture the round-2 current-state pages (APT Source
+          Manager, Docker, GNOME Settings) into a separate
+          round2-current-state-linux artifact. Linux-only; each page is
+          captured in its own isolated process run so one page's runtime
+          gating (e.g. docker/gsettings unavailable) can't block the others.
+          These pages are NOT part of tests/reference_screenshots/.
+        type: boolean
+        default: false
+        required: false
 
 jobs:
   # SSO-4093 / SSO-7306: split linux/macos into separate jobs so the Linux leg
@@ -81,6 +92,56 @@ jobs:
         with:
           name: reference-screenshots-linux
           path: tests/reference_screenshots/linux/
+          retention-days: 30
+          if-no-files-found: error
+
+      # SSO-14981: round-2 current-state capture — APT Source Manager,
+      # Docker, GNOME Settings. These pages are gated at runtime by
+      # ToolManager (App only registers them when the backing tool is
+      # detected — see app.cpp), so install what each check looks for before
+      # capturing. Kept out of scripts/update_screenshots.sh and
+      # tests/reference_screenshots/ entirely (see test_screenshots.cpp
+      # kRound2PageMap) — this is a one-off design-doc capture, not a new
+      # regression baseline.
+      - name: Install round-2 page dependencies
+        if: steps.skip-check.outputs.skipped != 'true' && inputs.round2_pages
+        run: |
+          apt-get install -y -qq \
+            docker.io \
+            gsettings-desktop-schemas \
+            dbus-x11
+
+      - name: Capture round-2 pages (SSO-14981)
+        if: steps.skip-check.outputs.skipped != 'true' && inputs.round2_pages
+        working-directory: build
+        run: |
+          set -euo pipefail
+          for page in apt_source_manager docker gnome_settings; do
+            echo "::group::Capturing $page"
+            # Gotcha #2 (CAPTURE_NOTES.md): each page runs as its own
+            # process invocation so a page that can't be driven on this
+            # host (missing/failed runtime tool check) doesn't abort the
+            # others. NEXIS_GENERATE_OUTPUT_ONLY keeps this off
+            # tests/reference_screenshots/. cwd is build/, matching
+            # scripts/update_screenshots.sh, so output lands at
+            # build/test_screenshots/linux/.
+            NEXIS_GENERATE_REFS=1 \
+            NEXIS_GENERATE_OUTPUT_ONLY=1 \
+            NEXIS_INCLUDE_ROUND2_PAGES=1 \
+            NEXIS_SCREENSHOT_ONLY="$page" \
+            dbus-run-session -- xvfb-run -a ./output/test-ScreenshotTests \
+              || echo "::warning::round-2 capture failed for $page — see log above"
+            echo "::endgroup::"
+          done
+          echo "Captured pages:"
+          find test_screenshots/linux -type f -name '*.png' | sort
+
+      - name: Upload round-2 current-state captures
+        if: steps.skip-check.outputs.skipped != 'true' && inputs.round2_pages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: round2-current-state-linux
+          path: build/test_screenshots/linux/
           retention-days: 30
           if-no-files-found: error
 

--- a/.github/workflows/screenshot-baselines.yml
+++ b/.github/workflows/screenshot-baselines.yml
@@ -110,6 +110,10 @@ jobs:
             docker.io \
             gsettings-desktop-schemas \
             dbus-x11
+          # AptSourceToolLinux::isAvailable() checks QDir("/etc/apt/sources.list.d").exists().
+          # The minimal ubuntu:26.04 container may not have this directory even after apt-get runs,
+          # so create it explicitly so the page is registered at runtime.
+          mkdir -p /etc/apt/sources.list.d
 
       - name: Capture round-2 pages (SSO-14981)
         if: steps.skip-check.outputs.skipped != 'true' && inputs.round2_pages
@@ -125,11 +129,21 @@ jobs:
             # tests/reference_screenshots/. cwd is build/, matching
             # scripts/update_screenshots.sh, so output lands at
             # build/test_screenshots/linux/.
+            #
+            # GSETTINGS_BACKEND=keyfile: forces gsettings to use file-based
+            # storage instead of the dconf bus, preventing GnomeSettingsPage
+            # from hanging on gsettings-get calls in a headless dbus session
+            # where dconf-service is not running. The keyfile backend reads
+            # compiled schemas from /usr/share/glib-2.0/schemas/ normally.
+            #
+            # timeout 60: hard safety cap per page — guards against any future
+            # hang at the Qt/xvfb level (each page capture should finish in <5s).
             NEXIS_GENERATE_REFS=1 \
             NEXIS_GENERATE_OUTPUT_ONLY=1 \
             NEXIS_INCLUDE_ROUND2_PAGES=1 \
             NEXIS_SCREENSHOT_ONLY="$page" \
-            dbus-run-session -- xvfb-run -a ./output/test-ScreenshotTests \
+            GSETTINGS_BACKEND=keyfile \
+            timeout 60 dbus-run-session -- xvfb-run -a ./output/test-ScreenshotTests \
               || echo "::warning::round-2 capture failed for $page — see log above"
             echo "::endgroup::"
           done

--- a/.github/workflows/screenshot-baselines.yml
+++ b/.github/workflows/screenshot-baselines.yml
@@ -109,11 +109,14 @@ jobs:
           apt-get install -y -qq \
             docker.io \
             gsettings-desktop-schemas \
+            dconf-gsettings-backend \
             dbus-x11
           # AptSourceToolLinux::isAvailable() checks QDir("/etc/apt/sources.list.d").exists().
-          # The minimal ubuntu:26.04 container may not have this directory even after apt-get runs,
-          # so create it explicitly so the page is registered at runtime.
+          # The minimal ubuntu:26.04 container may not have this directory, so create it.
           mkdir -p /etc/apt/sources.list.d
+          # dconf-service needs XDG_RUNTIME_DIR to create its socket; pre-create it here
+          # so it is available when dbus-run-session starts the capture processes below.
+          mkdir -p /tmp/xdg-runtime && chmod 0700 /tmp/xdg-runtime
 
       - name: Capture round-2 pages (SSO-14981)
         if: steps.skip-check.outputs.skipped != 'true' && inputs.round2_pages
@@ -130,19 +133,17 @@ jobs:
             # scripts/update_screenshots.sh, so output lands at
             # build/test_screenshots/linux/.
             #
-            # GSETTINGS_BACKEND=keyfile: forces gsettings to use file-based
-            # storage instead of the dconf bus, preventing GnomeSettingsPage
-            # from hanging on gsettings-get calls in a headless dbus session
-            # where dconf-service is not running. The keyfile backend reads
-            # compiled schemas from /usr/share/glib-2.0/schemas/ normally.
+            # XDG_RUNTIME_DIR: required so dconf-service can create its socket
+            # inside the dbus session. Without it, gsettings-get in GnomeSettingsPage
+            # hangs waiting for a dconf-service that can't start.
             #
             # timeout 60: hard safety cap per page — guards against any future
             # hang at the Qt/xvfb level (each page capture should finish in <5s).
+            XDG_RUNTIME_DIR=/tmp/xdg-runtime \
             NEXIS_GENERATE_REFS=1 \
             NEXIS_GENERATE_OUTPUT_ONLY=1 \
             NEXIS_INCLUDE_ROUND2_PAGES=1 \
             NEXIS_SCREENSHOT_ONLY="$page" \
-            GSETTINGS_BACKEND=keyfile \
             timeout 60 dbus-run-session -- xvfb-run -a ./output/test-ScreenshotTests \
               || echo "::warning::round-2 capture failed for $page — see log above"
             echo "::endgroup::"

--- a/tests/screenshots/test_screenshots.cpp
+++ b/tests/screenshots/test_screenshots.cpp
@@ -88,7 +88,7 @@ static const QVector<PageInfo> kBasePageMap = {
 // opt in per-page via NEXIS_SCREENSHOT_ONLY when driving a capture.
 #ifndef Q_OS_MACOS
 static const QVector<PageInfo> kRound2PageMap = {
-    {"AptSourceManagerPage", "apt_source_manager", {"QAbstractItemView"}, {}},
+    {"APTSourceManagerPage", "apt_source_manager", {"QAbstractItemView"}, {}},
     {"DockerPage",           "docker",             {"QAbstractItemView"}, {}},
     {"GnomeSettingsPage",    "gnome_settings",      {}, {}},
 };

--- a/tests/screenshots/test_screenshots.cpp
+++ b/tests/screenshots/test_screenshots.cpp
@@ -51,7 +51,14 @@ struct PageInfo {
 // Per-page declaration of which child widgets render live data and should be
 // masked. Anything not listed here is expected to be byte-stable (modulo
 // per-channel fuzz) between the reference capture and the comparison run.
-static const QVector<PageInfo> kPageMap = {
+//
+// This is the set used by the default CI regression suite (ctest -R
+// ScreenshotTests) and by scripts/update_screenshots.sh — it must stay in
+// sync with tests/reference_screenshots/. Round-2/one-off capture pages that
+// aren't part of the maintained baseline set go in kRound2PageMap instead
+// (see buildPageMap()), so a runtime-gated page (Docker/GNOME Settings not
+// available on every host) can never abort this default suite.
+static const QVector<PageInfo> kBasePageMap = {
     {"DashboardPage",     "dashboard",
         {"DashboardTileWrapper", "MetricTileBase", "NetworkTile"},
         {"systemSummary", "lblFooterRight"}},
@@ -73,6 +80,20 @@ static const QVector<PageInfo> kPageMap = {
     {"SettingsPage",      "settings",          {}, {}},
 };
 
+// SSO-14981: Linux-only pages that are gated behind a runtime tool check
+// (App::mPageSlots only registers them when ToolManager reports the backing
+// tool available — see app.cpp) and therefore aren't guaranteed to exist in
+// mStacked on every host. Kept out of kBasePageMap so a host missing one of
+// these (e.g. no docker binary) can't abort the default regression suite;
+// opt in per-page via NEXIS_SCREENSHOT_ONLY when driving a capture.
+#ifndef Q_OS_MACOS
+static const QVector<PageInfo> kRound2PageMap = {
+    {"AptSourceManagerPage", "apt_source_manager", {"QAbstractItemView"}, {}},
+    {"DockerPage",           "docker",             {"QAbstractItemView"}, {}},
+    {"GnomeSettingsPage",    "gnome_settings",      {}, {}},
+};
+#endif
+
 class ScreenshotTests : public QObject
 {
     Q_OBJECT
@@ -87,6 +108,30 @@ private:
     double mTolerance = kDefaultTolerance;
     int mChannelFuzz = kChannelFuzz;
     bool mGenerateMode = false;
+    // SSO-14981: when set, generate mode only writes captured PNGs to
+    // mOutDir (the build-tree scratch dir) and skips the ref-tree copy —
+    // used for one-off/round-2 captures that must not touch
+    // tests/reference_screenshots/.
+    bool mGenerateOutputOnly = false;
+    QVector<PageInfo> mPages;
+    // SSO-14981: NEXIS_SCREENSHOT_ONLY restricts the capture loop to this
+    // set of screenshotName values. Filtering happens before the
+    // "widget not found" QVERIFY2 below, so a page missing from
+    // mStacked on this host (e.g. Docker/GNOME Settings absent because
+    // the backing tool isn't installed) can't abort a run driving a
+    // *different* page — each round-2 page is captured as its own
+    // isolated process invocation (CAPTURE_NOTES.md gotcha #2).
+    QSet<QString> mOnlyFilter;
+
+    static QVector<PageInfo> buildPageMap()
+    {
+        QVector<PageInfo> pages = kBasePageMap;
+#ifndef Q_OS_MACOS
+        if (qEnvironmentVariableIsSet("NEXIS_INCLUDE_ROUND2_PAGES"))
+            pages += kRound2PageMap;
+#endif
+        return pages;
+    }
 
     static QString platformDir()
     {
@@ -257,10 +302,14 @@ private:
             }
         }
 
-        for (const auto &page : kPageMap) {
+        for (const auto &page : mPages) {
+            if (!mOnlyFilter.isEmpty() && !mOnlyFilter.contains(page.screenshotName))
+                continue;
+
             QWidget *widget = findPageByClassName(page.className);
             QVERIFY2(widget, qPrintable(QString("Page widget '%1' not found in stacked widget "
-                                                "— check kPageMap and App::ensureAllPages()")
+                                                "— check kBasePageMap/kRound2PageMap and "
+                                                "App::ensureAllPages()")
                                         .arg(page.className)));
 
             mStacked->setCurrentWidget(widget);
@@ -274,6 +323,10 @@ private:
             captured.save(outPath);
 
             if (mGenerateMode) {
+                if (mGenerateOutputOnly) {
+                    qInfo() << "Generated (output-only):" << outPath;
+                    continue;
+                }
                 const QString refPath = themeRefDir + "/" + page.screenshotName + ".png";
                 QDir().mkpath(themeRefDir);
                 captured.save(refPath);
@@ -284,7 +337,7 @@ private:
             const QString refPath = themeRefDir + "/" + page.screenshotName + ".png";
             QVERIFY2(QFile::exists(refPath),
                 qPrintable(QString("Reference missing: %1 — the baseline set is out of sync "
-                                   "with kPageMap. Regenerate with scripts/update_screenshots.sh.")
+                                   "with kBasePageMap. Regenerate with scripts/update_screenshots.sh.")
                            .arg(refPath)));
 
             QImage reference(refPath);
@@ -349,6 +402,15 @@ private slots:
         }
 
         mGenerateMode = qEnvironmentVariableIsSet("NEXIS_GENERATE_REFS");
+        mGenerateOutputOnly = qEnvironmentVariableIsSet("NEXIS_GENERATE_OUTPUT_ONLY");
+        mPages = buildPageMap();
+
+        QByteArray onlyEnv = qgetenv("NEXIS_SCREENSHOT_ONLY");
+        if (!onlyEnv.isEmpty()) {
+            const QStringList names = QString::fromUtf8(onlyEnv).split(',', Qt::SkipEmptyParts);
+            for (const QString &name : names)
+                mOnlyFilter.insert(name.trimmed());
+        }
 
         qApp->setApplicationName("nexis");
         qApp->setApplicationDisplayName("Nexis");


### PR DESCRIPTION
## Summary
Round-2 isolated capture pass for the 3 Linux pages deferred from round 1 (SSO-13745 placeholder, parent epic SSO-13723): APT Source Manager, Docker, GNOME Settings. No live capture exists anywhere for these pages today (see docs/design/ux-modernization/current-state/CAPTURE_NOTES.md).

This PR adds an **opt-in** capture path — it does not touch the existing 12-page regression baseline set (`kBasePageMap` / `tests/reference_screenshots/`):

- `tests/screenshots/test_screenshots.cpp`: new `kRound2PageMap` (Linux-only, gated behind `NEXIS_INCLUDE_ROUND2_PAGES`), plus `NEXIS_SCREENSHOT_ONLY` (single-page filter, so one page's runtime-gating failure can't abort another — CAPTURE_NOTES.md gotcha #2) and `NEXIS_GENERATE_OUTPUT_ONLY` (keeps generated PNGs out of `tests/reference_screenshots/`).
- `.github/workflows/screenshot-baselines.yml`: new `round2_pages` workflow_dispatch input on the Linux job — installs `docker.io`/`gsettings-desktop-schemas`/`dbus-x11` (satisfies `ToolManager::checkDocker()`/`checkGnomeSettings()`/`checkSourceRepository()` at app-init so the pages actually get constructed), captures each page as its own isolated process run, uploads a separate `round2-current-state-linux` artifact.

Captures + CAPTURE_NOTES.md update land in a follow-up commit on this same branch once the workflow run is verified.

Refs: SSO-14981

## Test plan
- [x] Reviewed diff: default `kBasePageMap`/CI regression path unchanged (no new required env vars for existing invocations).
- [ ] `gh workflow run screenshot-baselines.yml --ref claude/SSO-14981-round2-capture -f platforms=linux-x64 -f round2_pages=true`, watch to green.
- [ ] Download `round2-current-state-linux` artifact, confirm 6 PNGs (3 pages × 2 themes), commit into `docs/design/ux-modernization/current-state/linux/{dark,light}/`.
- [ ] DevOps merge gate (separate child issue) verifies full CI (existing regression suite unaffected) before merge.