### PR TITLE
fix(uninstaller): force LANG=C for pacman -Qi to fix locale package-list bug

### DIFF
--- a/changelog.d/gh-426-pacman-locale-packages.fixed.md
+++ b/changelog.d/gh-426-pacman-locale-packages.fixed.md
@@ -1,0 +1,5 @@
+Uninstaller Packages tab (GH#426): the pacman package list was empty on
+systems running a non-English locale, because `pacman -Qi`'s field labels
+(`Name`, `Description`, `Groups`) are translated and no longer matched the
+parser. `pacman -Qi` is now invoked with `LANG=C` to force English output,
+matching every other locale-sensitive command in the Linux package tool.

--- a/linux/nexis-core/Tools/package_tool.cpp
+++ b/linux/nexis-core/Tools/package_tool.cpp
@@ -296,7 +296,11 @@ QList<Package> PackageToolLinux::getPacmanPackages()
 {
     QList<Package> packages;
 
-    ExecResult result = CommandUtil::execWithStatus("bash", {"-c", "pacman -Qi 2> /dev/null"}, 60000);
+    // GH#426: pacman -Qi field labels (Name, Description, Groups, ...) are
+    // translated under a non-English locale, so the key == "Name" match
+    // below silently drops every package. Force English output like every
+    // other locale-sensitive parser in this file (apt, apt-mark, ...).
+    ExecResult result = CommandUtil::execWithStatus("bash", {"-c", "LANG=C pacman -Qi 2> /dev/null"}, 60000);
     if (!result.ok()) {
         qCritical() << result.error;
         return packages;


### PR DESCRIPTION
## Summary
- Fixes GH#426 — Uninstaller's Packages tab showed nothing on pacman (Arch-family) systems.
- Root cause: `pacman -Qi` field labels (`Name`, `Description`, `Groups`) are localized under a non-English `LANG`, so `getPacmanPackages()`'s `key == "Name"` match never fires and every package is silently dropped. `getPacmanOrphans()` (`pacman -Qtdq`, no field names) is unaffected — which matches the reporter's observation that Orphan Packages still worked while the full list didn't.
- Fix: prefix the `pacman -Qi` invocation with `LANG=C`, matching the existing pattern used by every other locale-sensitive parser in this file (`apt-get`, `apt-mark`, `apt-cache`, `lscpu`, `snap`, `flatpak`).

## Test plan
- [x] `cmake --build build` — builds clean
- [x] `ctest --test-dir build -R PackageTool` — 3/3 passing
- [ ] Reporter confirmation on CachyOS/Manjaro (no pacman available in this sandbox to reproduce live)

Fixes https://github.com/s4solutionsllc/Nexis/issues/426

🤖 Generated with [Claude Code](https://claude.com/claude-code)