### PR TITLE
fix(uninstaller/macOS): allow /Applications in AppUninstallDenyList (SSO-15384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- App Uninstaller (macOS, SSO-15384 follow-up): `AppUninstallDenyList::isSafeToDelete()`'s final "deny anything outside $HOME" rule silently blocked `trashApps()`/`trashLeftovers()` for every app installed in `/Applications` — the standard, overwhelmingly common macOS install location that `PackageToolMacOS::getInstalledApps()` scans directly — since `/Applications` sits outside `$HOME`. Only apps in the much rarer `~/Applications` location could actually be uninstalled. Added an explicit `/Applications` (covers `/Applications/Utilities` too) allow-list check ahead of the $HOME-only catch-all; the existing hard-deny system prefixes (`/System`, `/Library/LaunchDaemons`, etc.) still take priority and none of them nest under `/Applications`, so no unsafe path becomes newly deletable.
 - macOS build: `CrumbsReviewDialog` (SSO-15384, PR #319) declared the slot `onItemChanged(QTableWidgetItem *item)` without forward-declaring `QTableWidgetItem`, only `QTableWidget` — moc's generated code needs the type name visible even for a pointer-only parameter, so every macOS build on `native` since that merge failed at the `nexis-gui` moc-compile step (`unknown type name 'QTableWidgetItem'`) before Unit Tests could run. Added the missing `class QTableWidgetItem;` forward declaration alongside the existing `QTableWidget` one; the `.cpp` already had the real `#include <QTableWidgetItem>` it needed.
 
 ### Added

--- a/shared/nexis-core/Tools/app_uninstall_deny_list.cpp
+++ b/shared/nexis-core/Tools/app_uninstall_deny_list.cpp
@@ -92,6 +92,16 @@ bool isSafeToDelete(const QString &canonicalPath, const QString &bundleId)
             return false;
     }
 
+    // /Applications (and nested paths such as /Applications/Utilities) is the
+    // standard system-wide macOS app-install location — PackageToolMacOS::
+    // getInstalledApps() scans it directly, so paths there are the common
+    // case for trashApps(), not the exception. It must be allowed even
+    // though it falls outside $HOME; the hard deny-list above already
+    // covers every system path that must never be touched, and none of them
+    // nest under /Applications.
+    if (hasPrefix(path, QStringLiteral("/Applications")))
+        return true;
+
     // Deny paths outside $HOME entirely (Nexis never deletes system-wide files).
     if (!path.startsWith(home + QLatin1Char('/')) && path != home)
         return false;

--- a/tests/core/test_app_uninstall_deny_list.cpp
+++ b/tests/core/test_app_uninstall_deny_list.cpp
@@ -44,11 +44,14 @@ private slots:
     void allowUserLibraryLaunchAgents();   // ~/Library/LaunchAgents IS in scope
     void allowNonAppleBundleId();
     void allowEmptyBundleId();
+    void allowSystemApplicationsBundle();       // /Applications IS in scope, despite being outside $HOME
+    void allowSystemApplicationsUtilitiesBundle();
 
     // --- prefix boundary ---
     void denyExactMatch();
     void denyChildMatch();
     void allowSiblingNoFalsePrefix();
+    void denyApplicationsSiblingNoFalsePrefix();  // "/Applications2" must NOT match "/Applications"
 };
 
 static QString home()
@@ -161,6 +164,21 @@ void TestAppUninstallDenyList::allowEmptyBundleId()
     QVERIFY(AppUninstallDenyList::isSafeToDelete(path, {}));
 }
 
+void TestAppUninstallDenyList::allowSystemApplicationsBundle()
+{
+    // PackageToolMacOS::getInstalledApps() scans /Applications directly, so
+    // trashApps() must be able to delete bundles there even though the path
+    // is outside $HOME — this was a regression: the pre-existing $HOME-only
+    // rule silently blocked deletion of every app in the standard install
+    // location, the overwhelmingly common case.
+    QVERIFY(AppUninstallDenyList::isSafeToDelete(QStringLiteral("/Applications/Some App.app")));
+}
+
+void TestAppUninstallDenyList::allowSystemApplicationsUtilitiesBundle()
+{
+    QVERIFY(AppUninstallDenyList::isSafeToDelete(QStringLiteral("/Applications/Utilities/Some Utility.app")));
+}
+
 void TestAppUninstallDenyList::denyExactMatch()
 {
     QVERIFY(!AppUninstallDenyList::isSafeToDelete(QStringLiteral("/System")));
@@ -184,6 +202,13 @@ void TestAppUninstallDenyList::allowSiblingNoFalsePrefix()
     // We just check it doesn't falsely pass:
     // Actually home + "2/..." is outside home, so it should be denied.
     QVERIFY(!AppUninstallDenyList::isSafeToDelete(path));
+}
+
+void TestAppUninstallDenyList::denyApplicationsSiblingNoFalsePrefix()
+{
+    // "/Applications2" must NOT match the "/Applications" allow-list entry,
+    // and it's outside $HOME, so it's denied.
+    QVERIFY(!AppUninstallDenyList::isSafeToDelete(QStringLiteral("/Applications2/Fake.app")));
 }
 
 QTEST_MAIN(TestAppUninstallDenyList)


### PR DESCRIPTION
## Summary
- `AppUninstallDenyList::isSafeToDelete()`'s final "deny anything outside \$HOME" catch-all silently blocked `trashApps()`/`trashLeftovers()` for every app in `/Applications` — the standard, overwhelmingly common macOS install location that `PackageToolMacOS::getInstalledApps()` scans directly (`apps.append(scanAppDirectory("/Applications", "applications"))`). Only `~/Applications` (the rare case) actually worked end-to-end.
- Discovered while chasing the pre-existing `PackageToolMacOSTests` CI failure that [PR #340](https://github.com/s4solutionsllc/Nexis/pull/340)/[SSO-15647](/SSO/issues/SSO-15647) fixed at the test level (rooted the SSO-3366 test's temp dir inside `$HOME`) — that fix made the test pass but left this underlying product bug unaddressed.
- Adds an explicit `/Applications` allow-list check (covers `/Applications/Utilities` too) ahead of the `$HOME`-only catch-all. The existing hard-deny system prefixes (`/System`, `/Library/LaunchDaemons`, `/Library/PrivilegedHelperTools`, etc.) still take priority and none of them nest under `/Applications`, so nothing unsafe becomes newly deletable.

## Test plan
- [x] New unit tests: `allowSystemApplicationsBundle`, `allowSystemApplicationsUtilitiesBundle`, `denyApplicationsSiblingNoFalsePrefix` (prefix-boundary guard, `/Applications2` must not match).
- [x] Existing `denyPathOutsideHome` (`/tmp/...`) still denies as before — unaffected by this change.
- [ ] CI green (macOS/Linux x64/Linux ARM64 + CodeQL).

Relevant to [SSO-15384](/SSO/issues/SSO-15384) AC-7 fixture-validation follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)