### PR TITLE
fix(ci): reclaim workspace ownership before git commit in crowdin-sync (SSO-24079)

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -60,6 +60,13 @@ jobs:
       - name: Normalize translations with lupdate
         run: |
           set -euo pipefail
+          # crowdin/github-action is a Docker container action that runs as root
+          # inside the container, and its own git operations (branch switch, push)
+          # leave the bind-mounted .git/ owned by root. This step runs as the
+          # unprivileged runner user, so reclaim ownership before touching git —
+          # otherwise `git commit` fails with "could not open .git/COMMIT_EDITMSG:
+          # Permission denied" (SSO-24079).
+          sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE"
           # lupdate.yml is workflow_dispatch-only (manual backstop) precisely so it
           # never runs automatically on the Crowdin push to l10n_crowdin_translations,
           # regardless of which token/actor made that push. This is the single


### PR DESCRIPTION
## Summary

- crowdin-sync.yml's "Normalize translations with lupdate" step failed post-merge of #431/#432 (SSO-24079 item 2 verification, run [33558409796](https://github.com/s4solutionsllc/Nexis/actions/runs/33558409796)): `fatal: could not open '.git/COMMIT_EDITMSG': Permission denied`.
- Root cause: `crowdin/github-action` runs as root inside its Docker container (no `--user` flag on `docker run`), and its internal git operations leave the bind-mounted `.git/` root-owned. The later step runs as the unprivileged `runner` user and can't write into it. This was previously masked by the `exit 127` PATH bug (#431/#432 fixed that; this is the next latent bug it uncovered).
- Fix: `sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE"` at the start of the normalize step, before any git commands run.

## Test plan

- [x] Verified the failure live on run 33558409796 (post-merge of #431/#432)
- [ ] Re-run `crowdin-sync.yml` via `workflow_dispatch` on this branch/after merge and confirm "Normalize translations with lupdate" completes without error

DevOps authored this (Gate 0: won't self-merge) — routing review/merge to CTO via a child issue on SSO-24079, same pattern as SSO-24080/#432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)