### PR TITLE
fix: disable minimize-to-tray on systems without system tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Settings — "Minimize to Tray" / "Start Minimized to Tray" on desktop environments with no usable system tray: the checkboxes stayed enabled and toggleable even when `QSystemTrayIcon::isSystemTrayAvailable()` is false, letting a user enable minimize-to-tray and then have the window vanish on close/minimize with no tray icon to bring it back. `SettingsPage::init()` now disables both checkboxes (with an explanatory tooltip) whenever no tray is available, and `App::closeEvent()`/`App::changeEvent()` and the `--hide`/start-minimized launch path in `main.cpp` re-check tray availability at the point of use as defense-in-depth, so a stale `true` value in an existing config (e.g. carried over from a machine/session that did have a tray) can't strand the window hidden.
 - Website (SSO-22809): the install page's apt tab note still named EOL'd Ubuntu series (22.04 Jammy, 24.04 Noble, 25.04 Plucky) that had drifted from `README.md`'s PPA support statement after it moved to 25.10 Questing / 26.04 Resolute — new Linux users following the public install page were being told to add a PPA with no package for their series, or a series (Plucky) that no longer exists. `website/src/components/PackageManagerInstall.astro`'s apt note now matches README, with an adjacent caveat carrying across the Qt 6.8 LTS constraint (Nexis 2.6+) so 22.04/24.04 users are pointed at the AppImage instead of a dead end.
 
 ## [2.9.0] - 2026-08-12

--- a/shared/nexis/Pages/Settings/settings_page.cpp
+++ b/shared/nexis/Pages/Settings/settings_page.cpp
@@ -24,6 +24,7 @@
 #include <QScrollArea>
 #include <QGuiApplication>
 #include <QScreen>
+#include <QSystemTrayIcon>
 #include <Utils/format_util.h>
 #include <functional>
 
@@ -127,11 +128,19 @@ void SettingsPage::init()
     // app quit dont ask
     ui->checkAppQuitDontAsk->setChecked(mSettingManager->getAppQuitDialogDontAsk());
 
-    // minimize to tray
-    ui->checkMinimizeToTray->setChecked(mSettingManager->getMinimizeToTray());
-
-    // start minimized to tray (SSO-354)
-    ui->checkStartMinimizedToTray->setChecked(mSettingManager->getStartMinimizedToTray());
+    // minimize to tray — the setting is meaningless (and unrecoverable via the
+    // UI) on desktop environments that don't provide a usable system tray, so
+    // disable both tray-dependent options when Qt reports none is available.
+    bool trayAvailable = QSystemTrayIcon::isSystemTrayAvailable();
+    ui->checkMinimizeToTray->setChecked(trayAvailable && mSettingManager->getMinimizeToTray());
+    ui->checkMinimizeToTray->setEnabled(trayAvailable);
+    ui->checkStartMinimizedToTray->setChecked(trayAvailable && mSettingManager->getStartMinimizedToTray());
+    ui->checkStartMinimizedToTray->setEnabled(trayAvailable);
+    if (! trayAvailable) {
+        QString noTrayTip = tr("No system tray is available on this desktop environment.");
+        ui->checkMinimizeToTray->setToolTip(noTrayTip);
+        ui->checkStartMinimizedToTray->setToolTip(noTrayTip);
+    }
 
     // dashboard footer visibility
     ui->checkDashboardFooter->setChecked(mSettingManager->getDashboardFooterVisible());

--- a/shared/nexis/app.cpp
+++ b/shared/nexis/app.cpp
@@ -860,7 +860,7 @@ void App::closeEvent(QCloseEvent *event)
     SettingManager::ins()->setWindowGeometry(saveGeometry());
     SettingManager::ins()->setWindowState(saveState());
 
-    if (SettingManager::ins()->getMinimizeToTray()) {
+    if (SettingManager::ins()->getMinimizeToTray() && QSystemTrayIcon::isSystemTrayAvailable()) {
         emit SignalMapper::ins()->sigAppVisibilityChanged(false);
         hide();
 #ifdef Q_OS_MAC
@@ -881,7 +881,7 @@ void App::closeEvent(QCloseEvent *event)
 void App::changeEvent(QEvent *event)
 {
     if (event->type() == QEvent::WindowStateChange && windowState().testFlag(Qt::WindowMinimized)) {
-        if (SettingManager::ins()->getMinimizeToTray()) {
+        if (SettingManager::ins()->getMinimizeToTray() && QSystemTrayIcon::isSystemTrayAvailable()) {
             emit SignalMapper::ins()->sigAppVisibilityChanged(false);
             hide();
 #ifdef Q_OS_MAC

--- a/shared/nexis/main.cpp
+++ b/shared/nexis/main.cpp
@@ -411,8 +411,11 @@ int main(int argc, char *argv[])
 
     App w;
 
-    // SSO-354: setting-based equivalent of --hide for any launch path.
-    const bool startMinimizedToTray = SettingManager::ins()->getStartMinimizedToTray();
+    // SSO-354: setting-based equivalent of --hide for any launch path. Never
+    // honor this without a usable tray — otherwise the app launches with no
+    // window and no way to bring it back.
+    const bool startMinimizedToTray = SettingManager::ins()->getStartMinimizedToTray()
+        && QSystemTrayIcon::isSystemTrayAvailable();
 
     if (!isHide && !startMinimizedToTray) {
         w.show();


### PR DESCRIPTION
## Summary

Prevent users from enabling "Minimize to Tray" / "Start Minimized to Tray" on desktop environments where `QSystemTrayIcon::isSystemTrayAvailable()` returns false. Without a system tray, enabling these options causes the window to vanish on close/minimize with no way to recover it. The fix disables both checkboxes in Settings when no tray is available, and adds runtime checks at the point of use as defense-in-depth against stale config values.

## Linked issues

- Refs SSO-354

## Changes

**Settings UI (`settings_page.cpp`)**
- Added `#include <QSystemTrayIcon>`
- Modified `SettingsPage::init()` to check `QSystemTrayIcon::isSystemTrayAvailable()`
- Disable both tray-related checkboxes when no tray is available
- Set explanatory tooltip on disabled checkboxes
- Uncheck the options if tray becomes unavailable (e.g., config carried from a machine that had a tray)

**App startup (`main.cpp`)**
- Added runtime check in the `--hide` / start-minimized launch path to only honor `getStartMinimizedToTray()` if a tray is actually available
- Updated comment to explain the defense-in-depth rationale

**Window events (`app.cpp`)**
- Added tray availability checks in `App::closeEvent()` before minimizing to tray
- Added tray availability checks in `App::changeEvent()` before minimizing to tray on window state change

**Documentation (`CHANGELOG.md`)**
- Added entry under Fixed section describing the issue and the multi-layer fix

## Testing

- [ ] Built on Linux (`cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -jN`)
- [ ] Built on macOS (`cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$(brew --prefix qt@6) && cmake --build build -jN`)
- [ ] Unit tests (`ctest --test-dir build --output-on-failure`) pass
- [ ] Manually exercised the affected UI / code path

Notes: Verification should include:
1. On a system with a system tray: checkboxes are enabled and functional
2. On a system without a system tray (or in a test environment where `QSystemTrayIcon::isSystemTrayAvailable()` is mocked to return false): checkboxes are disabled with explanatory tooltip
3. Config with `MinimizeToTray=true` carried from another machine: setting is ignored at startup and on window events

## Docs

- [x] `CHANGELOG.md` updated under the current `## [Unreleased]` section
- [ ] `docs/APPLICATION_OVERVIEW.md` updated (N/A — no feature or UI change visible to users, only error prevention)
- [ ] `docs/ARCHITECTURE_REVIEW.md` updated (N/A — no new signals, singletons, or cross-component wiring)

## Reviewer checklist

- [x] Conventional-commit subject line (`type(scope): summary`)
- [x] No new hardcoded hex colors in C++
- [x] No new `setFocusPolicy(Qt::NoFocus)` on interactive controls
- [ ] CI is green

https://claude.ai/code/session_01Yb2Cu3V5V2NjRuDomN5UrQ