### PR TITLE
docs(readme): refresh competitive comparison with July 2026 research

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ This extends the global Phase 3 workflow.
 
 ## Notable Forks
 
-- **QuentiumYT/Stacer** — Most active upstream fork (78 stars). Reference for fixes and features.
+- **QuentiumYT/Stacer** — Most active upstream fork (114 stars, v1.7.0 May 2026, now the Debian upstream for `stacer`). Reference for fixes and features.
 
 ## graphify
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
   <b>Linux & macOS System Optimizer and Monitor</b><br>
-  <sub>The only free, open-source, cross-platform all-in-one system optimizer, monitor, and manager</sub>
+  <sub>Free, open-source, all-in-one system optimizer, monitor, and manager for Linux and macOS</sub>
 </p>
 
 <p align="center">
@@ -55,30 +55,39 @@
 
 ## How Nexis Compares
 
-| | **Nexis** | Stacer | CleanMyMac X | BleachBit |
-|---|:---:|:---:|:---:|:---:|
-| **Real-time monitoring** | :white_check_mark: | :white_check_mark: | Partial | :x: |
-| **System cleaning** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| **Process/service management** | :white_check_mark: | :white_check_mark: | :x: | :x: |
-| **Package management** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
-| **GPU monitoring** | :white_check_mark: | :x: | :x: | :x: |
-| **Hardware info panel** | :white_check_mark: | :x: | :x: | :x: |
-| **Battery & disk health** | :white_check_mark: | :x: | :x: | :x: |
-| **Docker management** | :white_check_mark: | :x: | :x: | :x: |
-| **System log viewer** | :white_check_mark: | :x: | :x: | :x: |
-| **Disk analysis & duplicates** | :white_check_mark: | :x: | :white_check_mark: | :x: |
-| **Network diagnostics** | :white_check_mark: | :x: | :x: | :x: |
-| **Scheduled cleaning** | :white_check_mark: | :x: | :white_check_mark: | :x: |
-| **Kiosk mode** | :white_check_mark: | :x: | :x: | :x: |
-| **Linux support** | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: |
-| **macOS support** | :white_check_mark: | :x: | :white_check_mark: | :x: |
-| **Actively maintained** | :white_check_mark: | :x: (since 2020) | :white_check_mark: | :white_check_mark: |
-| **Open source** | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: |
-| **Price** | **Free** | Free | ~$40/year | Free |
+| | **Nexis** | Stacer (fork)¹ | Mission Center | BleachBit | OnyX | CleanMyMac |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Linux support** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: |
+| **macOS support** | :white_check_mark: | :x: | :x: | Experimental | :white_check_mark: | :white_check_mark: |
+| **Real-time monitoring** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: | Partial |
+| **GPU monitoring** | :white_check_mark: | :x: | :white_check_mark: | :x: | :x: | :x: |
+| **Hardware info panel** | :white_check_mark: | :x: | Partial | :x: | :x: | :x: |
+| **Battery & disk health** | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
+| **System cleaning** | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **Scheduled cleaning** | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
+| **Secure file shredding** | :x: | :x: | :x: | :white_check_mark: | :x: | :white_check_mark: |
+| **Disk analysis & duplicates** | :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: |
+| **Process/service management** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: | Partial |
+| **Package uninstaller** | :white_check_mark: | :white_check_mark: | :x: | :x: | :white_check_mark: | :white_check_mark: |
+| **App updater** | :x: | :x: | :x: | :x: | :x: | :white_check_mark: |
+| **Malware removal** | :x: | :x: | :x: | :x: | :x: | :white_check_mark: |
+| **Docker management** | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
+| **System log viewer** | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
+| **Network diagnostics** | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
+| **Kiosk mode** | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
+| **Open source** | :white_check_mark: GPL-3.0 | :white_check_mark: GPL-3.0 | :white_check_mark: GPL-3.0 | :white_check_mark: GPL-3.0 | :x: | :x: |
+| **Price** | **Free** | Free | Free | Free | Free | $39.95/year² |
+| **Last release**³ | Jul 2026 | May 2026 | Nov 2025 | Jul 2026 | Jun 2026 | Active |
+
+¹ Upstream [Stacer](https://github.com/oguzhaninan/Stacer) was officially abandoned (last release 2019); the actively maintained community fork ([QuentiumYT/Stacer](https://github.com/QuentiumYT/Stacer), now the Debian upstream) is compared here.
+² Subscription; a one-time license is also available.
+³ As of July 2026.
+
+*Based on each project's documented features and release data, verified July 2026. Spotted an error? Corrections welcome via [issue](https://github.com/s4solutionsllc/Nexis/issues).*
 
 ## Background
 
-Nexis began as a fork of [Stacer](https://github.com/oguzhaninan/Stacer), a popular Linux system optimizer created by oguzhaninan. After the original project went inactive in 2020, development continued here -- porting to Qt 6 and C++17, adding native macOS support, GPU monitoring, a hardware info panel, kiosk mode, and fixing hundreds of bugs and regressions inherited from the upstream codebase. As the feature-set diverged, the project was rebranded as Nexis to reflect that it had become something new. Stacer laid the foundation; Nexis is where it goes from here.
+Nexis began as a fork of [Stacer](https://github.com/oguzhaninan/Stacer), a popular Linux system optimizer created by oguzhaninan. After the original project went inactive (last release 2019, officially declared abandoned), development continued here -- porting to Qt 6 and C++17, adding native macOS support, GPU monitoring, a hardware info panel, kiosk mode, and fixing hundreds of bugs and regressions inherited from the upstream codebase. As the feature-set diverged, the project was rebranded as Nexis to reflect that it had become something new. Stacer's lineage lives on in two places today: the [QuentiumYT fork](https://github.com/QuentiumYT/Stacer), which carries Stacer forward on Linux, and Nexis, which grew into a cross-platform rebuild. Stacer laid the foundation; Nexis is where it goes from here.
 
 ## Downloads
 


### PR DESCRIPTION
## Summary

Reruns the competitive research behind the README's "How Nexis Compares" section and regenerates it from verified July 2026 data (adversarially-verified web research + direct GitHub/GitLab API checks).

### Changes

- **Tagline softened** to a falsifiable claim: "Free, open-source, all-in-one system optimizer, monitor, and manager for Linux and macOS" (dropped the unprovable "only").
- **Comparison table rebuilt** with 6 columns — Nexis, Stacer (QuentiumYT fork), Mission Center, BleachBit, OnyX, CleanMyMac — and honest rows where Nexis loses (secure shredding, app updater, malware removal).
  - Stacer row now reflects the actively maintained QuentiumYT fork (v1.7.0, May 2026, current Debian upstream), footnoting the abandoned original.
  - BleachBit macOS marked "Experimental" per its own download page (previously ❌).
  - "CleanMyMac X" → "CleanMyMac"; pricing footnoted (one-time license exists).
  - Added a methodology + verified-date line inviting corrections via issue.
- **Background section** now acknowledges the two living branches of Stacer's lineage (QuentiumYT fork and Nexis).
- **CLAUDE.md**: refreshed the stale QuentiumYT fork note (78 → 114 stars, fork status).

CHANGELOG.md intentionally untouched — docs-only change, not shipped in release artifacts.

All table cells trace to documented features on official project pages or release data from the GitHub/GitLab APIs, verified 2026-07-20. Competitors that could not be verified (CCleaner for Mac, iStat Menus, GNOME/KDE tools) were deliberately excluded rather than asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)