### PR TITLE
chore(ci): group codeql-action bumps into one Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # CodeQL requires all its sub-actions (init, analyze, upload-sarif) to run
+    # the same version — split bumps break the Analyze job (see PR #302).
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
     commit-message:
       prefix: "chore(ci)"
       include: "scope"


### PR DESCRIPTION
## Summary
Adds a Dependabot `groups` entry so all `github/codeql-action/*` sub-actions (init, analyze, upload-sarif) are bumped together in a single PR.

## Why
PR #302 bumped only `codeql-action/analyze` to 4.37.1 while `init` stayed at 4.37.0, which made the CodeQL "Analyze (c-cpp)" job fail with:

> Loaded a configuration file for version '4.37.0', but running version '4.37.1'

CodeQL requires all its sub-actions to run the same version, so version bumps must land atomically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)