### PR TITLE
chore(release): 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.1] - 2026-08-14
+
 ### Fixed
 - Settings — "Minimize to Tray" / "Start Minimized to Tray" on desktop environments with no usable system tray: the checkboxes stayed enabled and toggleable even when `QSystemTrayIcon::isSystemTrayAvailable()` is false, letting a user enable minimize-to-tray and then have the window vanish on close/minimize with no tray icon to bring it back. `SettingsPage::init()` now disables both checkboxes (with an explanatory tooltip) whenever no tray is available, and `App::closeEvent()`/`App::changeEvent()` and the `--hide`/start-minimized launch path in `main.cpp` re-check tray availability at the point of use as defense-in-depth, so a stale `true` value in an existing config (e.g. carried over from a machine/session that did have a tray) can't strand the window hidden.
 - Website (SSO-22809): the install page's apt tab note still named EOL'd Ubuntu series (22.04 Jammy, 24.04 Noble, 25.04 Plucky) that had drifted from `README.md`'s PPA support statement after it moved to 25.10 Questing / 26.04 Resolute — new Linux users following the public install page were being told to add a PPA with no package for their series, or a series (Plucky) that no longer exists. `website/src/components/PackageManagerInstall.astro`'s apt note now matches README, with an adjacent caveat carrying across the Qt 6.8 LTS constraint (Nexis 2.6+) so 22.04/24.04 users are pointed at the AppImage instead of a dead end.
+- Settings page section cards (General, Appearance, Alerts, Tools, Scheduled Cleaning, Migration) rendered completely flat with no shadowbox despite `buildSectionCards()` setting `cardRole="elevated"` on each — Qt doesn't recursively re-evaluate dynamic-property QSS selectors on children after a parent property changes, so the elevated styling never painted. Section cards are now explicitly `unpolish()`/`polish()`'d after the property is set (BUG-56).
+- Sidebar nav: `btnMailCleanup` referenced `mail.svg`, but the icon file never existed for either theme, leaving Mail Cleanup as the only nav item with no icon. Added `mail.svg` to both the default and light theme sidebar-icon sets.
 
 ## [2.9.0] - 2026-08-12
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0" CACHE STRING "Minimum macOS deployment version")
 endif()
 
-project(Nexis VERSION 2.9.0)
+project(Nexis VERSION 2.9.1)
 
 # Adding features(build cache + faster linkers) and reasonable defaults(Debug build by default)
 include("${CMAKE_CURRENT_SOURCE_DIR}/shared/cmake/cxxbasics/CXXBasics.cmake")

--- a/docs/APPLICATION_OVERVIEW.md
+++ b/docs/APPLICATION_OVERVIEW.md
@@ -1,7 +1,7 @@
 # Nexis — Application Overview
 
 > A comprehensive reference for what Nexis does and how it is built.
-> Last updated: 2026-08-12 | Version 2.9.0
+> Last updated: 2026-08-14 | Version 2.9.1
 
 ---
 

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -1,7 +1,7 @@
 # Nexis — Architecture Review
 
 > A deep and comprehensive review of the Nexis architecture: how logic and UI work together, what's working well, what should change, and where the application should go next.
-> Last updated: 2026-08-12 (SSO-3469 / WI-05.a, SSO-3497, SSO-3383, SSO-3391 / WI-29, SSO-3396 / WI-33, SSO-3738 / FW-10, SSO-3739 / FW-11, SSO-3740 / FW-12, SSO-3743 / FW-15, GH#191, GH#182, GH#214, SSO-15566, SSO-17776, SSO-21680) | Version 2.9.0
+> Last updated: 2026-08-14 (SSO-3469 / WI-05.a, SSO-3497, SSO-3383, SSO-3391 / WI-29, SSO-3396 / WI-33, SSO-3738 / FW-10, SSO-3739 / FW-11, SSO-3740 / FW-12, SSO-3743 / FW-15, GH#191, GH#182, GH#214, SSO-15566, SSO-17776, SSO-21680, BUG-56) | Version 2.9.1
 
 > **Packaging note (SSO-3376, 2026-06):** The Flatpak (Flathub) distribution channel was retired. There is no `flatpak-spawn`/sandbox-detection layer in the codebase — the privileged-host operations Nexis depends on (`pkexec`, `systemctl`, `smartctl`, `fstrim`, `nvidia-smi`, `/proc` and `/sys` reads) are architecturally unsuited to a bubblewrap sandbox, and adding one would require routing `CommandUtil` through `flatpak-spawn --host` plus holding the `org.freedesktop.Flatpak` portal — i.e. eliminating the sandbox benefit. Linux ships via `.deb` (PPA + GitHub releases), AppImage, and AUR. **Reaffirmed 2026-08-02 (SSO-21643/SSO-21680):** a second relitigation hit the same architectural blocker, not new staleness; the `s4solutionsllc/flathub` fork is archived, and re-opening requires a fresh CEO decision with new technical facts.
 

--- a/linux/aur/PKGBUILD
+++ b/linux/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Luke Simpson <luke@s4solutions.ai>
 pkgname=nexis
-pkgver=2.9.0
+pkgver=2.9.1
 pkgrel=1
 pkgdesc="Linux system optimizer and monitoring tool"
 arch=('x86_64' 'aarch64')

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,12 @@
+nexis (2.9.1-1) unstable; urgency=medium
+
+  * Fix Minimize to Tray / Start Minimized to Tray settings not disabling
+    themselves when no system tray is available.
+  * Fix Settings page section cards not rendering elevated card styling.
+  * Fix missing Mail Cleanup nav icon.
+
+ -- Luke Simpson <luke@s4solutions.ai>  Fri, 14 Aug 2026 00:00:00 +0000
+
 nexis (2.9.0-1) unstable; urgency=medium
 
   * New release: Sparkle auto-update install pipeline, macOS/Linux Orphan

--- a/linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml
+++ b/linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml
@@ -74,6 +74,17 @@
   </screenshots>
 
   <releases>
+    <release version="2.9.1" date="2026-08-14">
+      <description>
+        <p>Fixes:</p>
+        <ul>
+          <li>Minimize to Tray / Start Minimized to Tray settings now disable themselves on desktop environments with no usable system tray.</li>
+          <li>Website apt install instructions updated to current supported Ubuntu series.</li>
+          <li>Settings page section cards now render with the intended elevated card styling.</li>
+          <li>Mail Cleanup nav item now has an icon.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.9.0" date="2026-08-12">
       <description>
         <p>New features:</p>


### PR DESCRIPTION
## Summary
- Bumps version 2.9.0 → 2.9.1 (patch release) across CMakeLists.txt, docs, AUR PKGBUILD, Debian changelog, and Flatpak/AppStream metainfo.
- Moves the accumulated unreleased fixes into a new CHANGELOG `[2.9.1]` section: tray-availability checkbox fix, website apt copy fix, settings card repolish, and the missing Mail Cleanup nav icon.

## Test plan
- [ ] CI green on this branch
- [ ] After merge, tag `v2.9.1` on `native` per RELEASE.md