### PR TITLE
fix(debian): use Debian-convention control synopsis (SSO-23010)

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -26,7 +26,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
          qt6-qpa-plugins,
          qt6-gtk-platformtheme | qt6ct
 Recommends: systemd, curl, adwaita-icon-theme | yaru-theme-icon
-Description: Linux System Optimizer and Monitoring
+Description: Linux system optimizer and monitor
  Nexis is an open-source system optimizer and application monitor
  that helps users manage startup applications, clean system caches,
  monitor resources, and manage services and packages.


### PR DESCRIPTION
## Summary
- Debian packaging prep for the 2.9.1-1 official-archive ITP upload (follow-up to SSO-15394).
- `linux/debian/control` synopsis changed from `Linux System Optimizer and Monitoring` to Debian convention: `Linux system optimizer and monitor` (lowercase, no trailing period), matching the ITP/RFS wording. Long description left intact.
- No other packaging files changed — `linux/debian/changelog` already tops out at `2.9.1-1`, and `debian/watch` already resolves correctly against the current GitHub tag (`v2.9.1`).

## Test plan
- [x] `debian-lintian.yml` CI workflow re-runs `lintian --pedantic` against this tree on this PR (paths: `linux/debian/**`) — will paste the result in the Paperclip issue comment (SSO-23010) once it completes.

Standard flow: PR against `native` → Reviewer → DevOps merges. This PR does not send anything to Debian; that remains operator-only per SSO-23010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)