### PR TITLE
fix(release): use debian revision -0 for 2.9.1 changelog entry

### DIFF
--- a/.github/workflows/ppa.yml
+++ b/.github/workflows/ppa.yml
@@ -133,7 +133,14 @@ jobs:
           DEBFULLNAME: Luke Simpson
         run: |
           TAG_VERSION="${{ steps.version.outputs.VERSION }}"
-          dch --newversion "${TAG_VERSION}-1~ppa1~${{ matrix.series }}1" \
+          # SSO-15394 follow-up: linux/debian/changelog's top entry is now
+          # Debian revision "-1" (debian-revision-is-zero is a lintian
+          # --pedantic error, so "-0" is no longer valid). dch requires the
+          # newly appended version to compare strictly greater than that
+          # entry; a PPA suffix of "-1~ppa1~<series>1" compares as *lower*
+          # than a plain "-1" (Debian version rules sort "~" before
+          # end-of-string), so the PPA revision must be at least "-2".
+          dch --newversion "${TAG_VERSION}-2~ppa1~${{ matrix.series }}1" \
               --distribution ${{ matrix.series }} \
               --force-distribution \
               "Release ${TAG_VERSION} for ${{ matrix.series }}"

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,4 +1,4 @@
-nexis (2.9.1-0) unstable; urgency=medium
+nexis (2.9.1-1) unstable; urgency=medium
 
   * Fix Minimize to Tray / Start Minimized to Tray settings not disabling
     themselves when no system tray is available.

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,4 +1,4 @@
-nexis (2.9.1-1) unstable; urgency=medium
+nexis (2.9.1-0) unstable; urgency=medium
 
   * Fix Minimize to Tray / Start Minimized to Tray settings not disabling
     themselves when no system tray is available.


### PR DESCRIPTION
## Summary
- The `v2.9.1` tag's Publish PPA workflow failed at the `dch --newversion` step for every series: `New version specified (2.9.1-1~ppa1~resolute1) is less than the current version number (2.9.1-1)!`
- First attempt (changelog `-1` → `-0`) broke the separate Debian Lintian Check job instead, which rejects `debian-revision-is-zero` under `--pedantic` (added in #336) — the two CI checks impose contradictory constraints on a single hardcoded value.
- Real fix: kept `linux/debian/changelog`'s top entry at the policy-correct `2.9.1-1`, and instead bumped `ppa.yml`'s hardcoded PPA-suffix revision from `1` to `2`, so `dch`'s appended version (`2.9.1-2~ppa1~<series>1`) is unambiguously greater than the plain `-1` entry it rewrites (Debian version rules sort `~` before end-of-string, so a PPA suffix can never compare greater than an equal-or-higher plain revision — it must start one revision number higher).

## Test plan
- [ ] After merge, re-tag (or re-run Publish PPA against a corrected tag) and confirm both the `dch` step and Debian Lintian Check succeed