### PR TITLE
fix(legal): make LICENSE verbatim GPL-3.0 so GitHub detects the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,3 @@
-Nexis — Linux & macOS System Optimizer and Monitoring
-Copyright (C) 2017-2020 Oğuzhan İnan (original Stacer project)
-Copyright (C) 2025-2026 S4 Solutions, LLC (Nexis fork and ongoing development)
-
-This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation, version 3 of the License.
-
-This program is distributed in the hope that it will be useful, but WITHOUT
-ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with
-this program. If not, see <https://www.gnu.org/licenses/>.
-
---------------------------------------------------------------------------------
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+Nexis — Linux & macOS System Optimizer and Monitoring
+Copyright (C) 2017-2020 Oğuzhan İnan (original Stacer project)
+Copyright (C) 2025-2026 S4 Solutions, LLC (Nexis fork and ongoing development)
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
## Summary
GitHub's API reports the repo license as `NOASSERTION` (`gh api repos/s4solutionsllc/Nexis --jq .license`), so the README license badge and repo metadata don't show GPL-3.0 even though the project is GPL-3.0-only.

Cause: `LICENSE` had a 17-line custom copyright/attribution header prepended before the GPL text. GitHub uses [licensee](https://github.com/licensee/licensee) to detect licenses by text similarity, and the added header drops the file below the detection threshold.

## Changes
- **LICENSE** — now the unmodified GPL-3.0 text only. Verified byte-identical to licensee's own vendored `gpl-3.0.txt` reference, so detection is guaranteed once merged.
- **NOTICE** (new) — the Nexis / original-Stacer copyright and attribution notice moved here, preserving it verbatim. licensee does not scan `NOTICE` files, so it cannot interfere with detection.

## Verification
- `diff` of the new LICENSE against licensee's reference GPL-3.0 body: identical.
- Repo metadata will update after this merges to `native` (detection runs on the default branch).
- Post-merge check: `gh api repos/s4solutionsllc/Nexis --jq .license.spdx_id` should return `GPL-3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)