### PR TITLE
fix(ci): apply Qt6 lupdate PATH fix to lupdate.yml (SSO-24079)

### DIFF
--- a/.github/workflows/lupdate.yml
+++ b/.github/workflows/lupdate.yml
@@ -27,6 +27,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qt6-l10n-tools qt6-tools-dev-tools
+          # Debian/Ubuntu Qt6 packaging installs tools under /usr/lib/qt6/bin,
+          # not on PATH by default (unlike the Qt5 packaging this repo used before).
+          echo "/usr/lib/qt6/bin" >> "$GITHUB_PATH"
 
       - name: Run lupdate
         run: |


### PR DESCRIPTION
## Summary
- lupdate.yml had the identical latent defect fixed in crowdin-sync.yml by #431 (SSO-24054): it installs `qt6-l10n-tools qt6-tools-dev-tools` but never puts `/usr/lib/qt6/bin` on `PATH`, so the bare `lupdate -recursive ...` invocation would exit 127 the first time this `workflow_dispatch` backstop is actually run.
- Applies the same `$GITHUB_PATH` append mechanism (not a hardcoded absolute path) to keep the two workflows consistent and runner-image-portable, with the same explanatory comment.
- No trigger change — `lupdate.yml` stays `workflow_dispatch`-only, as documented in the existing header comment.
- No changelog fragment (CI-only, not user-visible), consistent with #431.

Follow-up item 1/2 of SSO-24079 (item 2 is post-merge verification of #431 / crowdin-sync.yml, tracked separately in that issue).

## Test plan
- [x] `yamllint`/visual diff — three-line addition matches the proven fix in crowdin-sync.yml (#431)
- [ ] No live workflow run needed pre-merge: `workflow_dispatch`-only, exercised manually if/when this backstop is invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)