### PR TITLE
fix(ui): consistent tree branch chevron sizing

### DIFF
--- a/shared/nexis/static.qrc
+++ b/shared/nexis/static.qrc
@@ -65,6 +65,8 @@
         <file>static/themes/common/img/chevron-down.svg</file>
         <file>static/themes/common/img/chevron-right.svg</file>
         <file>static/themes/common/img/chevron-left.svg</file>
+        <file>static/themes/common/img/branch-chevron-down.svg</file>
+        <file>static/themes/common/img/branch-chevron-right.svg</file>
         <file>static/themes/common/img/sort-asc.svg</file>
         <file>static/themes/common/img/sort-dsc.svg</file>
         <file>static/themes/common/img/circle-checked.svg</file>

--- a/shared/nexis/static/themes/common/img/branch-chevron-down.svg
+++ b/shared/nexis/static/themes/common/img/branch-chevron-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
+  <path d="M1 3l4 4 4-4" stroke="#77767b" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/shared/nexis/static/themes/common/img/branch-chevron-right.svg
+++ b/shared/nexis/static/themes/common/img/branch-chevron-right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
+  <path d="M3 1l4 4-4 4" stroke="#77767b" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/shared/nexis/static/themes/default/style/style.qss
+++ b/shared/nexis/static/themes/default/style/style.qss
@@ -1555,15 +1555,19 @@ QLabel[accessibleName="dialog-title"] {
 
 #treeWidgetScanResult::branch:has-children:!has-siblings:closed,
 #treeWidgetScanResult::branch:closed:has-children:has-siblings {
-    image: url(:/static/themes/common/img/chevron-right.svg);
+    image: url(:/static/themes/common/img/branch-chevron-right.svg);
     border-image: none;
+    width: 10;
+    height: 10;
     padding: 4;
 }
 
 #treeWidgetScanResult::branch:open:has-children:!has-siblings,
 #treeWidgetScanResult::branch:open:has-children:has-siblings {
-    image: url(:/static/themes/common/img/chevron-down.svg);
+    image: url(:/static/themes/common/img/branch-chevron-down.svg);
     border-image: none;
+    width: 10;
+    height: 10;
     padding: 4;
 }
 
@@ -2025,15 +2029,19 @@ QLabel[accessibleName="dialog-title"] {
 
 #treeWidgetPackages::branch:has-children:!has-siblings:closed,
 #treeWidgetPackages::branch:closed:has-children:has-siblings {
-    image: url(:/static/themes/common/img/chevron-right.svg);
+    image: url(:/static/themes/common/img/branch-chevron-right.svg);
     border-image: none;
+    width: 10;
+    height: 10;
     padding: 4;
 }
 
 #treeWidgetPackages::branch:open:has-children:!has-siblings,
 #treeWidgetPackages::branch:open:has-children:has-siblings {
-    image: url(:/static/themes/common/img/chevron-down.svg);
+    image: url(:/static/themes/common/img/branch-chevron-down.svg);
     border-image: none;
+    width: 10;
+    height: 10;
     padding: 4;
 }
 
@@ -2304,15 +2312,19 @@ QLabel[accessibleName="dialog-title"] {
 
 #treeWidgetDuplicates::branch:has-children:!has-siblings:closed,
 #treeWidgetDuplicates::branch:closed:has-children:has-siblings {
-    image: url(:/static/themes/common/img/chevron-right.svg);
+    image: url(:/static/themes/common/img/branch-chevron-right.svg);
     border-image: none;
+    width: 10;
+    height: 10;
     padding: 4;
 }
 
 #treeWidgetDuplicates::branch:open:has-children:!has-siblings,
 #treeWidgetDuplicates::branch:open:has-children:has-siblings {
-    image: url(:/static/themes/common/img/chevron-down.svg);
+    image: url(:/static/themes/common/img/branch-chevron-down.svg);
     border-image: none;
+    width: 10;
+    height: 10;
     padding: 4;
 }
 
@@ -2359,15 +2371,19 @@ QLabel[accessibleName="dialog-title"] {
 
 #treeWidgetImages::branch:has-children:!has-siblings:closed,
 #treeWidgetImages::branch:closed:has-children:has-siblings {
-    image: url(:/static/themes/common/img/chevron-right.svg);
+    image: url(:/static/themes/common/img/branch-chevron-right.svg);
     border-image: none;
+    width: 10;
+    height: 10;
     padding: 4;
 }
 
 #treeWidgetImages::branch:open:has-children:!has-siblings,
 #treeWidgetImages::branch:open:has-children:has-siblings {
-    image: url(:/static/themes/common/img/chevron-down.svg);
+    image: url(:/static/themes/common/img/branch-chevron-down.svg);
     border-image: none;
+    width: 10;
+    height: 10;
     padding: 4;
 }
 
@@ -2419,8 +2435,10 @@ QLabel[accessibleName="dialog-title"] {
 #treeWidgetContainers::branch:closed:has-children:has-siblings,
 #treeWidgetVolumes::branch:has-children:!has-siblings:closed,
 #treeWidgetVolumes::branch:closed:has-children:has-siblings {
-    image: url(:/static/themes/common/img/chevron-right.svg);
+    image: url(:/static/themes/common/img/branch-chevron-right.svg);
     border-image: none;
+    width: 10;
+    height: 10;
     padding: 4;
 }
 
@@ -2428,8 +2446,10 @@ QLabel[accessibleName="dialog-title"] {
 #treeWidgetContainers::branch:open:has-children:has-siblings,
 #treeWidgetVolumes::branch:open:has-children:!has-siblings,
 #treeWidgetVolumes::branch:open:has-children:has-siblings {
-    image: url(:/static/themes/common/img/chevron-down.svg);
+    image: url(:/static/themes/common/img/branch-chevron-down.svg);
     border-image: none;
+    width: 10;
+    height: 10;
     padding: 4;
 }
 


### PR DESCRIPTION
## Summary
- Fixes inconsistent size/weight between the collapsed (`>`) and expanded (`v`) carrot icons on grouped tree widgets (Applications/Uninstaller, Homebrew, APT Source Manager, Disk Duplicates, Docker Images/Containers/Volumes, System Cleaner scan results).
- Root cause: `chevron-right.svg` (6x10) and `chevron-down.svg` (10x6) have mismatched bounding boxes, and Qt's `::branch` pseudo-element renders these at native size rather than stretching to fit — CSS `width`/`height` overrides had no effect.
- Fix: added dedicated square (10x10) `branch-chevron-right.svg` / `branch-chevron-down.svg` assets used only by the `::branch` rules; original assets are untouched so `QComboBox::down-arrow` styling is unaffected.

## Test plan
- [x] Clean rebuild (`rm -rf build && cmake ... && cmake --build`)
- [x] Manually verified in Uninstaller (Applications page) and Homebrew page — carrot now renders at consistent size/weight in both open and closed states