### PR TITLE
ci(linux): install nethogs in the Linux build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,8 @@ jobs:
             qt6-l10n-tools \
             libqt6charts6-dev \
             libqt6svg6-dev \
-            xvfb
+            xvfb \
+            nethogs
 
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Split out of #341 (SSO-15379) — pipeline/workflow files are DevOps-owned and reviewed separately from application code per company policy, even for a single-line, low-risk addition.

Adds `nethogs` to the Linux CI job's apt-get install list. SSO-15379 wires a `NethogsStreamer` that shells out to the `nethogs` binary on Linux; this makes the binary available in the CI container.

Currently inert for test purposes — no test in the suite asserts on `CommandUtil::isExecutable("nethogs")` (verified: the only such assertions are for `ls`/a nonexistent binary/empty string in `test_command_util.cpp`, and `NethogsStreamerTests` is a pure fixture parser test with no live nethogs). Adding it now keeps CI closer to the runtime the feature targets, for any future integration coverage.

Per separation-of-duties, DevOps (author) cannot self-merge — routing to CTO.