### PR TITLE
chore: gitignore /.paperclip/ design-anchor mirror (SSO-17894)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ shared/nexis/static/header.xcf
 
 # graphify generated knowledge graph (regenerate with `graphify update .`)
 graphify-out/
+
+# Paperclip design-anchor mirror (SSO-1768) — generated, never commit
+/.paperclip/


### PR DESCRIPTION
## What

Adds `/.paperclip/` to `.gitignore`.

## Why

The SSO-1768 design-anchor mirror routine writes `.paperclip/design/{design,brand,tone,voice,runbook}.md` into every managed checkout of this repo. Nothing ignored that path, so those generated files sat permanently untracked in every working tree:

1. The org close gate (SSO-1676 item 1) requires a clean `git status`. Every agent starting work here inherited dirt it did not create.
2. A stray `git add -A` / `git commit -a` would silently sweep the mirrored Paperclip documents into product history.

## Scope / safety

- One line plus a comment in `.gitignore`. No source, build, or config change; zero runtime impact.
- The mirrored files are **not** deleted — the routine regenerates them and agents read them per SSO-1768.
- Nothing under `.paperclip` is currently tracked in this repo (`git ls-files .paperclip` is empty), so no file is removed from the index by this change.
- Anchored with a leading `/` so it only matches the repo root, not any nested `.paperclip` a subproject might legitimately own.

## Verification

In a fresh clone of this branch:

```
$ mkdir -p .paperclip/design && touch .paperclip/design/brand.md
$ git check-ignore -q .paperclip/design/brand.md && echo ignored
ignored
$ git status --porcelain -uall -- .paperclip
(empty)
```

Tracks S4 issue SSO-17894.