### PR TITLE
chore(release): 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-08-31
+
 ### Changed
 - System tray menu (SSO-23896): the tray's right-click menu was a flat 22-row list mirroring the sidebar with its grouping discarded. It's now 12 top-level rows in 5 blocks — a new **Open Nexis** action; the headerless MONITOR pages flat (Dashboard, Hardware Info, Resources, Network Usage); **Manage** and **System** as native `QMenu` submenus; the existing **Quick Actions** submenu (FR-125); the checkable **Kiosk Mode (F11)** toggle; **Quit**. The grouping is derived from the same `mSections` model the sidebar itself builds from (`buildTrayMenuGroups()`, new `shared/nexis/Managers/tray_menu_model.{h,cpp}`), so a page added to a sidebar section appears in the matching tray group automatically — no tray-side edit, no second hand-maintained list to drift. Every tray item still only navigates via `clickSidebarButton()`; the sole action item remains the read-only "Run System Cleaner Scan". `QMenu::separator`/`QMenu::right-arrow` QSS added, reusing the sidebar's existing chevron SVGs so both surfaces read as one visual language (styling lands on Qt-rendered menus; GNOME's AppIndicator/DBusMenu export ignores QSS but the structural grouping still applies there).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "14.0" CACHE STRING "Minimum macOS deployment version")
 endif()
 
-project(Nexis VERSION 2.9.1)
+project(Nexis VERSION 2.10.0)
 
 # Adding features(build cache + faster linkers) and reasonable defaults(Debug build by default)
 include("${CMAKE_CURRENT_SOURCE_DIR}/shared/cmake/cxxbasics/CXXBasics.cmake")

--- a/docs/APPLICATION_OVERVIEW.md
+++ b/docs/APPLICATION_OVERVIEW.md
@@ -1,7 +1,7 @@
 # Nexis — Application Overview
 
 > A comprehensive reference for what Nexis does and how it is built.
-> Last updated: 2026-08-31 (SSO-23855, SSO-23896, SSO-23862, SSO-23856, SSO-23853, SSO-23854) | Version 2.9.1
+> Last updated: 2026-08-31 (SSO-23855, SSO-23896, SSO-23862, SSO-23856, SSO-23853, SSO-23854) | Version 2.10.0
 
 ---
 

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -1,7 +1,7 @@
 # Nexis — Architecture Review
 
 > A deep and comprehensive review of the Nexis architecture: how logic and UI work together, what's working well, what should change, and where the application should go next.
-> Last updated: 2026-08-31 (SSO-23855, SSO-23896, SSO-3469 / WI-05.a, SSO-3497, SSO-3383, SSO-3391 / WI-29, SSO-3396 / WI-33, SSO-3738 / FW-10, SSO-3739 / FW-11, SSO-3740 / FW-12, SSO-3743 / FW-15, GH#191, GH#182, GH#214, SSO-15566, SSO-17776, SSO-21680, BUG-56, SSO-23862, SSO-23867, SSO-23853, SSO-23854) | Version 2.9.1
+> Last updated: 2026-08-31 (SSO-23855, SSO-23896, SSO-3469 / WI-05.a, SSO-3497, SSO-3383, SSO-3391 / WI-29, SSO-3396 / WI-33, SSO-3738 / FW-10, SSO-3739 / FW-11, SSO-3740 / FW-12, SSO-3743 / FW-15, GH#191, GH#182, GH#214, SSO-15566, SSO-17776, SSO-21680, BUG-56, SSO-23862, SSO-23867, SSO-23853, SSO-23854) | Version 2.10.0
 
 > **Packaging note (SSO-3376, 2026-06):** The Flatpak (Flathub) distribution channel was retired. There is no `flatpak-spawn`/sandbox-detection layer in the codebase — the privileged-host operations Nexis depends on (`pkexec`, `systemctl`, `smartctl`, `fstrim`, `nvidia-smi`, `/proc` and `/sys` reads) are architecturally unsuited to a bubblewrap sandbox, and adding one would require routing `CommandUtil` through `flatpak-spawn --host` plus holding the `org.freedesktop.Flatpak` portal — i.e. eliminating the sandbox benefit. Linux ships via `.deb` (PPA + GitHub releases), AppImage, and AUR. **Reaffirmed 2026-08-02 (SSO-21643/SSO-21680):** a second relitigation hit the same architectural blocker, not new staleness; the `s4solutionsllc/flathub` fork is archived, and re-opening requires a fresh CEO decision with new technical facts.
 

--- a/linux/aur/PKGBUILD
+++ b/linux/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Luke Simpson <luke@s4solutions.ai>
 pkgname=nexis
-pkgver=2.9.1
+pkgver=2.10.0
 pkgrel=1
 pkgdesc="Linux system optimizer and monitoring tool"
 arch=('x86_64' 'aarch64')

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -1,3 +1,14 @@
+nexis (2.10.0-1) unstable; urgency=medium
+
+  * New release: macOS menu-bar health score + Clean Now, Linux tray health
+    score + Clean Now, compact always-on-top mini-monitor window, disk map
+    bubble-map and sunburst visualizations, and a macOS APFS/Time Machine
+    local snapshot manager. Also regroups the tray menu into MONITOR/Manage/
+    System, and lands an internal CleanerML parser (no execution engine yet).
+    See CHANGELOG.md for full details.
+
+ -- Luke Simpson <luke@s4solutions.ai>  Mon, 31 Aug 2026 00:00:00 +0000
+
 nexis (2.9.1-1) unstable; urgency=medium
 
   * Fix Minimize to Tray / Start Minimized to Tray settings not disabling

--- a/linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml
+++ b/linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml
@@ -74,6 +74,22 @@
   </screenshots>
 
   <releases>
+    <release version="2.10.0" date="2026-08-31">
+      <description>
+        <p>New features:</p>
+        <ul>
+          <li>macOS menu-bar health score with a one-click Clean Now action.</li>
+          <li>Linux tray health score with a one-click Clean Now action.</li>
+          <li>Compact always-on-top mini-monitor window (Linux and macOS).</li>
+          <li>Disk map bubble-map and sunburst visualization modes.</li>
+          <li>macOS APFS/Time Machine local snapshot manager.</li>
+        </ul>
+        <p>Changed:</p>
+        <ul>
+          <li>Tray menu regrouped into MONITOR/Manage/System sections.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.9.1" date="2026-08-14">
       <description>
         <p>Fixes:</p>


### PR DESCRIPTION
Cuts Nexis v2.10.0 (MINOR) per SSO-23946, following RELEASE.md §1.

- Anchor tag: v2.9.1 (8672ab18, 2026-08-14)
- Cut commit (parent of this PR's commit): f5739f85 — native HEAD was already exactly at the pinned SHA, no drift
- Renames CHANGELOG.md `## [Unreleased]` → `## [2.10.0] - 2026-08-31`, adds a fresh empty `## [Unreleased]`
- Bumps `CMakeLists.txt` `project(Nexis VERSION 2.10.0)`
- Bumps AUR `PKGBUILD` (`pkgver=2.10.0`, `pkgrel=1`)
- Adds `linux/debian/changelog` entry for 2.10.0-1
- Adds AppStream `<release version="2.10.0">` entry to the metainfo file

CI green on the cut SHA: run 33404904124 (macOS ARM64, Linux ARM64, Linux x64 all passed).

Once this merges to `native`, I'll tag `v2.10.0` via the App-token flow (protected `v*` tag ruleset) and report the published release on SSO-23946.

Gate 0: I (DevOps) authored this commit, so per pr-merge-gate Gate 0 I cannot merge it myself — escalating to the CTO.