### PR TITLE
fix(tests): un-stale Dashboard screenshot mask + fail loudly on stale masks (SSO-15971)

### DIFF
--- a/shared/nexis/Pages/Dashboard/dashboard_page.cpp
+++ b/shared/nexis/Pages/Dashboard/dashboard_page.cpp
@@ -426,6 +426,9 @@ void DashboardPage::init()
 
 void DashboardPage::buildSystemSummary()
 {
+    // SSO-15971: tests/screenshots/test_screenshots.cpp masks this widget by
+    // objectName for ScreenshotTests — keep its kPageMap entry in sync with
+    // whatever name it has after this rename.
     ui->systemSummary->setObjectName("systemSummaryCard");
 
     while (ui->summaryLayout->count() > 0) {

--- a/tests/screenshots/test_screenshots.cpp
+++ b/tests/screenshots/test_screenshots.cpp
@@ -55,9 +55,14 @@ struct PageInfo {
 // masked. Anything not listed here is expected to be byte-stable (modulo
 // per-channel fuzz) between the reference capture and the comparison run.
 static const QVector<PageInfo> kPageMap = {
+    // SSO-15971: DashboardPage::buildSystemSummary() renames this widget from
+    // "systemSummary" (its .ui name) to "systemSummaryCard" for the
+    // #systemSummaryCard QSS selector, before any capture — mask by the
+    // post-rename name or this silently stops masking the hostname/OS/CPU/RAM
+    // card, which is genuinely different on every CI runner.
     {"DashboardPage",     "dashboard",
         {"DashboardTileWrapper", "MetricTileBase", "NetworkTile"},
-        {"systemSummary", "lblFooterRight"}},
+        {"systemSummaryCard", "lblFooterRight"}},
     {"HardwareInfoPage",  "hardware_info",     {}, {}},
     {"StartupAppsPage",   "startup_apps",      {"QAbstractItemView"}, {}},
     // SSO-15956: showEvent() kicks off an async background disk-size scan on
@@ -139,7 +144,18 @@ private:
 
     // Build a mask region (in `root` coordinates) covering every child of
     // `page` that matches one of the declared dynamic class/object names.
-    static QRegion buildMaskRegion(QWidget *page, QWidget *root, const PageInfo &info)
+    //
+    // SSO-15971: a `dynamicObjectNames` entry that matches zero widgets
+    // (e.g. the widget was renamed or removed) degrades silently to "mask
+    // nothing there" instead of an error — that's exactly how the Dashboard
+    // systemSummary mask went stale through two baseline refreshes without
+    // anyone noticing. `unmatchedObjectNames`, when provided, is filled with
+    // any `dynamicObjectNames` entry that matched no child widget so the
+    // caller can fail loudly. Class-based masks are intentionally excluded:
+    // they can legitimately match zero widgets on conditionally-registered
+    // pages (SSO-15601).
+    static QRegion buildMaskRegion(QWidget *page, QWidget *root, const PageInfo &info,
+                                   QStringList *unmatchedObjectNames = nullptr)
     {
         QRegion mask;
         if (!page || !root) return mask;
@@ -147,6 +163,7 @@ private:
         const QList<QWidget *> allChildren = page->findChildren<QWidget *>();
         const QSet<QString> nameFilter(info.dynamicObjectNames.begin(),
                                        info.dynamicObjectNames.end());
+        QSet<QString> matchedNames;
 
         auto addWidgetRect = [&](QWidget *w) {
             if (!w || !w->isVisible()) return;
@@ -158,6 +175,7 @@ private:
 
         for (QWidget *w : allChildren) {
             if (!nameFilter.isEmpty() && nameFilter.contains(w->objectName())) {
+                matchedNames.insert(w->objectName());
                 addWidgetRect(w);
                 continue;
             }
@@ -166,6 +184,13 @@ private:
                     addWidgetRect(w);
                     break;
                 }
+            }
+        }
+
+        if (unmatchedObjectNames) {
+            for (const QString &name : info.dynamicObjectNames) {
+                if (!matchedNames.contains(name))
+                    unmatchedObjectNames->append(name);
             }
         }
         return mask;
@@ -355,7 +380,15 @@ private:
                            .arg(refPath)));
 
             QImage reference(refPath);
-            QRegion mask = buildMaskRegion(widget, mApp, page);
+            QStringList unmatchedMaskNames;
+            QRegion mask = buildMaskRegion(widget, mApp, page, &unmatchedMaskNames);
+            QVERIFY2(unmatchedMaskNames.isEmpty(),
+                qPrintable(QString("%1 (%2): dynamicObjectNames mask entries matched no child "
+                                   "widget: %3 — stale mask name (widget renamed/removed?) "
+                                   "silently stops masking that region instead of failing "
+                                   "loudly (SSO-15971)")
+                           .arg(page.className, theme, unmatchedMaskNames.join(", "))));
+
             CompareResult cmp = compareImages(captured, reference, mask,
                                               mTolerance, mChannelFuzz);
 


### PR DESCRIPTION
## Summary

- Root-caused the recurring `dashboard (dark)`/`dashboard (light)` ScreenshotTests baseline drift ([SSO-15971](https://s4solutions.ai) — tracked in Paperclip, not GitHub) by pulling the actual CI diff artifacts instead of re-baselining blind (3rd occurrence: PR #280 era, SSO-15460, SSO-15592).
- `DashboardPage::buildSystemSummary()` renames its summary widget from `"systemSummary"` to `"systemSummaryCard"` (for the `#systemSummaryCard` QSS selector) before any capture, but `kPageMap`'s mask list still targeted the pre-rename name. The mask never matched — the hostname/OS/CPU/RAM card (genuinely different per CI runner) has been fully exposed to pixel comparison since SSO-14441, which is why re-baselining only ever "fixes" it until the next differently-provisioned runner.
- Fixed the mask name, and added a loud failure (`QVERIFY2`) when any `dynamicObjectNames` mask entry matches zero child widgets, so a future rename can't silently degrade to "compare more pixels" the way this one did through two full baseline refreshes.

## Test plan

- [x] Dispatched `ScreenshotTests Stability Check` (repeat-until-fail, same tool used for SSO-15956) against this branch to confirm the fix — see run linked in the Paperclip issue.
- [ ] Once green, regenerate the Dashboard baseline PNGs and confirm CI passes normally (separate step per plan — fixing before re-baselining, not re-baselining over the bug again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)