### PR TITLE
fix(test): root SSO-3366 injection test temp dir inside $HOME (SSO-15384 CI fix)

### DIFF
--- a/tests/core/test_package_tool_macos.cpp
+++ b/tests/core/test_package_tool_macos.cpp
@@ -24,6 +24,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QStandardPaths>
 
 #ifdef Q_OS_MAC
 #include "Tools/package_tool_macos.h"
@@ -42,7 +43,10 @@ void TestPackageToolMacOS::trashApps_pathWithAppleScriptMetacharacters_noInjecti
 #ifndef Q_OS_MAC
     QSKIP("trashApps() is the macOS uninstaller path — covered by QFile::moveToTrash on Darwin only");
 #else
-    QTemporaryDir workDir;
+    // Root the temp dir inside $HOME so AppUninstallDenyList::isSafeToDelete()
+    // allows it — the deny-list rejects all paths outside $HOME as a safety net.
+    const QString homeBase = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+    QTemporaryDir workDir(QDir(homeBase).filePath(QStringLiteral("nexis-test-XXXXXX")));
     QVERIFY(workDir.isValid());
 
     // Marker the AppleScript injection payload would create if the path


### PR DESCRIPTION
**CI fix for native branch red: `TestPackageToolMacOS::trashApps_pathWithAppleScriptMetacharacters_noInjection`**

`QTemporaryDir` default location on macOS is `/var/folders/...` (outside `$HOME`). `AppUninstallDenyList::isSafeToDelete()` (added in PR #319 / SSO-15384) rejects all paths outside `$HOME` as a safety net, so `trashApps()` returns `false` and the test fails.

Fix: pass a `$HOME`-rooted template to `QTemporaryDir` so the test bundle lives inside the user home directory and passes the deny-list guard. The test still exercises the AppleScript-metacharacter injection prevention (the check that matters), now with a path the deny-list allows.

Fixes native CI red since `47e37765`. Unblocks PR #337 (SSO-15565).