### PR TITLE
fix(feedback): don't let a stuck URL handler freeze the dialog (NEX-24053)

### DIFF
--- a/changelog.d/gh-424-feedback-dialog-unresponsive.fixed.md
+++ b/changelog.d/gh-424-feedback-dialog-unresponsive.fixed.md
@@ -1,0 +1,6 @@
+Feedback dialog (GH#424): on Linux, "Report a Bug" / "Request a Feature" /
+"General Feedback" could leave the dialog unresponsive if the system's URL
+handler (e.g. an xdg-desktop-portal backend) blocked instead of returning.
+The dialog now closes immediately and the browser launch runs off the UI
+thread, so a stuck handler no longer freezes the app. The AUR package also
+now depends on `xdg-utils` so the `xdg-open` fallback is always present.

--- a/linux/aur/PKGBUILD
+++ b/linux/aur/PKGBUILD
@@ -6,7 +6,10 @@ pkgdesc="Linux system optimizer and monitoring tool"
 arch=('x86_64' 'aarch64')
 url="https://github.com/s4solutionsllc/Nexis"
 license=('GPL-3.0-only')
-depends=('qt6-base' 'qt6-charts' 'qt6-svg')
+# GH#424: xdg-utils provides the xdg-open fallback QDesktopServices::openUrl()
+# uses on Linux when no portal handles the request; minimal Arch/KDE installs
+# (AUR, unlike the self-contained AppImage) don't pull it in transitively.
+depends=('qt6-base' 'qt6-charts' 'qt6-svg' 'xdg-utils')
 makedepends=('cmake' 'gcc' 'make' 'qt6-tools')
 # GH#82: '!lto' stops makepkg injecting -flto. On distros that enable LTO by
 # default (CachyOS), GCC emits slim LTO objects that LLD cannot resolve, so the

--- a/shared/nexis/feedback.cpp
+++ b/shared/nexis/feedback.cpp
@@ -2,6 +2,7 @@
 #include "ui_feedback.h"
 
 #include <QDesktopServices>
+#include <QThreadPool>
 #include <QUrl>
 
 const QString Feedback::ISSUES_BASE_URL =
@@ -19,22 +20,34 @@ Feedback::Feedback(QWidget *parent) :
     ui->setupUi(this);
 }
 
+void Feedback::openIssueTemplate(const QString &templateFile)
+{
+    const QUrl url(ISSUES_BASE_URL + templateFile);
+#ifdef Q_OS_LINUX
+    // QDesktopServices::openUrl() can block the calling thread on some Linux
+    // desktops (e.g. a registered but unresponsive xdg-desktop-portal backend,
+    // GH#424) — dispatch it off the UI thread so the dialog always closes
+    // immediately regardless of what the URL handler does.
+    QThreadPool::globalInstance()->start([url]() { QDesktopServices::openUrl(url); });
+#else
+    QDesktopServices::openUrl(url);
+#endif
+    close();
+}
+
 void Feedback::on_btnReportBug_clicked()
 {
-    QDesktopServices::openUrl(QUrl(ISSUES_BASE_URL + "bug_report.yml"));
-    close();
+    openIssueTemplate("bug_report.yml");
 }
 
 void Feedback::on_btnRequestFeature_clicked()
 {
-    QDesktopServices::openUrl(QUrl(ISSUES_BASE_URL + "feature_request.yml"));
-    close();
+    openIssueTemplate("feature_request.yml");
 }
 
 void Feedback::on_btnFeedback_clicked()
 {
-    QDesktopServices::openUrl(QUrl(ISSUES_BASE_URL + "feedback.yml"));
-    close();
+    openIssueTemplate("feedback.yml");
 }
 
 void Feedback::on_btnClose_clicked()

--- a/shared/nexis/feedback.h
+++ b/shared/nexis/feedback.h
@@ -22,6 +22,8 @@ private slots:
     void on_btnClose_clicked();
 
 private:
+    void openIssueTemplate(const QString &templateFile);
+
     Ui::Feedback *ui;
 
     static const QString ISSUES_BASE_URL;


### PR DESCRIPTION
## Summary

GH#424 was reopened with new evidence: two independent reporters (AUR on
CachyOS KDE and Manjaro KDE) confirmed clicking any Feedback dialog button
except Close leaves the dialog completely unresponsive — no browser opens,
dialog stays open. AppImage builds on the same distros are unaffected.

Prior static review (no reproduction available) couldn't explain the "dialog
doesn't close" symptom, since `close()` already runs unconditionally right
after `QDesktopServices::openUrl()` in every handler. The only thing that
squares with "dialog doesn't close" plus "no browser opens" plus "AppImage
unaffected" is that `openUrl()` itself blocks the UI thread on some Linux
desktops — most plausibly a registered-but-unresponsive
`xdg-desktop-portal` backend, since minimal Arch/KDE AUR installs (unlike
the self-contained AppImage) don't guarantee the portal or the `xdg-open`
fallback are present/working.

- `shared/nexis/feedback.cpp`/`.h`: factor the three button handlers into
  `openIssueTemplate()`, and on Linux dispatch `QDesktopServices::openUrl()`
  onto a worker thread (`QThreadPool`) so `close()` never waits on it.
  macOS keeps the original synchronous call (unaffected, and Cocoa's
  `NSWorkspace` thread-safety off the main thread isn't guaranteed).
- `linux/aur/PKGBUILD`: add `xdg-utils` as a hard dependency so the
  `xdg-open` fallback `QDesktopServices::openUrl()` relies on is always
  present on AUR installs, closing the packaging gap AppImage doesn't have.
- `changelog.d/`: fragment per repo convention.

## Test plan

- [x] `cmake --build build --target nexis-gui` — clean build, no warnings
- [x] `python3 scripts/changelog_fragments.py lint` — passes
- [ ] Can't verify on a live Arch/KDE desktop from this sandbox (no GUI) —
      needs confirmation from the reporter or QA with a real desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)