### PR TITLE
fix(ci): put Qt6 tools dir on PATH so lupdate is found in crowdin-sync

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -53,6 +53,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qt6-l10n-tools qt6-tools-dev-tools
+          # Debian/Ubuntu Qt6 packaging installs tools under /usr/lib/qt6/bin,
+          # not on PATH by default (unlike the Qt5 packaging this repo used before).
+          echo "/usr/lib/qt6/bin" >> "$GITHUB_PATH"
 
       - name: Normalize translations with lupdate
         run: |


### PR DESCRIPTION
## Summary
- Now that `CROWDIN_SYNC_TOKEN` is provisioned (SSO-24054) and PR creation works (PR #430), the `crowdin-sync.yml` "Normalize translations with lupdate" step fails with `lupdate: command not found` — Ubuntu's `qt6-l10n-tools` package installs `lupdate` at `/usr/lib/qt6/bin/lupdate`, not on `$PATH`.
- Appends that directory to `$GITHUB_PATH` in the install step so the later `lupdate` invocation resolves.

## Evidence
- Failing run before this fix: https://github.com/s4solutionsllc/Nexis/actions/runs/33554183700 (Crowdin Sync step succeeded, opened PR #430; Normalize step failed with exit 127)

## Test plan
- [ ] `workflow_dispatch` re-run of `crowdin-sync.yml` after merge completes both the Crowdin Sync and Normalize steps without error