### PR TITLE
fix(website): update APT install copy to current Ubuntu series (SSO-22809)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Website (SSO-22809): the install page's apt tab note still named EOL'd Ubuntu series (22.04 Jammy, 24.04 Noble, 25.04 Plucky) that had drifted from `README.md`'s PPA support statement after it moved to 25.10 Questing / 26.04 Resolute — new Linux users following the public install page were being told to add a PPA with no package for their series, or a series (Plucky) that no longer exists. `website/src/components/PackageManagerInstall.astro`'s apt note now matches README, with an adjacent caveat carrying across the Qt 6.8 LTS constraint (Nexis 2.6+) so 22.04/24.04 users are pointed at the AppImage instead of a dead end.
+
 ## [2.9.0] - 2026-08-12
 
 ### Fixed

--- a/website/src/components/PackageManagerInstall.astro
+++ b/website/src/components/PackageManagerInstall.astro
@@ -8,7 +8,8 @@ const tabs = [
 sudo apt update
 sudo apt install nexis`,
     upgrade: `sudo apt update && sudo apt upgrade nexis`,
-    note: 'Supports Ubuntu 22.04 (Jammy), 24.04 (Noble), and 25.04 (Plucky) on x86_64 and ARM64.',
+    note: 'Supports Ubuntu 25.10 (Questing) and 26.04 (Resolute) on x86_64 and ARM64.',
+    caveat: 'Ubuntu 22.04 / 24.04 (and Linux Mint Zena): Nexis 2.6+ requires Qt 6.8 LTS, which isn’t available in those repos — install via the AppImage instead.',
   },
   {
     id: 'brew',
@@ -52,7 +53,8 @@ brew install --cask nexis`,
           data-pm-content={tab.id}
           class:list={['pm-content rounded-b-lg border border-nexis-border bg-nexis-dark p-6', i !== 0 && 'hidden']}
         >
-          <p class="mb-4 text-xs text-nexis-muted">{tab.note}</p>
+          <p class:list={['text-xs text-nexis-muted', tab.caveat ? 'mb-1' : 'mb-4']}>{tab.note}</p>
+          {tab.caveat && <p class="mb-4 text-xs text-nexis-muted/80">{tab.caveat}</p>}
 
           <p class="mb-1 text-xs font-semibold uppercase tracking-wider text-nexis-muted">Install</p>
           <pre class="mb-5 overflow-x-auto rounded-md bg-nexis-dark-surface p-4 text-sm leading-relaxed text-nexis-light"><code>{tab.install}</code></pre>


### PR DESCRIPTION
## Summary
- `website/src/components/PackageManagerInstall.astro`'s apt tab note named EOL'd Ubuntu series (22.04 Jammy, 24.04 Noble, 25.04 Plucky) that had drifted from `README.md:108`, which was updated to 25.10 Questing / 26.04 Resolute after the PPA series moved.
- Updated the note to match README, and added an adjacent `caveat` line (rendered only for the apt tab) carrying across the Qt 6.8 LTS constraint from `README.md:110`, pointing 22.04/24.04 users at the AppImage instead of a dead-end PPA add.
- Checked `website/src/pages/migrating-from-stacer.astro` (~line 38) — already correct (25.10/26.04 + Qt 6.8 caveat), no change needed.
- Swept the rest of `website/` for other hardcoded Ubuntu series references — the only other hit (`alternatives/stacer.astro:34`) is about Stacer's own compatibility problems, not Nexis support, so it's correctly out of scope.
- No change to tab component structure, IDs, or the tab-switching script — copy/content only.

## Test plan
- [x] `npm run build` in `website/` succeeds
- [x] Verified rendered `dist/index.html` shows "Supports Ubuntu 25.10 (Questing) and 26.04 (Resolute)..." and the Qt 6.8/AppImage caveat
- [x] Verified no leftover "Plucky"/"25.04" references in the built output

Fixes SSO-22809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)