### PR TITLE
fix(startup-apps): keep app icons square instead of stretched (gh-383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Startup Apps page (gh-383): app icons rendered stretched vertically — `startup_app.ui`'s `lblStartupAppIcon` had a non-square min/max size (22×24 / 44×48) combined with `scaledContents=true`, which stretches a square source icon to fill the taller box. Min/max size is now square (22×22 / 44×44); no C++ change needed.
+
 ### Added
 - Distribution: the Fedora COPR channel is **live** (SSO-17801, completes the SSO-15393 groundwork) — `sudo dnf copr enable luke-s4solutions/nexis && sudo dnf install nexis`. The v2.9.1 tag was the first release to run `copr.yml`'s `publish-copr` job through to a real submission (it parks behind the `copr-publish` environment's required-reviewer gate per SSO-99); it created [copr.fedorainfracloud.org/coprs/luke-s4solutions/nexis](https://copr.fedorainfracloud.org/coprs/luke-s4solutions/nexis/) and built `nexis-2.9.1-1` successfully for `fedora-43-x86_64`, `fedora-44-x86_64` and `fedora-rawhide-x86_64` ([build 10867952](https://copr.fedorainfracloud.org/coprs/build/10867952)). Install instructions are now in `README.md` and on the website's install page alongside the existing PPA/AUR/Homebrew channels. COPR is Fedora's community build service, not an official Fedora repository — that caveat is carried in both places.
 

--- a/shared/nexis/Pages/StartupApps/startup_app.ui
+++ b/shared/nexis/Pages/StartupApps/startup_app.ui
@@ -84,13 +84,13 @@
           <property name="minimumSize">
            <size>
             <width>22</width>
-            <height>24</height>
+            <height>22</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
             <width>44</width>
-            <height>48</height>
+            <height>44</height>
            </size>
           </property>
           <property name="text">


### PR DESCRIPTION
## Summary
- Fixes #383 — Startup Apps page icons rendered stretched vertically.
- Root cause: `startup_app.ui`'s `lblStartupAppIcon` had a non-square min/max size (22×24 / 44×48) combined with `scaledContents=true`, which stretches a square source icon to fill the taller box.
- Fix: min/max size is now square (22×22 / 44×44). `.ui`-only change, no C++.

Scope agreed with Product Owner on SSO-23404.

## Test plan
- [x] Incremental build succeeds (`nexis` target links).
- [x] `ScreenshotTests` run under `QT_QPA_PLATFORM=offscreen`: `StartupAppsPage` screenshot passes; the only failures (`dashboard` light/dark, ~2.3% diff) are the pre-existing font-rendering flake documented in `CHANGELOG.md`'s 2026-08-12 entry (SSO-17802), unrelated to this change.
- [x] `CHANGELOG.md` updated under `[Unreleased] / Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)