### PR TITLE
ci: bound release.yml artifact retention to 7 days (SSO-23017)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,6 +279,8 @@ jobs:
             ${{ steps.deb.outputs.DEB_PATH }}
             ${{ steps.appimage.outputs.APPIMAGE_PATH }}
             build/output/nexis-${{ matrix.arch }}
+          # Job-to-job handoff only; the durable copy is the GitHub Release asset.
+          retention-days: 7
 
   # ============================================================================
   # AppImage (x86_64) — built on the ubuntu-22.04 runner (glibc 2.35) so the
@@ -415,6 +417,8 @@ jobs:
         with:
           name: linux-appimage-x86_64
           path: ${{ steps.appimage.outputs.APPIMAGE_PATH }}
+          # Job-to-job handoff only; the durable copy is the GitHub Release asset.
+          retention-days: 7
 
   # ============================================================================
   # macOS build: .app bundle + .dmg
@@ -596,6 +600,8 @@ jobs:
         with:
           name: macos-artifacts
           path: build/output/Nexis-${{ steps.version.outputs.VERSION }}-macOS-arm64.dmg
+          # Job-to-job handoff only; the durable copy is the GitHub Release asset.
+          retention-days: 7
 
       - name: Cleanup keychain
         if: always() && steps.signing.outputs.ENABLED == 'true'


### PR DESCRIPTION
Closes the one remaining unbounded artifact-retention path in this repo (SSO-23017).

`release.yml`'s three `upload-artifact` steps had no `retention-days`, so they inherited the 90-day repo default. Every other workflow in `.github/workflows` already sets one explicitly (build 14, screenshot-baselines 30, screenshot-stability-check 14, debian-lintian 14, copr 7, ppa 1).

**Why 7 days is safe:** all three uploads are pure job-to-job handoffs. The `release` job (`needs: [build-linux, build-appimage-x86_64, build-macos]`) downloads each one and attaches the files to a GitHub Release. The durable, user-facing copy is the Release asset; the Actions artifact is scratch space that only has to survive the same workflow run. Nothing else in the repo downloads these names.

**No audit-of-record artifact is affected.** `reference-screenshots-linux` / `-macos` (the human-reviewed design baselines) are produced by `screenshot-baselines.yml` and are untouched by this PR.

Measured on `native` before this change: 4,830 artifact records, of which 4,581 are already expired (content deleted by GitHub, 0 bytes stored). Live storage is 3.51 GiB, and 2.85 GiB of that is these three release uploads — the only class that was accumulating at 90 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
