### PR TITLE
ci: consumer-side COPR install verification (SSO-17801 AC3)

### DIFF
--- a/.github/workflows/copr-verify.yml
+++ b/.github/workflows/copr-verify.yml
@@ -1,0 +1,85 @@
+# Verifies that the published COPR channel actually installs on stock Fedora
+# (SSO-17801 AC3). This is a consumer-side check: it uses only the two commands
+# a user would run, against the live copr.fedorainfracloud.org project — it does
+# not build anything from this checkout.
+#
+# Scope of the evidence this produces:
+#   - `dnf copr enable` + `dnf install nexis` resolve on a clean image
+#     (repo metadata, GPG key, and RPM dependencies are all good)
+#   - the installed binary starts far enough to answer `--version` and to stay
+#     alive under a virtual X server
+# It does NOT prove the GUI renders correctly on real hardware; that still needs
+# a human on a real Fedora desktop.
+name: Verify COPR install
+
+on:
+  workflow_dispatch:
+    inputs:
+      copr_project:
+        description: "COPR project to verify (owner/project)"
+        required: true
+        default: luke-s4solutions/nexis
+      expected_version:
+        description: "Expected nexis version, e.g. 2.9.1 (blank = any)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  dnf-install:
+    name: Fedora ${{ matrix.fedora }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Chroots the COPR project builds for, minus rawhide.
+        fedora: ["43", "44"]
+    container:
+      image: fedora:${{ matrix.fedora }}
+    steps:
+      - name: Enable the COPR repository
+        run: |
+          set -euxo pipefail
+          dnf -y install dnf-plugins-core
+          dnf -y copr enable "${{ inputs.copr_project }}"
+
+      - name: Install nexis
+        run: |
+          set -euxo pipefail
+          dnf -y install nexis
+
+      - name: Record installed package
+        run: |
+          set -euxo pipefail
+          rpm -qi nexis
+          rpm -q --queryformat '%{NAME} %{VERSION}-%{RELEASE} %{ARCH}\n' nexis
+
+      - name: Check version matches expectation
+        if: inputs.expected_version != ''
+        run: |
+          set -euxo pipefail
+          installed=$(rpm -q --queryformat '%{VERSION}' nexis)
+          if [ "$installed" != "${{ inputs.expected_version }}" ]; then
+            echo "::error::expected nexis ${{ inputs.expected_version }}, got $installed"
+            exit 1
+          fi
+
+      - name: Launch smoke test under Xvfb
+        run: |
+          set -euxo pipefail
+          dnf -y install xorg-x11-server-Xvfb dbus-daemon mesa-dri-drivers
+          xvfb-run -a nexis --version
+          # `timeout` exits 124 when the process was still running at the
+          # deadline, which is the success case here: the app came up and
+          # stayed up instead of crashing on startup.
+          set +e
+          xvfb-run -a timeout -s TERM 30 nexis --nosplash
+          rc=$?
+          set -e
+          if [ "$rc" -ne 124 ]; then
+            echo "::error::nexis exited early with status $rc"
+            exit 1
+          fi
+          echo "nexis stayed alive for 30s under Xvfb"


### PR DESCRIPTION
Adds `.github/workflows/copr-verify.yml` — a `workflow_dispatch` job that verifies the **published** COPR channel from a consumer's point of view (SSO-17801 AC3).

What it does, on stock `fedora:43` and `fedora:44` container images:
1. `dnf install dnf-plugins-core` → `dnf copr enable luke-s4solutions/nexis`
2. `dnf install nexis`
3. records `rpm -qi nexis`, optionally asserts an expected version
4. smoke-launches under Xvfb: `nexis --version`, then requires the app to still be running after 30s

Why: the live publish already succeeded (COPR build [10867952](https://copr.fedorainfracloud.org/coprs/build/10867952), `nexis 2.9.1-1`, chroots f43/f44/rawhide), but AC3 asks for a clean-machine install check and no CI runner or agent sandbox here has a Fedora desktop. This makes the machine-checkable part of that check repeatable and re-runnable on demand for future releases.

Explicitly **not** covered: GUI rendering on real hardware, and aarch64 (the COPR project only builds x86_64). Both still need a human on a real Fedora desktop — tracked on SSO-17801.

Alternative considered: a one-off throwaway container run in an agent sandbox. Rejected — no container runtime or `dnf` exists in the sandbox, and a one-off leaves no artifact for the next release.

Docs-and-CI only; no application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)