### PR TITLE
fix(settings): repolish section cards so cardRole styling actually paints

### DIFF
--- a/shared/nexis/Pages/Settings/settings_page.cpp
+++ b/shared/nexis/Pages/Settings/settings_page.cpp
@@ -25,6 +25,7 @@
 #include <QGuiApplication>
 #include <QScreen>
 #include <QSystemTrayIcon>
+#include <QStyle>
 #include <Utils/format_util.h>
 #include <functional>
 
@@ -892,6 +893,13 @@ void SettingsPage::buildSectionCards()
     for (QWidget *card : cards) {
         card->setAttribute(Qt::WA_StyledBackground, true);
         card->setProperty("cardRole", "elevated");
+        // Dynamic properties set after setupUi() don't retroactively
+        // trigger a repolish (BUG-56) — without this, the [cardRole]
+        // fill/border/radius never paints even though the property is
+        // set correctly, because SettingsPage's parent is already part
+        // of a visible widget tree by the time init() runs.
+        card->style()->unpolish(card);
+        card->style()->polish(card);
     }
 
     // Inner content padding now that the QGroupBox native title/frame is


### PR DESCRIPTION
## Summary
- Settings page section cards (General, Appearance, Alerts, Tools, Scheduled Cleaning, Migration) were rendering completely flat — no elevated-card fill, border, or shadow — despite `buildSectionCards()` setting `cardRole="elevated"` on each container.
- Root cause confirmed by live-inspecting the built app: pages that set `cardRole` in the `.ui` file (Hardware Info, Search) render the DS §2 elevated-card recipe correctly, but pages that set it via `setProperty()` in C++ *after* `setupUi()` — Settings and (separately, out of scope here) Services — never repaint, because Qt doesn't retroactively repolish a widget's style when a dynamic property changes post-construction.
- Adds `style()->unpolish(card)` / `style()->polish(card)` right after `setProperty("cardRole", "elevated")` in `SettingsPage::buildSectionCards()` so the card actually repaints with the intended fill/border/shadow.

## Notes for reviewer
- Same underlying bug likely affects `ServicesPage` (and possibly `GnomeSettings`/`Uninstaller`/other pages that set `cardRole` via C++ `setProperty()` rather than the `.ui` file) — confirmed Services also renders flat in the running app, but that page is out of scope for this PR and should get the same fix separately.
- Verified visually by relaunching a fresh build of `nexis.app` and using the in-app command palette (Cmd+K) to navigate to Settings/Services/Hardware Info/Search to compare rendering.

## Test plan
- [ ] Build (`cmake --build build`) and launch `nexis.app`
- [ ] Navigate to Settings — confirm General/Appearance/Alerts/Tools/Scheduled Cleaning/Migration each render as a distinct elevated card (fill, 1px border, rounded corners, drop shadow) matching the Hardware Info page treatment
- [ ] Toggle light/dark theme and confirm the card shadow color updates via `refreshThemeColors()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)