### PR TITLE
ci: gate build-artifact upload behind workflow_dispatch, not every push (SSO-23450)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [native, master, main]
   pull_request:
     branches: [native, master, main]
+  workflow_dispatch:
 
 jobs:
   # Linux build matrix runs inside a Resolute (26.04 LTS) container — see
@@ -94,11 +95,13 @@ jobs:
 
       # SSO-23450: this binary has no downstream consumer in CI — it exists
       # purely for a maintainer to grab a build without waiting on a release.
-      # Uploading it on every PR (in addition to every push) doubled the copy
-      # count for a use case PRs don't serve; skip it there and keep the
-      # short 3-day floor a human actually needs to notice and download it.
+      # It was previously uploaded on every push to native/master/main,
+      # which at this repo's merge cadence (10+ pushes/day) dwarfed every
+      # other artifact category combined. Compile+test still run on every
+      # push/PR for CI signal; only the upload is gated behind a manual
+      # workflow_dispatch, so a maintainer can still grab a build on demand.
       - name: Upload build artifact
-        if: success() && github.event_name != 'pull_request'
+        if: success() && github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.artifact-name }}
@@ -155,8 +158,10 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
 
+      # SSO-23450: same rationale as the Linux upload above — gated behind
+      # workflow_dispatch instead of firing on every push to native.
       - name: Upload build artifact
-        if: success() && github.event_name != 'pull_request'
+        if: success() && github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nexis-macos-arm64


### PR DESCRIPTION
## Summary
- The SSO-23450 retention fix (#404) skipped `nexis-*` build-artifact upload on `pull_request` but left it uploading on every push to `native`/`master`/`main`.
- Verified live push cadence is high (16 pushes to `native` in <24h during this session, organic PR merges — not from this run). At `retention-days: 3`, that alone keeps the standing live-artifact total well above the 400 MB target from SSO-23450's acceptance criteria, even once the pre-fix 14-day-retention backlog fully decays (~2026-09-07).
- These three build binaries have no downstream CI consumer (confirmed: no other workflow references `nexis-linux-x64`/`nexis-linux-arm64`/`nexis-macos-arm64`). They exist only for a maintainer to grab a build without waiting on a release.
- Gates the upload step behind `workflow_dispatch` instead of firing automatically on every push. Compile + unit tests still run on every push/PR unchanged — only the artifact upload is now opt-in.

## Test plan
- [x] YAML parses (`npx js-yaml .github/workflows/build.yml`)
- [ ] CI green on this PR (build+test jobs run as before, just without upload on push/PR events)
- [ ] Manual `workflow_dispatch` still produces the artifact (spot-check post-merge)

SSO-23450