### PR TITLE
fix(duplicate-finder): remove cross-thread flake in DuplicateFinderTests (SSO-17858)

### DIFF
--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -497,6 +497,8 @@ Converted Dashboard (removed 3 timers), Resources (removed 2 timers), and Proces
 
 **FW-08 (SSO-3736):** `DuplicateFinderService` gained a virtual `moveToTrash()` seam plus a virtual `loadExclusions()` seam so the destructive `trashFiles()` path is exercised without touching the user's real trash or settings. The service now consults the cleaner exclusion engine across all three scan modes (duplicates, top-N largest, empty folders) and enforces the never-delete-last-copy invariant at the service layer via `filterSafeTrashCandidates()` — the UI is no longer the only line of defense.
 
+**SSO-17858:** added a virtual `runsAsynchronously()` seam (default `true`, production unchanged). `TestDuplicateFinder` overrides it to `false` so `scan()`/`scanLargest()`/`scanEmptyFolders()` run their pipeline and emit `*Finished` synchronously instead of via `QtConcurrent::run()`. This removes the suite from a cross-thread queued-connection delivery hop that intermittently exceeded `QSignalSpy::wait()`'s timeout under CPU-throttled CI runners (SSO-13969, SSO-14443) — the earlier fixes patched symptoms (raising timeouts, pre-warming the thread pool); this removes the nondeterministic hop these tests never needed to exercise.
+
 **Key refactoring:** FR-36 established the pattern with `parseSmartctlJsonInto()` shared static (dedup), `deriveHealthVerdict()` public static, `getNextRunTime()` injectable `now` parameter. FR-76 scaled this to 10 additional classes by extracting parsing logic into public static methods on shared base classes (`*_shared.cpp` files). Fixture data files in `tests/fixtures/` provide deterministic test input. CleanerExclusions tests link against `nexis-gui` library to access CleanerService.
 
 ---

--- a/shared/nexis/Services/duplicate_finder_service.cpp
+++ b/shared/nexis/Services/duplicate_finder_service.cpp
@@ -69,15 +69,19 @@ void DuplicateFinderService::scan(const QStringList &directories,
     mCancelled.storeRelaxed(0);
     const auto exclusions = loadExclusions();
 
-    mWorkerFuture = QtConcurrent::run(
-        [this, directories, minSize, globFilter, exclusions]() {
+    auto job = [this, directories, minSize, globFilter, exclusions]() {
         QList<DuplicateGroup> results =
             runPipeline(directories, minSize, globFilter, exclusions);
         if (mCancelled.loadRelaxed())
             emit scanCancelled();
         else
             emit scanFinished(results);
-    });
+    };
+
+    if (runsAsynchronously())
+        mWorkerFuture = QtConcurrent::run(job);
+    else
+        job();
 }
 
 void DuplicateFinderService::scanLargest(const QStringList &directories, int topN)
@@ -88,14 +92,19 @@ void DuplicateFinderService::scanLargest(const QStringList &directories, int top
     mCancelled.storeRelaxed(0);
     const auto exclusions = loadExclusions();
 
-    mWorkerFuture = QtConcurrent::run([this, directories, topN, exclusions]() {
+    auto job = [this, directories, topN, exclusions]() {
         QList<LargeFileEntry> results =
             runLargestPipeline(directories, topN, exclusions);
         if (mCancelled.loadRelaxed())
             emit scanCancelled();
         else
             emit largestScanFinished(results);
-    });
+    };
+
+    if (runsAsynchronously())
+        mWorkerFuture = QtConcurrent::run(job);
+    else
+        job();
 }
 
 void DuplicateFinderService::scanEmptyFolders(const QStringList &directories)
@@ -106,13 +115,18 @@ void DuplicateFinderService::scanEmptyFolders(const QStringList &directories)
     mCancelled.storeRelaxed(0);
     const auto exclusions = loadExclusions();
 
-    mWorkerFuture = QtConcurrent::run([this, directories, exclusions]() {
+    auto job = [this, directories, exclusions]() {
         QStringList results = runEmptyFoldersPipeline(directories, exclusions);
         if (mCancelled.loadRelaxed())
             emit scanCancelled();
         else
             emit emptyFoldersScanFinished(results);
-    });
+    };
+
+    if (runsAsynchronously())
+        mWorkerFuture = QtConcurrent::run(job);
+    else
+        job();
 }
 
 QStringList DuplicateFinderService::trashFiles(

--- a/shared/nexis/Services/duplicate_finder_service.h
+++ b/shared/nexis/Services/duplicate_finder_service.h
@@ -91,6 +91,17 @@ protected:
     // QStandardPaths or the real settings backend.
     virtual QList<CleanerService::ExclusionEntry> loadExclusions() const;
 
+    // SSO-17858: test seam — scan()/scanLargest()/scanEmptyFolders() emit
+    // their *Finished signal from a QThreadPool worker thread by default,
+    // so QSignalSpy::wait() has to survive a cross-thread queued-connection
+    // hop. Under CPU-throttled CI runners that hop occasionally exceeds the
+    // spy's timeout (SSO-13969, SSO-14443, SSO-17858) even though the
+    // pipeline itself is correct — the flake is in the delivery latency,
+    // not the result. Tests that only care about pipeline correctness
+    // override this to run the pipeline and emit synchronously, removing
+    // the thread hop (and the flake) entirely.
+    virtual bool runsAsynchronously() const { return true; }
+
     explicit DuplicateFinderService(QObject *parent = nullptr);
     virtual ~DuplicateFinderService();
 

--- a/tests/managers/test_duplicate_finder.cpp
+++ b/tests/managers/test_duplicate_finder.cpp
@@ -12,8 +12,6 @@
 #include <QSignalSpy>
 #include <QStandardPaths>
 #include <QTemporaryDir>
-#include <QThreadPool>
-#include <QtConcurrent>
 
 #include "Services/duplicate_finder_service.h"
 #include "Managers/cleaner_service.h"
@@ -61,6 +59,13 @@ public:
 
 protected:
     QList<Entry> loadExclusions() const override { return injectedExclusions; }
+
+    // SSO-17858: run the pipeline synchronously so *Finished fires before
+    // QSignalSpy::wait() is even called, removing this suite from the
+    // cross-thread queued-connection timing this test doesn't need to
+    // exercise (these tests assert pipeline correctness, not QtConcurrent
+    // scheduling). See duplicate_finder_service.h for the rationale.
+    bool runsAsynchronously() const override { return false; }
 
     bool moveToTrash(const QString &path) override
     {
@@ -127,10 +132,6 @@ void TestDuplicateFinder::initTestCase()
     // Match the cleaner test conventions: route QStandardPaths to a
     // sandbox in case any production code path is reached unexpectedly.
     QStandardPaths::setTestModeEnabled(true);
-    // SSO-14443: pre-warm the global QThreadPool so the first QtConcurrent::run()
-    // call doesn't pay thread-creation latency inside a spy.wait() timeout. Under
-    // GitHub Actions container CPU throttling the spawn delay can exceed 10 s.
-    QtConcurrent::run([] {}).waitForFinished();
 }
 
 // ─── Duplicate grouping ───────────────────────────────────────────────────────

--- a/tests/managers/test_duplicate_finder.cpp
+++ b/tests/managers/test_duplicate_finder.cpp
@@ -157,7 +157,12 @@ void TestDuplicateFinder::duplicates_groupsKnownIdenticalFiles()
     QSignalSpy spy(&svc, &DuplicateFinderService::scanFinished);
     svc.scan({tmp.path()}, /*minSize=*/0);
 
-    QVERIFY(spy.wait(30000));
+    // SSO-17858: TestableDuplicateFinderService runs synchronously, so
+    // scanFinished may already be recorded by the time we get here —
+    // QSignalSpy::wait() only detects emissions *after* it's called, so
+    // it would otherwise time out waiting for a signal that already fired.
+    if (spy.isEmpty())
+        QVERIFY(spy.wait(30000));
     QCOMPARE(spy.count(), 1);
 
     const auto results = spy.takeFirst().at(0).value<QList<DuplicateGroup>>();
@@ -191,7 +196,12 @@ void TestDuplicateFinder::duplicates_sameSizeDifferentContent_notGrouped()
     QSignalSpy spy(&svc, &DuplicateFinderService::scanFinished);
     svc.scan({tmp.path()}, /*minSize=*/0);
 
-    QVERIFY(spy.wait(30000));
+    // SSO-17858: TestableDuplicateFinderService runs synchronously, so
+    // scanFinished may already be recorded by the time we get here —
+    // QSignalSpy::wait() only detects emissions *after* it's called, so
+    // it would otherwise time out waiting for a signal that already fired.
+    if (spy.isEmpty())
+        QVERIFY(spy.wait(30000));
     const auto results = spy.takeFirst().at(0).value<QList<DuplicateGroup>>();
     QVERIFY2(results.isEmpty(),
              "same-size, different-content files must not be grouped");
@@ -208,7 +218,12 @@ void TestDuplicateFinder::duplicates_singletonSize_dropped()
     QSignalSpy spy(&svc, &DuplicateFinderService::scanFinished);
     svc.scan({tmp.path()}, /*minSize=*/0);
 
-    QVERIFY(spy.wait(30000));
+    // SSO-17858: TestableDuplicateFinderService runs synchronously, so
+    // scanFinished may already be recorded by the time we get here —
+    // QSignalSpy::wait() only detects emissions *after* it's called, so
+    // it would otherwise time out waiting for a signal that already fired.
+    if (spy.isEmpty())
+        QVERIFY(spy.wait(30000));
     const auto results = spy.takeFirst().at(0).value<QList<DuplicateGroup>>();
     QVERIFY(results.isEmpty());
 }
@@ -273,7 +288,12 @@ void TestDuplicateFinder::largest_scan_emitsResults()
     QSignalSpy spy(&svc, &DuplicateFinderService::largestScanFinished);
     svc.scanLargest({tmp.path()}, /*topN=*/2);
 
-    QVERIFY(spy.wait(30000));
+    // SSO-17858: TestableDuplicateFinderService runs synchronously, so
+    // scanFinished may already be recorded by the time we get here —
+    // QSignalSpy::wait() only detects emissions *after* it's called, so
+    // it would otherwise time out waiting for a signal that already fired.
+    if (spy.isEmpty())
+        QVERIFY(spy.wait(30000));
     const auto results = spy.takeFirst().at(0).value<QList<LargeFileEntry>>();
     QCOMPARE(results.size(), 2);
     QCOMPARE(results.at(0).size, quint64(512));
@@ -295,7 +315,12 @@ void TestDuplicateFinder::emptyFolders_detectsLeaves()
     QSignalSpy spy(&svc, &DuplicateFinderService::emptyFoldersScanFinished);
     svc.scanEmptyFolders({tmp.path()});
 
-    QVERIFY(spy.wait(30000));
+    // SSO-17858: TestableDuplicateFinderService runs synchronously, so
+    // scanFinished may already be recorded by the time we get here —
+    // QSignalSpy::wait() only detects emissions *after* it's called, so
+    // it would otherwise time out waiting for a signal that already fired.
+    if (spy.isEmpty())
+        QVERIFY(spy.wait(30000));
     const auto results = spy.takeFirst().at(0).toStringList();
     QCOMPARE(results.size(), 2);
     QVERIFY(results.contains(tmp.path() + "/empty_one"));
@@ -315,7 +340,12 @@ void TestDuplicateFinder::emptyFolders_ignoresNonEmpty()
     QSignalSpy spy(&svc, &DuplicateFinderService::emptyFoldersScanFinished);
     svc.scanEmptyFolders({tmp.path()});
 
-    QVERIFY(spy.wait(30000));
+    // SSO-17858: TestableDuplicateFinderService runs synchronously, so
+    // scanFinished may already be recorded by the time we get here —
+    // QSignalSpy::wait() only detects emissions *after* it's called, so
+    // it would otherwise time out waiting for a signal that already fired.
+    if (spy.isEmpty())
+        QVERIFY(spy.wait(30000));
     const auto results = spy.takeFirst().at(0).toStringList();
     QVERIFY2(!results.contains(tmp.path() + "/has_hidden"),
              "folder with a hidden file must not be reported as empty");
@@ -336,7 +366,12 @@ void TestDuplicateFinder::emptyFolders_excludedFolder_notReported()
 
     QSignalSpy spy(&svc, &DuplicateFinderService::emptyFoldersScanFinished);
     svc.scanEmptyFolders({tmp.path()});
-    QVERIFY(spy.wait(30000));
+    // SSO-17858: TestableDuplicateFinderService runs synchronously, so
+    // scanFinished may already be recorded by the time we get here —
+    // QSignalSpy::wait() only detects emissions *after* it's called, so
+    // it would otherwise time out waiting for a signal that already fired.
+    if (spy.isEmpty())
+        QVERIFY(spy.wait(30000));
     const auto results = spy.takeFirst().at(0).toStringList();
     QVERIFY(results.contains(tmp.path() + "/empty_visible"));
     QVERIFY(!results.contains(tmp.path() + "/empty_protected"));
@@ -362,7 +397,12 @@ void TestDuplicateFinder::exclusions_excludedFile_notFlaggedAsDuplicate()
 
     QSignalSpy spy(&svc, &DuplicateFinderService::scanFinished);
     svc.scan({tmp.path()}, /*minSize=*/0);
-    QVERIFY(spy.wait(30000));
+    // SSO-17858: TestableDuplicateFinderService runs synchronously, so
+    // scanFinished may already be recorded by the time we get here —
+    // QSignalSpy::wait() only detects emissions *after* it's called, so
+    // it would otherwise time out waiting for a signal that already fired.
+    if (spy.isEmpty())
+        QVERIFY(spy.wait(30000));
     const auto results = spy.takeFirst().at(0).value<QList<DuplicateGroup>>();
     QCOMPARE(results.size(), 1);
     QCOMPARE(results.at(0).files.size(), 2);
@@ -393,7 +433,12 @@ void TestDuplicateFinder::exclusions_excludedFolder_membersHidden()
 
     QSignalSpy spy(&svc, &DuplicateFinderService::scanFinished);
     svc.scan({tmp.path()}, /*minSize=*/0);
-    QVERIFY(spy.wait(30000));
+    // SSO-17858: TestableDuplicateFinderService runs synchronously, so
+    // scanFinished may already be recorded by the time we get here —
+    // QSignalSpy::wait() only detects emissions *after* it's called, so
+    // it would otherwise time out waiting for a signal that already fired.
+    if (spy.isEmpty())
+        QVERIFY(spy.wait(30000));
     const auto results = spy.takeFirst().at(0).value<QList<DuplicateGroup>>();
     QCOMPARE(results.size(), 1);
     QCOMPARE(results.at(0).files.size(), 2);
@@ -418,7 +463,12 @@ void TestDuplicateFinder::exclusions_largestScan_respected()
 
     QSignalSpy spy(&svc, &DuplicateFinderService::largestScanFinished);
     svc.scanLargest({tmp.path()}, /*topN=*/10);
-    QVERIFY(spy.wait(30000));
+    // SSO-17858: TestableDuplicateFinderService runs synchronously, so
+    // scanFinished may already be recorded by the time we get here —
+    // QSignalSpy::wait() only detects emissions *after* it's called, so
+    // it would otherwise time out waiting for a signal that already fired.
+    if (spy.isEmpty())
+        QVERIFY(spy.wait(30000));
     const auto results = spy.takeFirst().at(0).value<QList<LargeFileEntry>>();
     QCOMPARE(results.size(), 1);
     QCOMPARE(results.at(0).info.absoluteFilePath(), tmp.path() + "/keep/big.bin");


### PR DESCRIPTION
## Summary
- Root cause: `scan()`/`scanLargest()`/`scanEmptyFolders()` emit `*Finished` from a `QtConcurrent::run()` worker thread, so `QSignalSpy::wait()` in the test suite has to survive a cross-thread queued-connection hop — that hop occasionally exceeds the spy's timeout under CPU-throttled CI runners (this is the third occurrence: SSO-13969, SSO-14443, SSO-17858). The pipeline result itself was never wrong; earlier fixes raised timeouts / pre-warmed the thread pool, which are symptom patches, not a fix.
- Added a `runsAsynchronously()` virtual seam on `DuplicateFinderService` (default `true` — no production behavior change). `TestableDuplicateFinderService` overrides it to `false` so the whole `DuplicateFinderTests` suite runs its pipeline and emits synchronously, removing the cross-thread hop these tests never needed to exercise.
- Dropped the now-dead SSO-14443 thread-pool pre-warm hack in `initTestCase()`.
- `docs/ARCHITECTURE_REVIEW.md` updated alongside the FW-08 seam documentation.

## Test plan
- [ ] CI: `ctest -R DuplicateFinderTests` green, including a few repeat runs against the same binary to confirm the flake is gone
- Could not build or run ctest locally — this sandbox has no cmake/g++/Qt6 toolchain (same constraint already documented on SSO-15662). CI is the verification gate for this change.

Paperclip: SSO-17858